### PR TITLE
feat(toast): add queue management and limit for visible toasts

### DIFF
--- a/packages/toast/README.md
+++ b/packages/toast/README.md
@@ -538,6 +538,29 @@ Get all currently active toasts.
 
 Get all toasts ever created (including dismissed).
 
+### Queue Management
+
+Control how many toasts are visible at once:
+
+```ts
+toast.setLimit(3);      // Max 3 visible toasts (others queue)
+toast.getLimit();       // Get current limit
+toast.getQueue();       // Get queued toasts waiting to show
+toast.cleanQueue();     // Clear queued toasts (keeps visible)
+```
+
+### Custom Store
+
+Create isolated toast stores for testing or multiple toaster instances:
+
+```ts
+import { createToastStore } from "@opentui-ui/toast";
+
+const myStore = createToastStore();
+myStore.success("Isolated toast!");
+myStore.setLimit(2);
+```
+
 ### Toast Options
 
 | Option        | Type                       | Default    | Description                        |

--- a/packages/toast/examples/basic-toast.ts
+++ b/packages/toast/examples/basic-toast.ts
@@ -117,6 +117,8 @@ Keyboard Controls:
   p - Promise toast (simulated async)
   u - Update last toast
   d - Dismiss all toasts
+  c - Clean queue (remove queued toasts)
+  l - Toggle limit (3 vs unlimited)
   
   t - Cycle themes (Custom -> Minimal -> Monochrome)
   i - Cycle icon sets (Default -> Emoji -> ASCII)
@@ -305,6 +307,20 @@ function handleKeyPress(key: KeyEvent): void {
       updateStatus();
       toast.info(`Stacking: ${stackingMode}`);
       break;
+
+    case "c":
+      // Clean queue - remove queued (non-visible) toasts
+      toast.cleanQueue();
+      break;
+
+    case "l": {
+      // Toggle toast limit
+      const currentLimit = toast.getLimit();
+      const newLimit = currentLimit === 3 ? Infinity : 3;
+      toast.setLimit(newLimit);
+      toast.info(`Limit: ${newLimit === Infinity ? "unlimited" : newLimit}`);
+      break;
+    }
 
     case "q":
       renderer?.destroy();

--- a/packages/toast/src/index.ts
+++ b/packages/toast/src/index.ts
@@ -9,7 +9,7 @@
 // =============================================================================
 
 export { ToasterRenderable } from "./renderables";
-export { toast } from "./state";
+export { createToastStore, toast } from "./state";
 
 // =============================================================================
 // Types - For TypeScript users

--- a/packages/toast/src/state.ts
+++ b/packages/toast/src/state.ts
@@ -35,6 +35,11 @@ class Observer {
   toasts: Toast[] = [];
   dismissedToasts: Set<string | number> = new Set();
 
+  /** Queued toasts waiting to be shown when limit allows */
+  private queue: Toast[] = [];
+  /** Maximum visible toasts (default: 5, Infinity for unlimited) */
+  private limit = 5;
+
   // Cached active toasts for referential stability
   private _activeToasts: Toast[] = [];
 
@@ -77,12 +82,46 @@ class Observer {
   };
 
   /**
-   * Add a new toast
+   * Add a new toast (respects limit, queues if over)
    */
   addToast = (data: Toast): void => {
-    this.toasts = [...this.toasts, data];
-    this._updateActiveToastsCache();
-    this.publish(data);
+    // Count current visible toasts (not dismissed)
+    const visibleCount = this.toasts.filter(
+      (t) => !this.dismissedToasts.has(t.id),
+    ).length;
+
+    if (visibleCount >= this.limit) {
+      // Over limit, add to queue
+      this.queue = [...this.queue, data];
+    } else {
+      // Under limit, show immediately
+      this.toasts = [...this.toasts, data];
+      this._updateActiveToastsCache();
+      this.publish(data);
+    }
+  };
+
+  /**
+   * Process queue - show queued toasts if under limit
+   */
+  private processQueue = (): void => {
+    const visibleCount = this.toasts.filter(
+      (t) => !this.dismissedToasts.has(t.id),
+    ).length;
+
+    while (
+      this.queue.length > 0 &&
+      visibleCount + this.queue.length > visibleCount &&
+      this.toasts.filter((t) => !this.dismissedToasts.has(t.id)).length <
+        this.limit
+    ) {
+      const nextToast = this.queue.shift();
+      if (nextToast) {
+        this.toasts = [...this.toasts, nextToast];
+        this._updateActiveToastsCache();
+        this.publish(nextToast);
+      }
+    }
   };
 
   /**
@@ -172,6 +211,9 @@ class Observer {
       }
       this._updateActiveToastsCache();
     }
+
+    // Process queue to show waiting toasts
+    setTimeout(() => this.processQueue(), 0);
 
     return id;
   };
@@ -444,6 +486,56 @@ class Observer {
   getActiveToasts = (): Toast[] => {
     return this._activeToasts;
   };
+
+  // ===========================================================================
+  // Queue Management
+  // ===========================================================================
+
+  /**
+   * Set the maximum number of visible toasts.
+   * Toasts beyond this limit are queued.
+   *
+   * @example
+   * ```ts
+   * toast.setLimit(3);  // Show max 3 toasts at once
+   * toast.setLimit(Infinity);  // No limit
+   * ```
+   */
+  setLimit = (limit: number): void => {
+    this.limit = limit;
+  };
+
+  /**
+   * Get the current limit for visible toasts.
+   */
+  getLimit = (): number => {
+    return this.limit;
+  };
+
+  /**
+   * Get queued toasts waiting to be shown.
+   *
+   * @example
+   * ```ts
+   * const queued = toast.getQueue();
+   * console.log(`${queued.length} toasts waiting`);
+   * ```
+   */
+  getQueue = (): Toast[] => {
+    return [...this.queue];
+  };
+
+  /**
+   * Clear all queued toasts (keeps visible toasts).
+   *
+   * @example
+   * ```ts
+   * toast.cleanQueue();  // Remove toasts that haven't been shown yet
+   * ```
+   */
+  cleanQueue = (): void => {
+    this.queue = [];
+  };
 }
 
 /**
@@ -482,6 +574,21 @@ const getHistory = () => ToastState.toasts;
 const getToasts = () => ToastState.getActiveToasts();
 
 /**
+ * Create a new independent toast store.
+ *
+ * Useful for testing or having multiple isolated toaster instances.
+ *
+ * @example
+ * ```ts
+ * const myStore = createToastStore();
+ * myStore.success("Isolated toast!");
+ * ```
+ */
+export function createToastStore(): Observer {
+  return new Observer();
+}
+
+/**
  * The main toast API - a function with methods attached
  *
  * @example
@@ -507,6 +614,10 @@ const getToasts = () => ToastState.getActiveToasts();
  * const id = toast('Hello');
  * toast.dismiss(id);
  * toast.dismiss(); // dismiss all
+ *
+ * // Queue management
+ * toast.setLimit(3);  // Max 3 visible toasts
+ * toast.cleanQueue(); // Clear queued toasts
  * ```
  */
 export const toast = Object.assign(
@@ -520,6 +631,11 @@ export const toast = Object.assign(
     promise: ToastState.promise,
     dismiss: ToastState.dismiss,
     loading: ToastState.loading,
+    // Queue management
+    setLimit: ToastState.setLimit,
+    getLimit: ToastState.getLimit,
+    getQueue: ToastState.getQueue,
+    cleanQueue: ToastState.cleanQueue,
   },
   { getHistory, getToasts },
 );


### PR DESCRIPTION
Introduce queue management for toasts, allowing a limit on the number of visible toasts at any time. This change includes methods to set and get the limit, manage queued toasts, and clear the queue. Additionally, it supports creating isolated toast stores for testing or multiple instances.