### PR TITLE
fix: address registry consumer feedback

### DIFF
--- a/.changeset/calm-dialogs-focus.md
+++ b/.changeset/calm-dialogs-focus.md
@@ -1,0 +1,11 @@
+---
+"@opentui-ui/core": patch
+"@opentui-ui/react": patch
+"@opentui-ui/solid": patch
+---
+
+Make disabled controls truthful focus-traversal candidates, preserve rendered
+Dialog focus order and programmatic focus restoration, and reshape the Dialog
+recipes into responsive shadcn-style compound exports. Registry builds now
+prepare nested item paths and React recipes install their required type
+declarations.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,21 +12,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "pnpm"
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,22 +17,22 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20
+          node-version: 24
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
 
@@ -65,7 +65,7 @@ jobs:
 
       - name: Create Release PR or Publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           commit: "chore(release): version packages"
           title: "chore(release): version packages"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "validate:packages:built": "node scripts/validate-packages.mjs",
     "validate:registry": "node scripts/validate-registry.mjs",
     "validate:registry:built": "node scripts/validate-registry.mjs --built",
+    "registry:build": "node scripts/build-registry.mjs",
     "changeset:status": "changeset status",
     "validate:release-scope": "node scripts/validate-foundation-release.mjs",
     "validate:foundation": "pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm validate:packages:built && pnpm validate:registry:built && pnpm validate:release-scope",

--- a/packages/core/src/button/button-primitive.test.ts
+++ b/packages/core/src/button/button-primitive.test.ts
@@ -143,6 +143,7 @@ describe("Button primitive", () => {
     });
 
     root.disabled = true;
+    expect(root.focusable).toBe(false);
     expect(root.getState()).toEqual({
       disabled: true,
       focused: false,
@@ -156,6 +157,7 @@ describe("Button primitive", () => {
     expect(presses).toEqual([]);
 
     root.disabled = undefined;
+    expect(root.focusable).toBe(true);
     root.focus();
     await setup.mockMouse.pressDown(0, 0);
     root.blur();

--- a/packages/core/src/button/primitive.ts
+++ b/packages/core/src/button/primitive.ts
@@ -102,7 +102,12 @@ export class ButtonRenderable extends BoxRenderable {
       if (disabled !== undefined) store.setDisabled(disabled);
       if (onPress !== undefined) store.setOnPress(onPress);
     }
-    this._unsubscribe = this._store.subscribe(() => this.requestRender());
+    this._focusable = !this._store.state.disabled;
+    this._unsubscribe = this._store.subscribe((state) => {
+      if (state.disabled && this._focused) this.blur();
+      this._focusable = !state.disabled;
+      this.requestRender();
+    });
   }
 
   getState(): ButtonState {
@@ -123,8 +128,13 @@ export class ButtonRenderable extends BoxRenderable {
 
   protected override onMouseEvent(event: MouseEvent): void {
     super.onMouseEvent(event);
+    if (this._store.state.disabled) {
+      event.preventDefault();
+      if (this._focused) super.blur();
+      return;
+    }
     if (event.type === "down") {
-      if (event.button !== 0 || this._store.state.disabled) return;
+      if (event.button !== 0) return;
       if (event.defaultPrevented) {
         this._store.setPressed(false);
         return;
@@ -187,9 +197,7 @@ export class ButtonRenderable extends BoxRenderable {
   }
 
   set disabled(disabled: boolean | null | undefined) {
-    const next = disabled ?? false;
-    this._store.setDisabled(next);
-    if (next && this._focused) super.blur();
+    this._store.setDisabled(disabled ?? false);
   }
 
   set onPress(callback: ((details: ButtonPressDetails) => void) | undefined) {

--- a/packages/core/src/checkbox/checkbox-primitive.test.ts
+++ b/packages/core/src/checkbox/checkbox-primitive.test.ts
@@ -87,6 +87,7 @@ describe("Checkbox primitive", () => {
     });
     setup.renderer.root.add(root);
 
+    expect(root.focusable).toBe(false);
     root.focus();
     root.press();
 
@@ -95,6 +96,7 @@ describe("Checkbox primitive", () => {
     expect(changes).toEqual([]);
 
     root.disabled = undefined;
+    expect(root.focusable).toBe(true);
     root.press();
     expect(root.checked).toBe(true);
   });

--- a/packages/core/src/checkbox/primitive.ts
+++ b/packages/core/src/checkbox/primitive.ts
@@ -108,7 +108,12 @@ export class CheckboxRootRenderable extends BoxRenderable {
       if (onCheckedChange !== undefined)
         store.setOnCheckedChange(onCheckedChange);
     }
-    this._unsubscribe = this._store.subscribe(() => this.requestRender());
+    this._focusable = !this._store.state.disabled;
+    this._unsubscribe = this._store.subscribe((state) => {
+      if (state.disabled && this._focused) this.blur();
+      this._focusable = !state.disabled;
+      this.requestRender();
+    });
   }
 
   getState(): CheckboxState {
@@ -166,9 +171,7 @@ export class CheckboxRootRenderable extends BoxRenderable {
   }
 
   set disabled(disabled: boolean | null | undefined) {
-    const next = disabled ?? false;
-    this._store.setDisabled(next);
-    if (next && this._focused) super.blur();
+    this._store.setDisabled(disabled ?? false);
   }
 
   set onCheckedChange(callback: ((checked: boolean) => void) | undefined) {

--- a/packages/core/src/dialog/dialog-primitive.test.ts
+++ b/packages/core/src/dialog/dialog-primitive.test.ts
@@ -175,6 +175,21 @@ describe("Dialog Core primitive", () => {
     })();
   });
 
+  it("restores the focused control after programmatic opening", async () => {
+    setup = await createTestRenderer({ width: 40, height: 10 });
+    const opener = new BoxRenderable(setup.renderer, { focusable: true });
+    setup.renderer.root.add(opener);
+    opener.focus();
+    const store = new DialogStore(setup.renderer);
+    dialog(setup.renderer, store);
+
+    store.setOpen(true);
+    expect(opener.focused).toBe(false);
+    store.setOpen(false);
+
+    expect(opener.focused).toBe(true);
+  });
+
   it("arbitrates direct backdrop dismissal to the topmost layer", () => {
     return (async () => {
       setup = await createTestRenderer({ width: 40, height: 10 });

--- a/packages/core/src/dialog/index.ts
+++ b/packages/core/src/dialog/index.ts
@@ -539,7 +539,7 @@ export class DialogPopupRenderable extends BoxRenderable {
       this.initialTarget && this.isLiveDescendant(this.initialTarget)
         ? this.initialTarget
         : undefined;
-    const targets = [...new Set([...explicit, ...descendants])];
+    const targets = [...new Set([...descendants, ...explicit])];
     if (initial) {
       const index = targets.indexOf(initial);
       if (index !== -1) targets.splice(index, 1);

--- a/packages/core/src/dialog/index.ts
+++ b/packages/core/src/dialog/index.ts
@@ -491,8 +491,16 @@ export class DialogPopupRenderable extends BoxRenderable {
       visible: false,
     });
     this.store = store;
-    this.initialTarget = initialFocus;
+    this.initialFocus = initialFocus;
     coordinatorFor(ctx).setPopup(store, this);
+  }
+
+  get initialFocus(): Renderable | undefined {
+    return this.initialTarget;
+  }
+
+  set initialFocus(target: Renderable | undefined) {
+    this.initialTarget = target;
   }
 
   registerFocusable(target: Renderable, initial = false): () => void {

--- a/packages/core/src/input/input-primitive.test.ts
+++ b/packages/core/src/input/input-primitive.test.ts
@@ -95,6 +95,7 @@ describe("InputRenderable", () => {
       onSubmit: (value) => events.push(`submit:${value}`),
     });
 
+    expect(input.focusable).toBe(false);
     input.focus();
     await setup?.mockInput.typeText("X");
 
@@ -102,5 +103,8 @@ describe("InputRenderable", () => {
     expect(input.value).toBe("Fixed");
     expect(input.submit()).toBe(false);
     expect(events).toEqual([]);
+
+    input.disabled = false;
+    expect(input.focusable).toBe(true);
   });
 });

--- a/packages/core/src/input/primitive.ts
+++ b/packages/core/src/input/primitive.ts
@@ -27,6 +27,7 @@ export class InputRenderable extends OpenTuiInputRenderable {
     } = options;
     super(ctx, inputOptions);
     this._disabled = disabled;
+    this._focusable = !disabled;
     this.traits = { ...this.traits, suspend: disabled };
     if (onInput) this.on(InputRenderableEvents.INPUT, onInput);
     if (onChange) this.on(InputRenderableEvents.CHANGE, onChange);
@@ -56,5 +57,6 @@ export class InputRenderable extends OpenTuiInputRenderable {
     this._disabled = disabled;
     this.traits = { ...this.traits, suspend: disabled };
     if (disabled && this._focused) this.blur();
+    this._focusable = !disabled;
   }
 }

--- a/packages/core/src/switch/primitive.ts
+++ b/packages/core/src/switch/primitive.ts
@@ -101,7 +101,12 @@ export class SwitchRootRenderable extends BoxRenderable {
       if (onCheckedChange !== undefined)
         store.setOnCheckedChange(onCheckedChange);
     }
-    this._unsubscribe = this._store.subscribe(() => this.requestRender());
+    this._focusable = !this._store.state.disabled;
+    this._unsubscribe = this._store.subscribe((state) => {
+      if (state.disabled && this._focused) this.blur();
+      this._focusable = !state.disabled;
+      this.requestRender();
+    });
   }
 
   getState(): SwitchState {
@@ -158,9 +163,7 @@ export class SwitchRootRenderable extends BoxRenderable {
   }
 
   set disabled(disabled: boolean | null | undefined) {
-    const next = disabled ?? false;
-    this._store.setDisabled(next);
-    if (next && this._focused) super.blur();
+    this._store.setDisabled(disabled ?? false);
   }
 
   set onCheckedChange(callback: ((checked: boolean) => void) | undefined) {

--- a/packages/core/src/switch/switch-primitive.test.ts
+++ b/packages/core/src/switch/switch-primitive.test.ts
@@ -92,6 +92,7 @@ describe("Switch primitive", () => {
     });
     setup.renderer.root.add(root);
 
+    expect(root.focusable).toBe(false);
     root.focus();
     root.press();
     expect(root.handleKeyPress({ name: "space" } as KeyEvent)).toBe(false);
@@ -99,6 +100,7 @@ describe("Switch primitive", () => {
     expect(changes).toEqual([]);
 
     root.disabled = undefined;
+    expect(root.focusable).toBe(true);
     expect(root.handleKeyPress({ name: "enter" } as KeyEvent)).toBe(true);
     expect(root.checked).toBe(true);
     expect(root.handleKeyPress({ name: "return" } as KeyEvent)).toBe(true);

--- a/packages/react/src/dialog/dialog-primitive.test.tsx
+++ b/packages/react/src/dialog/dialog-primitive.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import type { Renderable } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import type {
@@ -237,6 +238,49 @@ describe("React Dialog", () => {
     await act(async () => closeRef.current?.press());
     await setup.waitFor(() => rootRef.current?.state.open === false);
     expect(popupRef.current?.visible).toBe(false);
+  });
+
+  it("updates initial focus after a descendant ref becomes available", async () => {
+    const triggerRef = createRef<DialogTriggerRenderable>();
+    const popupRef = createRef<DialogPopupRenderable>();
+    const actionRef = createRef<Renderable>();
+
+    function InitialFocusDialog() {
+      const [initialFocus, setInitialFocus] = useState<Renderable>();
+      return createElement(
+        Dialog.Root,
+        null,
+        createElement(Dialog.Trigger, { ref: triggerRef }),
+        createElement(
+          Dialog.Portal,
+          null,
+          createElement(
+            Dialog.Popup,
+            { ref: popupRef, initialFocus },
+            createElement("box", {
+              id: "react-initial-action",
+              focusable: true,
+              ref: (value: Renderable | null) => {
+                actionRef.current = value;
+                if (value) setInitialFocus(value);
+              },
+            }),
+            createElement(Dialog.Close),
+          ),
+        ),
+      );
+    }
+
+    setup = await testRender(createElement(InitialFocusDialog), {
+      width: 40,
+      height: 10,
+    });
+    await setup.waitFor(
+      () => popupRef.current?.initialFocus === actionRef.current,
+    );
+    await act(async () => triggerRef.current?.press());
+
+    expect(setup.renderer.currentFocusedRenderable).toBe(actionRef.current);
   });
 
   it("applies one controlled request without remounting the layer", async () => {

--- a/packages/react/src/dialog/dialog-primitive.test.tsx
+++ b/packages/react/src/dialog/dialog-primitive.test.tsx
@@ -170,6 +170,10 @@ describe("React Dialog", () => {
               ref: descriptionRef,
               content: "Description",
             }),
+            createElement("box", {
+              id: "react-action",
+              focusable: true,
+            }),
             createElement(Dialog.Close, {
               id: "react-close",
               ref: closeRef,
@@ -206,7 +210,7 @@ describe("React Dialog", () => {
 
     await act(async () => triggerRef.current?.press());
     await setup.waitFor(() => rootRef.current?.state.open === true);
-    expect(closeRef.current?.focused).toBe(true);
+    expect(setup.renderer.currentFocusedRenderable?.id).toBe("react-action");
     await act(async () => setup?.mockInput.pressTab());
     expect(closeRef.current?.focused).toBe(true);
     await act(async () => setup?.mockInput.pressEscape());

--- a/packages/react/src/dialog/primitive.tsx
+++ b/packages/react/src/dialog/primitive.tsx
@@ -29,10 +29,7 @@ import {
   type Ref,
   useCallback,
   useContext,
-  useEffect,
-  useImperativeHandle,
   useRef,
-  useState,
   useSyncExternalStore,
 } from "react";
 
@@ -58,7 +55,6 @@ extend({
 });
 
 const StoreContext = createContext<DialogStore | null>(null);
-const PopupContext = createContext<DialogPopupRenderable | null>(null);
 type PartProps<Options, Renderable> = Omit<Options, "store"> & {
   ref?: Ref<Renderable>;
   children?: ReactNode;
@@ -160,25 +156,11 @@ export function Backdrop({ children, ref, ...props }: Backdrop.Props) {
   );
 }
 export function Popup({ children, ref, ...props }: Popup.Props) {
-  const store = useStore("Popup");
-  const [popup, setPopup] = useState<DialogPopupRenderable | null>(null);
   return createElement(
     tags.popup,
-    { ...props, store, ref: setPopup },
-    popup ? createElement(PopupContent, { children, popup, ref }) : undefined,
+    { ...props, store: useStore("Popup"), ref },
+    children,
   );
-}
-function PopupContent({
-  children,
-  popup,
-  ref,
-}: {
-  children?: ReactNode;
-  popup: DialogPopupRenderable;
-  ref?: Ref<DialogPopupRenderable>;
-}) {
-  useImperativeHandle(ref, () => popup, [popup]);
-  return createElement(PopupContext.Provider, { value: popup }, children);
 }
 function TextPart({
   tag,
@@ -208,31 +190,11 @@ export function Description({ children, ...props }: Description.Props) {
   );
 }
 export function Close({ children, ref, ...props }: Close.Props) {
-  const store = useStore("Close");
-  const popup = useContext(PopupContext);
-  const [close, setClose] = useState<DialogCloseRenderable | null>(null);
   return createElement(
     tags.close,
-    { ...props, store, ref: setClose },
-    close
-      ? createElement(CloseContent, { children, close, popup, ref })
-      : undefined,
+    { ...props, store: useStore("Close"), ref },
+    children,
   );
-}
-function CloseContent({
-  children,
-  close,
-  popup,
-  ref,
-}: {
-  children?: ReactNode;
-  close: DialogCloseRenderable;
-  popup: DialogPopupRenderable | null;
-  ref?: Ref<DialogCloseRenderable>;
-}) {
-  useImperativeHandle(ref, () => close, [close]);
-  useEffect(() => popup?.registerFocusable(close), [close, popup]);
-  return children;
 }
 export namespace Root {
   export type Props = RootProps;

--- a/packages/solid/src/dialog/dialog-primitive.test.tsx
+++ b/packages/solid/src/dialog/dialog-primitive.test.tsx
@@ -160,6 +160,32 @@ describe("Solid Dialog", () => {
     expect(popup?.visible).toBe(false);
   });
 
+  it("follows rendered descendant order when choosing initial focus", async () => {
+    let trigger: DialogTriggerRenderable | undefined;
+    let close: DialogCloseRenderable | undefined;
+    setup = await testRender(
+      () => (
+        <Dialog.Root>
+          <Dialog.Trigger ref={(value) => (trigger = value)} />
+          <Dialog.Portal>
+            <Dialog.Popup>
+              <box id="solid-first-action" focusable />
+              <Dialog.Close ref={(value) => (close = value)} />
+            </Dialog.Popup>
+          </Dialog.Portal>
+        </Dialog.Root>
+      ),
+      { width: 40, height: 10 },
+    );
+
+    trigger?.press();
+    expect(setup.renderer.currentFocusedRenderable?.id).toBe(
+      "solid-first-action",
+    );
+    await setup.mockInput.pressTab();
+    expect(close?.focused).toBe(true);
+  });
+
   it("applies one controlled request without remounting the layer", async () => {
     const changes: string[] = [];
     let root: DialogRootRenderable | undefined;

--- a/packages/solid/src/dialog/dialog-primitive.test.tsx
+++ b/packages/solid/src/dialog/dialog-primitive.test.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @opentui/solid */
 
 import { afterEach, describe, expect, it } from "bun:test";
+import type { Renderable } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/solid";
 import type {
@@ -184,6 +185,46 @@ describe("Solid Dialog", () => {
     );
     await setup.mockInput.pressTab();
     expect(close?.focused).toBe(true);
+  });
+
+  it("updates initial focus after a descendant ref becomes available", async () => {
+    let trigger: DialogTriggerRenderable | undefined;
+    let popup: DialogPopupRenderable | undefined;
+    let action: Renderable | undefined;
+    let selectInitialFocus: ((target: Renderable) => void) | undefined;
+    setup = await testRender(
+      () => {
+        const [initialFocus, setInitialFocus] = createSignal<Renderable>();
+        selectInitialFocus = (target) => setInitialFocus(target);
+        return (
+          <Dialog.Root>
+            <Dialog.Trigger ref={(value) => (trigger = value)} />
+            <Dialog.Portal>
+              <Dialog.Popup
+                ref={(value) => (popup = value)}
+                initialFocus={initialFocus()}
+              >
+                <box
+                  id="solid-initial-action"
+                  focusable
+                  ref={(value: Renderable) => {
+                    action = value;
+                  }}
+                />
+                <Dialog.Close />
+              </Dialog.Popup>
+            </Dialog.Portal>
+          </Dialog.Root>
+        );
+      },
+      { width: 40, height: 10 },
+    );
+    if (!action) throw new Error("Solid Dialog action ref was not assigned");
+    selectInitialFocus?.(action);
+    await setup.waitFor(() => popup?.initialFocus === action);
+    trigger?.press();
+
+    expect(setup.renderer.currentFocusedRenderable).toBe(action);
   });
 
   it("applies one controlled request without remounting the layer", async () => {

--- a/packages/solid/src/dialog/primitive.tsx
+++ b/packages/solid/src/dialog/primitive.tsx
@@ -192,11 +192,18 @@ export function Backdrop(props: Backdrop.Props): JSX.Element {
 export function Popup(props: Popup.Props): JSX.Element {
   const store = useStore("Popup");
   const renderer = useRenderer();
-  const [local, initial] = splitProps(props, ["children", "ref"]);
+  const [local, initial] = splitProps(props, [
+    "children",
+    "initialFocus",
+    "ref",
+  ]);
   const element = new DialogPopupRenderable(
     renderer,
-    untrack(() => ({ ...initial, store })),
+    untrack(() => ({ ...initial, initialFocus: local.initialFocus, store })),
   );
+  createEffect(() => {
+    element.initialFocus = local.initialFocus;
+  });
   setRenderableRef(local.ref, element);
   spreadRenderableProps(element, () => ({
     ...initial,

--- a/registry.json
+++ b/registry.json
@@ -35,6 +35,7 @@
         "@opentui/react@^0.4.3",
         "react@^19.2.0"
       ],
+      "devDependencies": ["@types/react@^19.2.0"],
       "files": [
         {
           "path": "registry/checkbox/react.tsx",
@@ -107,6 +108,7 @@
         "@opentui/react@^0.4.3",
         "react@^19.2.0"
       ],
+      "devDependencies": ["@types/react@^19.2.0"],
       "files": [
         {
           "path": "registry/switch/react.tsx",
@@ -179,6 +181,7 @@
         "@opentui/react@^0.4.3",
         "react@^19.2.0"
       ],
+      "devDependencies": ["@types/react@^19.2.0"],
       "files": [
         {
           "path": "registry/button/react.tsx",
@@ -249,6 +252,7 @@
         "@opentui/react@^0.4.3",
         "react@^19.2.0"
       ],
+      "devDependencies": ["@types/react@^19.2.0"],
       "files": [
         {
           "path": "registry/badge/react.tsx",
@@ -319,6 +323,7 @@
         "@opentui/react@^0.4.3",
         "react@^19.2.0"
       ],
+      "devDependencies": ["@types/react@^19.2.0"],
       "files": [
         {
           "path": "registry/radio-group/react.tsx",
@@ -365,6 +370,7 @@
       "title": "Input (Core)",
       "description": "Editable imperative Input recipe preserving OpenTUI-native editing and events.",
       "dependencies": ["@opentui-ui/core@^0.0.3-rc.0", "@opentui/core@^0.4.3"],
+      "docs": "Input preserves OpenTUI's native mutable buffer: changed programmatic value assignments invoke onInput, while onChange reports blur or submit commits.",
       "files": [
         {
           "path": "registry/input/core.ts",
@@ -391,6 +397,8 @@
         "@opentui/react@^0.4.3",
         "react@^19.2.0"
       ],
+      "devDependencies": ["@types/react@^19.2.0"],
+      "docs": "Input preserves OpenTUI's native mutable buffer: changed programmatic value assignments invoke onInput, while onChange reports blur or submit commits.",
       "files": [
         {
           "path": "registry/input/react.tsx",
@@ -417,6 +425,7 @@
         "@opentui/solid@^0.4.3",
         "solid-js@1.9.12"
       ],
+      "docs": "Input preserves OpenTUI's native mutable buffer: changed programmatic value assignments invoke onInput, while onChange reports blur or submit commits.",
       "files": [
         {
           "path": "registry/input/solid.tsx",
@@ -461,6 +470,7 @@
         "@opentui/react@^0.4.3",
         "react@^19.2.0"
       ],
+      "devDependencies": ["@types/react@^19.2.0"],
       "files": [
         {
           "path": "registry/dialog/react.tsx",

--- a/registry/README.md
+++ b/registry/README.md
@@ -57,6 +57,18 @@ The CLI installs declared dependencies and copies the recipe into
 `components/ui`. Running ordinary `add` against an existing file asks before
 replacement and defaults to preserving the local file.
 
+## Build The Registry
+
+Registry maintainers can build every distributable item without preparing its
+nested framework directories manually:
+
+```bash
+pnpm registry:build --output ./public/r
+```
+
+Application consumers use `shadcn add` against the published item address and
+do not run this build command.
+
 ## Discover And Review Updates
 
 The current registry item is the upstream recipe revision. Its Git commit, tag,

--- a/registry/dialog/README.md
+++ b/registry/dialog/README.md
@@ -5,10 +5,11 @@ Each item copies an editable composition into `components/ui/dialog.*`; it does
 not replace the foundation Dialog primitive exported by `@opentui-ui/core`,
 `@opentui-ui/react`, and `@opentui-ui/solid`.
 
-The recipe owns the terminal-wide black backdrop, centered popup, border,
-padding, colors, title and description treatment, and the `× Close` affordance.
-It intentionally keeps convenience props small (`title`, optional
-`description`, and optional `closeLabel`) so applications can edit the source.
+The recipe owns the terminal-wide black backdrop, responsive centered popup,
+border, padding, colors, and the default treatment of each public part. React
+and Solid expose the shadcn-style `Dialog`, `DialogTrigger`, `DialogContent`,
+`DialogTitle`, `DialogDescription`, and `DialogClose` composition. Each wrapper
+retains the matching primitive props and Renderable ref.
 
 ## Ownership and interaction
 
@@ -23,6 +24,11 @@ owner must provide the next `open` value. `defaultOpen` is uncontrolled. Escape
 and backdrop interaction target only the topmost eligible layer; a popup click
 does not dismiss it. Nested dialogs receive a higher layer and closing one
 restores focus to its parent or original trigger.
+
+`DialogContent` wraps the primitive Portal, Backdrop, and Popup. Its props are
+the primitive Popup props, so callers can set `initialFocus`, dimensions, and
+native OpenTUI presentation without replacing the layer behavior. A
+`DialogClose` with `reason="action"` reports an accepted action dismissal.
 
 This recipe is validated preview catalog evidence rather than part of the
 six-family starter catalog. The adopted `@opentui-ui/dialog` manager, provider,

--- a/registry/dialog/core.ts
+++ b/registry/dialog/core.ts
@@ -1,4 +1,8 @@
-import { type RenderContext, TextRenderable } from "@opentui/core";
+import {
+  type BoxOptions,
+  type RenderContext,
+  TextRenderable,
+} from "@opentui/core";
 import {
   DialogBackdropRenderable,
   DialogCloseRenderable,
@@ -13,7 +17,7 @@ import {
 
 /** Visual defaults only; the Dialog primitive retains all layer behavior. */
 export interface DialogOptions extends DialogRootOptions {
-  width?: number;
+  width?: BoxOptions["width"];
 }
 
 export interface DialogRecipe {
@@ -27,14 +31,12 @@ export interface DialogRecipe {
 /** Assemble an editable, terminal-wide Dialog layer from packaged Core parts. */
 export function createDialog(
   ctx: RenderContext,
-  { width = 48, ...options }: DialogOptions = {},
+  { width = "80%", ...options }: DialogOptions = {},
 ): DialogRecipe {
   const root = new DialogRootRenderable(ctx, options);
   const trigger = new DialogTriggerRenderable(ctx, {
     store: root.store,
     backgroundColor: "#262626",
-    border: true,
-    borderColor: "#525252",
     paddingLeft: 1,
     paddingRight: 1,
   });
@@ -56,12 +58,13 @@ export function createDialog(
   const popup = new DialogPopupRenderable(ctx, {
     store: root.store,
     width,
+    maxWidth: 56,
     flexDirection: "column",
     backgroundColor: "#171717",
     border: true,
     borderColor: "#737373",
-    padding: 1,
-    gap: 1,
+    paddingLeft: 1,
+    paddingRight: 1,
   });
   portal.add(backdrop);
   portal.add(popup);
@@ -106,8 +109,6 @@ export function addDialogClose(
   const close = new DialogCloseRenderable(ctx, {
     store: dialog.root.store,
     backgroundColor: "#262626",
-    border: true,
-    borderColor: "#525252",
     paddingLeft: 1,
     paddingRight: 1,
   });

--- a/registry/dialog/react.tsx
+++ b/registry/dialog/react.tsx
@@ -1,78 +1,84 @@
 /** @jsxImportSource @opentui/react */
 
 import { Dialog as DialogPrimitive } from "@opentui-ui/react/dialog";
-import type { ReactNode } from "react";
 
-export interface DialogProps
-  extends Omit<DialogPrimitive.Root.Props, "children"> {
-  children?: ReactNode;
-  closeLabel?: string;
-  description?: string;
-  title: string;
-  trigger: ReactNode;
+/** Props for the consumer-owned Dialog root. */
+export interface DialogProps extends DialogPrimitive.Root.Props {}
+
+/** Props for the styled Dialog content composition. */
+export interface DialogContentProps extends DialogPrimitive.Popup.Props {
+  backdropColor?: DialogPrimitive.Backdrop.Props["backgroundColor"];
 }
 
-/** Editable visual composition over the packaged Dialog primitive parts. */
-export function Dialog({
-  children,
-  closeLabel = "× Close",
-  description,
-  title,
-  trigger,
-  ...props
-}: DialogProps) {
-  return (
-    <DialogPrimitive.Root {...props}>
-      <DialogTrigger>{trigger}</DialogTrigger>
-      <DialogPrimitive.Portal
-        position="absolute"
-        width="100%"
-        height="100%"
-        alignItems="center"
-        justifyContent="center"
-      >
-        <DialogPrimitive.Backdrop
-          position="absolute"
-          width="100%"
-          height="100%"
-          backgroundColor="#000000"
-        />
-        <DialogPrimitive.Popup
-          width={48}
-          flexDirection="column"
-          backgroundColor="#171717"
-          border
-          borderColor="#737373"
-          padding={1}
-          gap={1}
-        >
-          <DialogPrimitive.Title content={title} fg="#FFFFFF" />
-          {description ? (
-            <DialogPrimitive.Description content={description} fg="#A3A3A3" />
-          ) : null}
-          {children}
-          <DialogPrimitive.Close
-            backgroundColor="#262626"
-            border
-            borderColor="#525252"
-            paddingLeft={1}
-            paddingRight={1}
-          >
-            <text content={closeLabel} fg="#E5E5E5" />
-          </DialogPrimitive.Close>
-        </DialogPrimitive.Popup>
-      </DialogPrimitive.Portal>
-    </DialogPrimitive.Root>
-  );
+/** Consumer-owned wrapper over the packaged Dialog root. */
+export function Dialog(props: DialogProps) {
+  return <DialogPrimitive.Root {...props} />;
 }
 
-/** A small, editable trigger presentation for the packaged Trigger part. */
+/** Editable trigger presentation that retains the primitive Trigger ref. */
 export function DialogTrigger(props: DialogPrimitive.Trigger.Props) {
   return (
     <DialogPrimitive.Trigger
       backgroundColor="#262626"
-      border
-      borderColor="#525252"
+      paddingLeft={1}
+      paddingRight={1}
+      {...props}
+    />
+  );
+}
+
+/** Responsive Portal, Backdrop, and Popup composition for Dialog content. */
+export function DialogContent({
+  backdropColor = "#000000",
+  children,
+  ...props
+}: DialogContentProps) {
+  return (
+    <DialogPrimitive.Portal
+      position="absolute"
+      width="100%"
+      height="100%"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <DialogPrimitive.Backdrop
+        position="absolute"
+        width="100%"
+        height="100%"
+        backgroundColor={backdropColor}
+      />
+      <DialogPrimitive.Popup
+        width="80%"
+        maxWidth={56}
+        flexDirection="column"
+        backgroundColor="#171717"
+        border
+        borderColor="#737373"
+        paddingLeft={1}
+        paddingRight={1}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Popup>
+    </DialogPrimitive.Portal>
+  );
+}
+
+/** Editable semantic Dialog title. */
+export function DialogTitle(props: DialogPrimitive.Title.Props) {
+  return <DialogPrimitive.Title fg="#FFFFFF" {...props} />;
+}
+
+/** Editable semantic Dialog description. */
+export function DialogDescription(props: DialogPrimitive.Description.Props) {
+  return <DialogPrimitive.Description fg="#A3A3A3" {...props} />;
+}
+
+/** Editable Dialog dismissal or action control. */
+export function DialogClose(props: DialogPrimitive.Close.Props) {
+  return (
+    <DialogPrimitive.Close
+      backgroundColor="#262626"
       paddingLeft={1}
       paddingRight={1}
       {...props}

--- a/registry/dialog/smoke/react.test.tsx
+++ b/registry/dialog/smoke/react.test.tsx
@@ -10,7 +10,13 @@ import {
   type DialogTriggerRenderable,
 } from "@opentui-ui/core/dialog";
 import { act, createRef } from "react";
-import { Dialog } from "./components/ui/dialog";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "./components/ui/dialog";
 
 let setup: TestRendererSetup | undefined;
 
@@ -24,22 +30,26 @@ test("installed React Dialog recipe delegates controlled intent once and retains
   let changes = 0;
   setup = await testRender(
     <box flexDirection="column">
-      <Dialog
-        ref={root}
-        defaultOpen={false}
-        title="Delete file?"
-        trigger={<text content="Open" />}
-      >
-        <box>
+      <Dialog ref={root} defaultOpen={false}>
+        <DialogTrigger>
+          <text content="Open" />
+        </DialogTrigger>
+        <DialogContent>
+          <DialogTitle content="Delete file?" />
           <text content="Body" />
-        </box>
+          <DialogClose>
+            <text content="Close" />
+          </DialogClose>
+        </DialogContent>
       </Dialog>
-      <Dialog
-        open={false}
-        title="Controlled"
-        trigger={<text content="Controlled open" />}
-        onOpenChange={() => changes++}
-      />
+      <Dialog open={false} onOpenChange={() => changes++}>
+        <DialogTrigger>
+          <text content="Controlled open" />
+        </DialogTrigger>
+        <DialogContent>
+          <DialogTitle content="Controlled" />
+        </DialogContent>
+      </Dialog>
     </box>,
     { width: 60, height: 16 },
   );

--- a/registry/dialog/smoke/solid.test.tsx
+++ b/registry/dialog/smoke/solid.test.tsx
@@ -10,7 +10,13 @@ import {
   type DialogTriggerRenderable,
 } from "@opentui-ui/core/dialog";
 import { createSignal } from "solid-js";
-import { Dialog } from "./components/ui/dialog";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "./components/ui/dialog";
 
 let setup: TestRendererSetup | undefined;
 
@@ -28,28 +34,35 @@ test("installed Solid Dialog recipe delegates controlled intent once and retains
       const [controlledOpen, setControlledOpen] = createSignal(false);
       return (
         <box flexDirection="column">
-          <Dialog
-            ref={(node) => (root = node)}
-            defaultOpen={false}
-            title="Delete file?"
-            trigger={<text content="Open" />}
-          >
-            <box>
+          <Dialog ref={(node) => (root = node)} defaultOpen={false}>
+            <DialogTrigger>
+              <text content="Open" />
+            </DialogTrigger>
+            <DialogContent>
+              <DialogTitle content="Delete file?" />
               <text content="Body" />
-            </box>
+              <DialogClose>
+                <text content="Close" />
+              </DialogClose>
+            </DialogContent>
           </Dialog>
           <Dialog
             ref={(node) => {
               controlledRoot = node;
             }}
             open={controlledOpen()}
-            title="Controlled"
-            trigger={<text content="Controlled open" />}
             onOpenChange={(open) => {
               controlledChanges++;
               setControlledOpen(open);
             }}
-          />
+          >
+            <DialogTrigger>
+              <text content="Controlled open" />
+            </DialogTrigger>
+            <DialogContent>
+              <DialogTitle content="Controlled" />
+            </DialogContent>
+          </Dialog>
         </box>
       );
     },

--- a/registry/dialog/solid.tsx
+++ b/registry/dialog/solid.tsx
@@ -1,82 +1,82 @@
 /** @jsxImportSource @opentui/solid */
 
 import { Dialog as DialogPrimitive } from "@opentui-ui/solid/dialog";
-import type { JSX } from "solid-js";
 import { splitProps } from "solid-js";
 
-export interface DialogProps
-  extends Omit<DialogPrimitive.Root.Props, "children"> {
-  children?: JSX.Element;
-  closeLabel?: string;
-  description?: string;
-  title: string;
-  trigger: JSX.Element;
+/** Props for the consumer-owned Dialog root. */
+export interface DialogProps extends DialogPrimitive.Root.Props {}
+
+/** Props for the styled Dialog content composition. */
+export interface DialogContentProps extends DialogPrimitive.Popup.Props {
+  backdropColor?: DialogPrimitive.Backdrop.Props["backgroundColor"];
 }
 
-/** Editable visual composition over the packaged Dialog primitive parts. */
+/** Consumer-owned wrapper over the packaged Dialog root. */
 export function Dialog(props: DialogProps) {
-  const [recipe, root] = splitProps(props, [
-    "children",
-    "closeLabel",
-    "description",
-    "title",
-    "trigger",
-  ]);
-  return (
-    <DialogPrimitive.Root {...root}>
-      <DialogTrigger>{recipe.trigger}</DialogTrigger>
-      <DialogPrimitive.Portal
-        position="absolute"
-        width="100%"
-        height="100%"
-        alignItems="center"
-        justifyContent="center"
-      >
-        <DialogPrimitive.Backdrop
-          position="absolute"
-          width="100%"
-          height="100%"
-          backgroundColor="#000000"
-        />
-        <DialogPrimitive.Popup
-          width={48}
-          flexDirection="column"
-          backgroundColor="#171717"
-          border
-          borderColor="#737373"
-          padding={1}
-          gap={1}
-        >
-          <DialogPrimitive.Title content={recipe.title} fg="#FFFFFF" />
-          {recipe.description ? (
-            <DialogPrimitive.Description
-              content={recipe.description}
-              fg="#A3A3A3"
-            />
-          ) : null}
-          {recipe.children}
-          <DialogPrimitive.Close
-            backgroundColor="#262626"
-            border
-            borderColor="#525252"
-            paddingLeft={1}
-            paddingRight={1}
-          >
-            <text content={recipe.closeLabel ?? "× Close"} fg="#E5E5E5" />
-          </DialogPrimitive.Close>
-        </DialogPrimitive.Popup>
-      </DialogPrimitive.Portal>
-    </DialogPrimitive.Root>
-  );
+  return <DialogPrimitive.Root {...props} />;
 }
 
-/** A small, editable trigger presentation for the packaged Trigger part. */
+/** Editable trigger presentation that retains the primitive Trigger ref. */
 export function DialogTrigger(props: DialogPrimitive.Trigger.Props) {
   return (
     <DialogPrimitive.Trigger
       backgroundColor="#262626"
-      border
-      borderColor="#525252"
+      paddingLeft={1}
+      paddingRight={1}
+      {...props}
+    />
+  );
+}
+
+/** Responsive Portal, Backdrop, and Popup composition for Dialog content. */
+export function DialogContent(props: DialogContentProps) {
+  const [recipe, popup] = splitProps(props, ["backdropColor", "children"]);
+  return (
+    <DialogPrimitive.Portal
+      position="absolute"
+      width="100%"
+      height="100%"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <DialogPrimitive.Backdrop
+        position="absolute"
+        width="100%"
+        height="100%"
+        backgroundColor={recipe.backdropColor ?? "#000000"}
+      />
+      <DialogPrimitive.Popup
+        width="80%"
+        maxWidth={56}
+        flexDirection="column"
+        backgroundColor="#171717"
+        border
+        borderColor="#737373"
+        paddingLeft={1}
+        paddingRight={1}
+        {...popup}
+      >
+        {recipe.children}
+      </DialogPrimitive.Popup>
+    </DialogPrimitive.Portal>
+  );
+}
+
+/** Editable semantic Dialog title. */
+export function DialogTitle(props: DialogPrimitive.Title.Props) {
+  return <DialogPrimitive.Title fg="#FFFFFF" {...props} />;
+}
+
+/** Editable semantic Dialog description. */
+export function DialogDescription(props: DialogPrimitive.Description.Props) {
+  return <DialogPrimitive.Description fg="#A3A3A3" {...props} />;
+}
+
+/** Editable Dialog dismissal or action control. */
+export function DialogClose(props: DialogPrimitive.Close.Props) {
+  return (
+    <DialogPrimitive.Close
+      backgroundColor="#262626"
       paddingLeft={1}
       paddingRight={1}
       {...props}

--- a/scripts/build-registry.mjs
+++ b/scripts/build-registry.mjs
@@ -1,0 +1,38 @@
+import { mkdirSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const root = resolve(import.meta.dirname, "..");
+const args = process.argv.slice(2);
+const outputFlag = args.findIndex((argument) => argument === "--output");
+const inlineOutput = args.find((argument) => argument.startsWith("--output="));
+const requestedOutput =
+  inlineOutput?.slice("--output=".length) ??
+  (outputFlag === -1 ? undefined : args[outputFlag + 1]);
+
+if (outputFlag !== -1 && !requestedOutput) {
+  console.error("--output requires a directory");
+  process.exitCode = 1;
+} else {
+  const output = resolve(root, requestedOutput ?? "public/r");
+  const registry = JSON.parse(
+    readFileSync(join(root, "registry.json"), "utf8"),
+  );
+  for (const item of registry.items) {
+    mkdirSync(dirname(join(output, `${item.name}.json`)), { recursive: true });
+  }
+
+  const buildArgs = ["build", "registry.json", ...args];
+  if (!requestedOutput) buildArgs.push("--output", output);
+  const executable = join(
+    root,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "shadcn.cmd" : "shadcn",
+  );
+  const result = spawnSync(executable, buildArgs, {
+    cwd: root,
+    stdio: "inherit",
+  });
+  process.exitCode = result.status ?? 1;
+}

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -39,9 +39,6 @@ const frameworks = {
   react: {
     extension: "tsx",
     localPackages: ["@opentui-ui/core", "@opentui-ui/react"],
-    devDependencies: {
-      "@types/react": "19.2.17",
-    },
     compilerOptions: {
       jsx: "react-jsx",
       jsxImportSource: "@opentui/react",
@@ -306,6 +303,12 @@ try {
     assert(existsSync(join(root, consumer.smoke)), `Missing ${consumer.smoke}`);
   }
   for (const item of registry.items) {
+    if (item.meta?.framework === "react") {
+      assert(
+        item.devDependencies?.includes("@types/react@^19.2.0"),
+        `${item.name} must install React types as a development dependency`,
+      );
+    }
     for (const dependency of item.dependencies) {
       if (!Object.hasOwn(packageDirectories, packageName(dependency))) continue;
       assert(
@@ -457,6 +460,11 @@ try {
       JSON.stringify(builtItem.dependencies) ===
         JSON.stringify(registryItem.dependencies),
       `${itemName} build changed registry dependencies`,
+    );
+    assert(
+      JSON.stringify(builtItem.devDependencies) ===
+        JSON.stringify(registryItem.devDependencies),
+      `${itemName} build changed registry development dependencies`,
     );
     assert(
       JSON.stringify(builtItem.meta) === JSON.stringify(registryItem.meta),


### PR DESCRIPTION
## Summary

- make disabled controls truthful focus-traversal candidates
- reshape Dialog recipes into responsive compound components with natural focus order and programmatic focus restoration
- support reactive Dialog `initialFocus` in React and Solid
- make nested registry builds reproducible and install React type declarations
- document native Input callback semantics
- update and pin GitHub Actions dependencies

## Validation

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- clean React and Solid Dialog registry consumer validation