### PR TITLE
feat(dialog): implement context dialogs and update dialog functionality

### DIFF
--- a/packages/dialog/README.md
+++ b/packages/dialog/README.md
@@ -24,20 +24,35 @@
 
 ## Table of Contents
 
+- [Features](#features)
+- [Table of Contents](#table-of-contents)
 - [Installation](#installation)
 - [Core Usage](#core-usage)
   - [Quick Start](#quick-start)
   - [Quick Reference](#quick-reference)
   - [Choosing the Right Method](#choosing-the-right-method)
   - [Async Prompts](#async-prompts)
+    - [Context Methods at a Glance](#context-methods-at-a-glance)
   - [API Reference](#api-reference)
 - [Framework Adapters (React & Solid)](#framework-adapters-react--solid)
+    - [`DialogManager`](#dialogmanager)
+    - [`DialogContainerRenderable`](#dialogcontainerrenderable)
+    - [`DialogStyle`](#dialogstyle)
+  - [Update Dialog](#update-dialog)
+  - [Context Dialogs](#context-dialogs)
+- [Framework Adapters (React \& Solid)](#framework-adapters-react--solid)
   - [Setup](#setup)
+    - [Using Themes](#using-themes)
   - [Choosing the Right Method](#choosing-the-right-method-1)
   - [Async Prompts (Framework)](#async-prompts-framework)
   - [useDialog() Hook](#usedialog-hook)
   - [useDialogState() Hook](#usedialogstate-hook)
   - [useDialogKeyboard() Hook](#usedialogkeyboard-hook)
+    - [Building Custom Async Dialogs](#building-custom-async-dialogs)
+  - [`useDialog()` Hook](#usedialog-hook)
+  - [`useDialogState()` Hook](#usedialogstate-hook)
+  - [`useDialogKeyboard()` Hook](#usedialogkeyboard-hook)
+    - [Manual Implementation with `dialogId`](#manual-implementation-with-dialogid)
   - [Full Example](#full-example)
 - [Customization](#customization)
   - [Default Styling](#default-styling)
@@ -300,6 +315,49 @@ interface DialogStyle {
   paddingBottom?: number;
   paddingLeft?: number;
 }
+```
+
+---
+
+### Update Dialog
+
+Update an existing dialog's props (style, backdrop, etc.) without closing it:
+
+```ts
+const id = manager.show({
+  content: (ctx) => new TextRenderable(ctx, { content: "Hello" }),
+});
+
+// Later, update the dialog's appearance
+manager.updateDialog(id, {
+  style: { backgroundColor: "#2d4a3e", borderColor: "#16c79a" },
+  backdropOpacity: 0.8,
+});
+```
+
+### Context Dialogs
+
+Pre-register dialog templates and open them by name:
+
+```ts
+// Register once at startup
+manager.registerContextDialog<{ filename: string }>(
+  "deleteConfirm",
+  (ctx, { innerProps, close }) => {
+    const box = new BoxRenderable(ctx, { flexDirection: "column" });
+    box.add(new TextRenderable(ctx, { content: `Delete ${innerProps.filename}?` }));
+    const confirmBtn = new TextRenderable(ctx, { content: "Delete" });
+    confirmBtn.on("mouseUp", close);
+    box.add(confirmBtn);
+    return box;
+  },
+);
+
+// Open from anywhere with custom props
+manager.openContextDialog("deleteConfirm", {
+  innerProps: { filename: "document.txt" },
+  size: "small",
+});
 ```
 
 ---

--- a/packages/dialog/examples/basic-dialog.ts
+++ b/packages/dialog/examples/basic-dialog.ts
@@ -74,6 +74,32 @@ function createUI(rendererInstance: CliRenderer): void {
   });
   renderer.root.add(dialogContainer);
 
+  // Register context dialog template
+  dialogManager.registerContextDialog<{ title: string; message: string }>(
+    "preregistered-info",
+    (ctx, { innerProps, close: _close }) => {
+      const box = new BoxRenderable(ctx, {
+        id: "context-dialog-content",
+        flexDirection: "column",
+        gap: 1,
+      });
+      const titleText = new TextRenderable(ctx, {
+        id: "context-title",
+        content: innerProps.title,
+        fg: "#3498db",
+      });
+      box.add(titleText);
+      const messageText = new TextRenderable(ctx, {
+        id: "context-message",
+        content: `${innerProps.message}\n\nPress ESC to close.`,
+        fg: "#ffffff",
+        wrapMode: "word",
+      });
+      box.add(messageText);
+      return box;
+    },
+  );
+
   // Set up keyboard handler
   renderer.keyInput.on("keypress", handleKeyPress);
 }
@@ -83,8 +109,9 @@ function getHelpText(): string {
 Keyboard Controls:
   1 - Simple dialog          2 - Dialog with long content
   3 - Stacked dialogs        4 - Custom styled dialog
-  5 - MS-DOS style dialog
+  5 - MS-DOS style dialog    6 - Context dialog (pre-registered)
   
+  u - Update top dialog style (demo updateDialog)
   s - Cycle sizes (small -> medium -> large -> full)
   
   Escape - Close top dialog
@@ -370,6 +397,33 @@ Press ESC to close.`,
       });
       updateStatus();
       break;
+
+    case "6":
+      // Context dialog (pre-registered template)
+      dialogManager.openContextDialog("preregistered-info", {
+        innerProps: {
+          title: "Context Dialog",
+          message: "This dialog was opened from a pre-registered template!",
+        },
+        size: sizes[sizeIndex],
+        onClose: () => updateStatus(),
+      });
+      updateStatus();
+      break;
+
+    case "u": {
+      // Update top dialog style
+      const topDialog = dialogManager.getTopDialog();
+      if (topDialog) {
+        dialogManager.updateDialog(topDialog.id, {
+          style: {
+            backgroundColor: "#2d4a3e",
+            borderColor: "#16c79a",
+          },
+        });
+      }
+      break;
+    }
 
     case "s": {
       // Cycle sizes - note: size changes only affect NEW dialogs now

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -28,6 +28,8 @@ export type {
   BaseConfirmOptions,
   BaseDialogActions,
   BasePromptOptions,
+  ContextDialogFactory,
+  ContextDialogProps,
   Dialog,
   DialogContainerOptions,
   DialogContentFactory,
@@ -36,5 +38,7 @@ export type {
   DialogSize,
   DialogStyle,
   DialogToClose,
+  DialogUpdated,
+  OpenContextDialogOptions,
 } from "./types";
-export { isDialogToClose } from "./types";
+export { isDialogToClose, isDialogUpdated } from "./types";

--- a/packages/dialog/src/types.ts
+++ b/packages/dialog/src/types.ts
@@ -171,7 +171,66 @@ export interface BaseDialogActions<TShowOptions> {
 }
 
 export function isDialogToClose(
-  value: Dialog | DialogToClose,
+  value: Dialog | DialogToClose | DialogUpdated,
 ): value is DialogToClose {
   return "close" in value && value.close === true;
+}
+
+// =============================================================================
+// Context Dialog Types
+// =============================================================================
+// Context dialogs are pre-registered dialog templates that can be opened by name.
+
+/**
+ * Props passed to context dialog content factories.
+ * @template T The type of innerProps passed when opening the dialog.
+ */
+export interface ContextDialogProps<T = Record<string, unknown>> {
+  /** Custom props passed when opening this context dialog. */
+  innerProps: T;
+  /** The dialog ID for this dialog. */
+  dialogId: DialogId;
+  /** Close this dialog. */
+  close: () => void;
+}
+
+/**
+ * Factory function for creating context dialog content.
+ * @template T The type of innerProps passed when opening the dialog.
+ */
+export type ContextDialogFactory<T = Record<string, unknown>> = (
+  ctx: RenderContext,
+  props: ContextDialogProps<T>,
+) => Renderable;
+
+/**
+ * Options for opening a context dialog.
+ * @template T The type of innerProps for the context dialog.
+ */
+export interface OpenContextDialogOptions<T = Record<string, unknown>>
+  extends AsyncDialogOptions {
+  /** Custom props to pass to the context dialog. */
+  innerProps: T;
+}
+
+/**
+ * Payload for updating an existing dialog's props.
+ */
+export interface DialogUpdatePayload extends Partial<DialogShowOptions> {
+  /** ID of the dialog to update. */
+  id: DialogId;
+}
+
+/**
+ * Event published when a dialog is updated.
+ */
+export interface DialogUpdated {
+  id: DialogId;
+  updated: true;
+}
+
+export function isDialogUpdated(
+  value: Dialog | DialogToClose | DialogUpdated,
+): value is DialogUpdated {
+  return "updated" in value && value.updated === true;
 }


### PR DESCRIPTION
Introduce context dialogs that allow pre-registration of dialog templates for easier access by name. Update existing dialog functionality to support dynamic updates without closing the dialog. Enhance type definitions and documentation to reflect these changes.