### PR TITLE
feat(dialog): add async prompt methods and large refactor

### DIFF
--- a/.changeset/rich-loops-accept.md
+++ b/.changeset/rich-loops-accept.md
@@ -1,0 +1,5 @@
+---
+"@opentui-ui/dialog": patch
+---
+
+add async prompt methods

--- a/packages/dialog/src/constants.ts
+++ b/packages/dialog/src/constants.ts
@@ -15,6 +15,3 @@ export const DIALOG_Z_INDEX = 9998;
 
 /** @internal Used by React/Solid bindings for JSX portals */
 export const JSX_CONTENT_KEY = Symbol("dialog-jsx-content");
-
-/** @internal Used to prevent flicker when JSX content is injected via portals */
-export const DEFERRED_KEY = Symbol("dialog-deferred");

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -1,40 +1,37 @@
-export {
-  DEFAULT_SIZE,
-  DEFAULT_SIZES,
-  DIALOG_Z_INDEX,
-  FULL_SIZE_OFFSET,
-} from "./constants";
-export { DialogManager } from "./manager";
-export {
-  DialogContainerRenderable,
-  type DialogContainerRenderableOptions,
-  type DialogKeyboardEvent,
-  DialogRenderable,
-  type DialogRenderableOptions,
-} from "./renderables";
-export {
-  DEFAULT_BACKDROP_OPACITY,
-  DEFAULT_PADDING,
-  DEFAULT_STYLE,
-  type DialogTheme,
-  themes,
-} from "./themes";
+// Core
+
+// Async Dialog Options (for imperative/core usage)
 export type {
+  AlertOptions,
+  ChoiceOptions,
+  ConfirmOptions,
+  PromptOptions,
+} from "./manager";
+export { DialogManager } from "./manager";
+// Context Types (for content functions)
+export type {
+  AlertContext,
+  ChoiceContext,
+  ConfirmContext,
+  PromptContext,
+} from "./prompts";
+export { DialogContainerRenderable } from "./renderables";
+// Themes
+export { type DialogTheme, themes } from "./themes";
+// Configuration Types
+// Base Types (for building custom adapters)
+export type {
+  AsyncDialogOptions,
+  BaseAlertOptions,
+  BaseChoiceOptions,
+  BaseConfirmOptions,
+  BaseDialogActions,
+  BasePromptOptions,
   Dialog,
   DialogBackdropMode,
   DialogContainerOptions,
-  DialogContentFactory,
   DialogId,
-  DialogOptions,
   DialogShowOptions,
   DialogSize,
   DialogStyle,
-  DialogToClose,
 } from "./types";
-export { isDialogToClose } from "./types";
-export {
-  type ComputeDialogStyleInput,
-  type ComputedDialogStyle,
-  computeDialogStyle,
-  getDialogWidth,
-} from "./utils";

--- a/packages/dialog/src/prompts/index.ts
+++ b/packages/dialog/src/prompts/index.ts
@@ -1,0 +1,7 @@
+export type {
+  AlertContext,
+  ChoiceContext,
+  ConfirmContext,
+  DialogState,
+  PromptContext,
+} from "./types";

--- a/packages/dialog/src/prompts/types.ts
+++ b/packages/dialog/src/prompts/types.ts
@@ -1,0 +1,82 @@
+import type { Dialog, DialogId } from "../types";
+
+// =============================================================================
+// Dialog State (shared by framework adapters)
+// =============================================================================
+
+/**
+ * Dialog state available via useDialogState selector.
+ * Shared interface used by both React and Solid adapters.
+ */
+export interface DialogState {
+  /** Whether any dialog is currently open. */
+  isOpen: boolean;
+  /** Array of all active dialogs (oldest first). */
+  dialogs: readonly Dialog[];
+  /** The top-most (most recent) dialog, or undefined if none. */
+  topDialog: Dialog | undefined;
+  /** Number of currently open dialogs. */
+  count: number;
+}
+
+// =============================================================================
+// Context Types
+// =============================================================================
+// These are passed to content functions in async dialog methods (prompt, confirm, alert, choice).
+// Each context provides callbacks for the user to resolve the dialog.
+//
+// All contexts use a consistent `resolve()` pattern:
+// - Call `resolve(value)` to complete the dialog with a value
+// - Call `dismiss()` (where available) to cancel without a value
+//
+// ESC key and backdrop clicks are handled separately via the method's `fallback` option.
+
+/**
+ * Context for a generic prompt dialog.
+ * Call `resolve(value)` to complete with a value, or `dismiss()` to cancel.
+ * @template T The type of value the prompt resolves to.
+ */
+export interface PromptContext<T> {
+  /** Resolves the Promise with the given value and closes the dialog. */
+  resolve: (value: T) => void;
+  /** Dismisses the dialog without a value. Resolves Promise with `undefined`. */
+  dismiss: () => void;
+  /** The unique ID of this dialog. Use with `useDialogKeyboard` for scoped keyboard handling. */
+  dialogId: DialogId;
+}
+
+/**
+ * Context for a confirm dialog.
+ * Call `resolve(true)` to confirm or `resolve(false)` to cancel.
+ */
+export interface ConfirmContext {
+  /** Resolves the Promise with the given boolean and closes the dialog. */
+  resolve: (confirmed: boolean) => void;
+  /** The unique ID of this dialog. Use with `useDialogKeyboard` for scoped keyboard handling. */
+  dialogId: DialogId;
+}
+
+/**
+ * Context for an alert dialog.
+ * Call `dismiss()` to acknowledge and close the dialog.
+ */
+export interface AlertContext {
+  /** Acknowledges and closes the alert dialog. */
+  dismiss: () => void;
+  /** The unique ID of this dialog. Use with `useDialogKeyboard` for scoped keyboard handling. */
+  dialogId: DialogId;
+}
+
+/**
+ * Context for a choice dialog.
+ * Call `resolve(key)` to select an option, or `dismiss()` to cancel.
+ * @template K The type of keys for the available choices.
+ */
+export interface ChoiceContext<K> {
+  /** Resolves the Promise with the selected key and closes the dialog. */
+  resolve: (key: K) => void;
+  /** Dismisses the dialog without selection. Resolves Promise with `undefined`. */
+  dismiss: () => void;
+  /** The unique ID of this dialog. Use with `useDialogKeyboard` for scoped keyboard handling. */
+  dialogId: DialogId;
+}

--- a/packages/dialog/src/renderables/dialog-container.ts
+++ b/packages/dialog/src/renderables/dialog-container.ts
@@ -56,7 +56,7 @@ export class DialogContainerRenderable extends BoxRenderable {
     const { manager: _, ...containerOptions } = options;
     this._options = containerOptions;
 
-    this._ctx.keyInput.on("keypress", (key) => this.handleKeyboard(key));
+    this._ctx.keyInput.on("keypress", this.handleKeyboard);
 
     this.subscribe();
   }
@@ -78,7 +78,7 @@ export class DialogContainerRenderable extends BoxRenderable {
   /**
    * Handle keyboard events. Returns true if handled (e.g., ESC closed a dialog).
    */
-  private handleKeyboard(evt: DialogKeyboardEvent): boolean {
+  private handleKeyboard = (evt: DialogKeyboardEvent): boolean => {
     if (this._options.closeOnEscape === false) {
       return false;
     }
@@ -94,7 +94,7 @@ export class DialogContainerRenderable extends BoxRenderable {
     }
 
     return false;
-  }
+  };
 
   private getTopDialogRenderable(): DialogRenderable | undefined {
     if (this._dialogRenderables.size === 0) {
@@ -223,7 +223,7 @@ export class DialogContainerRenderable extends BoxRenderable {
     this._unsubscribe?.();
     this._unsubscribe = null;
 
-    this._ctx.keyInput.off("keypress", (key) => this.handleKeyboard(key));
+    this._ctx.keyInput.off("keypress", this.handleKeyboard);
 
     for (const [, renderable] of this._dialogRenderables) {
       renderable.destroy();

--- a/packages/dialog/src/renderables/dialog.ts
+++ b/packages/dialog/src/renderables/dialog.ts
@@ -4,17 +4,12 @@ import {
   type RenderContext,
   RGBA,
 } from "@opentui/core";
-import { DEFERRED_KEY } from "../constants";
 import type { Dialog, DialogContainerOptions } from "../types";
 import {
   type ComputedDialogStyle,
   computeDialogStyle,
   getDialogWidth,
 } from "../utils";
-
-interface DialogWithDeferred extends Dialog {
-  [DEFERRED_KEY]?: boolean;
-}
 
 export interface DialogRenderableOptions {
   dialog: Dialog;
@@ -29,7 +24,7 @@ export class DialogRenderable extends BoxRenderable {
   private _dialog: Dialog;
   private _computedStyle: ComputedDialogStyle;
   private _containerOptions?: DialogContainerOptions;
-  private __contentBox: BoxRenderable;
+  private _contentBox: BoxRenderable;
   private _onRemove?: (dialog: Dialog) => void;
   private _onBackdropClick?: () => void;
   private _onReveal?: () => void;
@@ -55,8 +50,7 @@ export class DialogRenderable extends BoxRenderable {
 
     backdropColor.a = backdropOpacity / 255;
 
-    const isDeferred =
-      (options.dialog as DialogWithDeferred)[DEFERRED_KEY] === true;
+    const isDeferred = options.dialog.deferred === true;
 
     super(ctx, {
       id: `dialog-${options.dialog.id}`,
@@ -81,8 +75,8 @@ export class DialogRenderable extends BoxRenderable {
     this._revealed = !isDeferred;
     this._isTopmost = options.isTopmost;
 
-    this.__contentBox = this.createContentPanel();
-    this.add(this.__contentBox);
+    this._contentBox = this.createContentPanel();
+    this.add(this._contentBox);
     this.createContent();
   }
 
@@ -122,7 +116,7 @@ export class DialogRenderable extends BoxRenderable {
   private createContent(): void {
     try {
       const contentRenderable = this._dialog.content(this.ctx);
-      this.__contentBox.add(contentRenderable);
+      this._contentBox.add(contentRenderable);
     } catch (error) {
       const dialogId = this._dialog.id;
       const originalMessage =
@@ -151,7 +145,7 @@ export class DialogRenderable extends BoxRenderable {
 
     this._dialog.onBackdropClick?.();
 
-    if (this._dialog.closeOnClickOutside !== false) {
+    if (this._dialog.closeOnClickOutside === true) {
       this._onBackdropClick?.();
     }
   }
@@ -195,8 +189,8 @@ export class DialogRenderable extends BoxRenderable {
       typeof this._computedStyle.width === "number"
         ? this._computedStyle.width
         : dialogWidth;
-    this.__contentBox.width = panelWidth;
-    this.__contentBox.maxWidth = this._computedStyle.maxWidth ?? width - 2;
+    this._contentBox.width = panelWidth;
+    this._contentBox.maxWidth = this._computedStyle.maxWidth ?? width - 2;
 
     this.requestRender();
   }
@@ -227,8 +221,8 @@ export class DialogRenderable extends BoxRenderable {
   }
 
   /** @internal For framework portal rendering */
-  public get _contentBox(): BoxRenderable {
-    return this.__contentBox;
+  public get contentBox(): BoxRenderable {
+    return this._contentBox;
   }
 
   public get isClosed(): boolean {

--- a/packages/dialog/src/themes.ts
+++ b/packages/dialog/src/themes.ts
@@ -26,24 +26,6 @@ export const minimal: DialogTheme = {
   },
 };
 
-export const classic: DialogTheme = {
-  name: "Classic",
-  description: "Traditional dialog style with heavier backdrop",
-  backdropMode: "per-dialog",
-  dialogOptions: {
-    style: {
-      backdropOpacity: 0.59,
-      backdropColor: "#000000",
-      backgroundColor: "#1a1a1a",
-      border: false,
-      paddingTop: 1,
-      paddingRight: 2,
-      paddingBottom: 1,
-      paddingLeft: 2,
-    },
-  },
-};
-
 export const unstyled: DialogTheme = {
   name: "Unstyled",
   description: "No default styles - full control for custom implementations",
@@ -63,29 +45,7 @@ export const unstyled: DialogTheme = {
   },
 };
 
-export const danger: DialogTheme = {
-  name: "Danger",
-  description: "Red-accented for destructive actions",
-  backdropMode: "top-only",
-  dialogOptions: {
-    style: {
-      backdropOpacity: 0.65,
-      backdropColor: "#1a0000",
-      backgroundColor: "#1a1a1a",
-      border: true,
-      borderColor: "#b91c1c",
-      borderStyle: "single",
-      paddingTop: 1,
-      paddingRight: 2,
-      paddingBottom: 1,
-      paddingLeft: 2,
-    },
-  },
-};
-
 export const themes = {
   minimal,
-  classic,
   unstyled,
-  danger,
 } as const;

--- a/packages/dialog/src/types.ts
+++ b/packages/dialog/src/types.ts
@@ -37,8 +37,15 @@ export interface Dialog {
   style?: DialogStyle;
   unstyled?: boolean;
   backdropMode?: DialogBackdropMode;
-  /** @default true */
+  /** @default false */
   closeOnClickOutside?: boolean;
+  /**
+   * When true, the dialog is initially hidden until `reveal()` is called.
+   * Used by framework adapters to prevent flicker when JSX content is
+   * injected via portals after the dialog renderable is created.
+   * @internal
+   */
+  deferred?: boolean;
   onClose?: () => void;
   onOpen?: () => void;
   onBackdropClick?: () => void;
@@ -69,6 +76,76 @@ export interface DialogContainerOptions {
   unstyled?: boolean;
   /** @default "top-only" */
   backdropMode?: DialogBackdropMode;
+}
+
+// =============================================================================
+// Async Dialog Base Types
+// =============================================================================
+// These generic types reduce duplication between core and framework adapters.
+// Framework adapters (React, Solid, etc.) extend these with their content types.
+
+/**
+ * Base options for async dialog methods (prompt, confirm, alert, choice).
+ * Excludes `content` (replaced by context-specific content) and `id` (auto-generated).
+ * Note: `onClose` is supported - it will be called before the Promise resolves.
+ */
+export interface AsyncDialogOptions
+  extends Omit<DialogShowOptions, "content" | "id"> {}
+
+/**
+ * Generic base for prompt dialog options.
+ * @template T The type of value the prompt resolves to.
+ * @template TContent The content type (varies by adapter).
+ */
+export interface BasePromptOptions<T, TContent> extends AsyncDialogOptions {
+  /** Content factory that receives the prompt context. */
+  content: TContent;
+  /** Fallback value when dialog is dismissed via ESC or backdrop click. */
+  fallback?: T;
+}
+
+/**
+ * Generic base for confirm dialog options.
+ * @template TContent The content type (varies by adapter).
+ */
+export interface BaseConfirmOptions<TContent> extends AsyncDialogOptions {
+  /** Content factory that receives the confirm context. */
+  content: TContent;
+}
+
+/**
+ * Generic base for alert dialog options.
+ * @template TContent The content type (varies by adapter).
+ */
+export interface BaseAlertOptions<TContent> extends AsyncDialogOptions {
+  /** Content factory that receives the alert context. */
+  content: TContent;
+}
+
+/**
+ * Generic base for choice dialog options.
+ * @template TContent The content type (varies by adapter).
+ */
+export interface BaseChoiceOptions<TContent> extends AsyncDialogOptions {
+  /** Content factory that receives the choice context. */
+  content: TContent;
+}
+
+/**
+ * Base interface for dialog actions returned by useDialog() hooks.
+ * Contains the non-generic methods shared by all framework adapters.
+ * Framework adapters extend this and add the generic prompt/confirm/alert/choice methods.
+ * @template TShowOptions Options for show/replace methods.
+ */
+export interface BaseDialogActions<TShowOptions> {
+  /** Show a new dialog and return its ID. */
+  show: (options: TShowOptions) => DialogId;
+  /** Close a specific dialog by ID, or the top-most dialog if no ID provided. */
+  close: (id?: DialogId) => DialogId | undefined;
+  /** Close all open dialogs. */
+  closeAll: () => void;
+  /** Close all dialogs and show a new one. */
+  replace: (options: TShowOptions) => DialogId;
 }
 
 export function isDialogToClose(

--- a/packages/dialog/src/utils/style.ts
+++ b/packages/dialog/src/utils/style.ts
@@ -71,7 +71,9 @@ export function computeDialogStyle(
     ? { top: 0, right: 0, bottom: 0, left: 0 }
     : DEFAULT_PADDING;
 
-  const resolvedPadding = resolvePadding(computed, defaultPadding);
+  const resolvedPadding = isUnstyled
+    ? { top: 0, right: 0, bottom: 0, left: 0 }
+    : resolvePadding(computed, defaultPadding);
 
   return {
     ...computed,


### PR DESCRIPTION
## Summary

Adds promise-based async dialog methods for common UI patterns: confirmations, alerts, prompts, and choice selections.

## Changes

### New Async Methods

Added four async methods to `DialogManager` and framework adapters:

- **`confirm()`** - Yes/no decisions, returns `Promise<boolean>`
- **`alert()`** - Acknowledgment dialogs, returns `Promise<void>`
- **`prompt<T>()`** - Generic value input, returns `Promise<T | undefined>`
- **`choice<K>()`** - Multiple option selection, returns `Promise<K | undefined>`

Added `useDialogKeyboard` hook for scoped keyboard handling within stacked dialogs

### Framework Support

All methods available in:
- Core `DialogManager` (imperative usage)
- `@opentui-ui/dialog/react` via `useDialog()`
- `@opentui-ui/dialog/solid` via `useDialog()`

## Usage

```tsx
const dialog = useDialog();

// Confirmation
const confirmed = await dialog.confirm({
  content: ({ resolve }) => (
    <ConfirmDialog onConfirm={() => resolve(true)} onCancel={() => resolve(false)} />
  ),
});

// Alert
await dialog.alert({
  content: ({ dismiss }) => <AlertDialog onDismiss={dismiss} />,
});

// Choice
const action = await dialog.choice<"save" | "discard">({
  content: ({ resolve, dismiss }) => (
    <ChoiceDialog onSave={() => resolve("save")} onDiscard={() => resolve("discard")} />
  ),
});
```
