### PR TITLE
feat(toast): add queue management and limit for visible toasts

### DIFF
--- a/packages/toast/README.md
+++ b/packages/toast/README.md
@@ -538,6 +538,29 @@ Get all currently active toasts.
 
 Get all toasts ever created (including dismissed).
 
+### Queue Management
+
+Control how many toasts are visible at once:
+
+```ts
+toast.setLimit(3);      // Max 3 visible toasts (others queue)
+toast.getLimit();       // Get current limit
+toast.getQueue();       // Get queued toasts waiting to show
+toast.cleanQueue();     // Clear queued toasts (keeps visible)
+```
+
+### Custom Store
+
+Create isolated toast stores for testing or multiple toaster instances:
+
+```ts
+import { createToastStore } from "@opentui-ui/toast";
+
+const myStore = createToastStore();
+myStore.success("Isolated toast!");
+myStore.setLimit(2);
+```
+
 ### Toast Options
 
 | Option        | Type                       | Default    | Description                        |

--- a/packages/toast/examples/basic-toast.ts
+++ b/packages/toast/examples/basic-toast.ts
@@ -117,6 +117,8 @@ Keyboard Controls:
   p - Promise toast (simulated async)
   u - Update last toast
   d - Dismiss all toasts
+  c - Clean queue (remove queued toasts)
+  l - Toggle limit (3 vs unlimited)
   
   t - Cycle themes (Custom -> Minimal -> Monochrome)
   i - Cycle icon sets (Default -> Emoji -> ASCII)
@@ -305,6 +307,20 @@ function handleKeyPress(key: KeyEvent): void {
       updateStatus();
       toast.info(`Stacking: ${stackingMode}`);
       break;
+
+    case "c":
+      // Clean queue - remove queued (non-visible) toasts
+      toast.cleanQueue();
+      break;
+
+    case "l": {
+      // Toggle toast limit
+      const currentLimit = toast.getLimit();
+      const newLimit = currentLimit === 3 ? Infinity : 3;
+      toast.setLimit(newLimit);
+      toast.info(`Limit: ${newLimit === Infinity ? "unlimited" : newLimit}`);
+      break;
+    }
 
     case "q":
       renderer?.destroy();

--- a/packages/toast/src/index.ts
+++ b/packages/toast/src/index.ts
@@ -9,7 +9,7 @@
 // =============================================================================
 
 export { ToasterRenderable } from "./renderables";
-export { toast } from "./state";
+export { createToastStore, toast } from "./state";
 
 // =============================================================================
 // Types - For TypeScript users


### PR DESCRIPTION
Introduce queue management for toasts, allowing a limit on the number of visible toasts at any time. This change includes methods to set and get the limit, manage queued toasts, and clear the queue. Additionally, it supports creating isolated toast stores for testing or multiple instances.