### PR TITLE
fix: classify registry recipes as UI components

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -5,14 +5,14 @@
   "items": [
     {
       "name": "core/checkbox",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Checkbox (Core)",
       "description": "Editable imperative Checkbox recipe built on the OpenTUI UI foundation primitive.",
       "dependencies": ["@opentui-ui/core@^0.0.3-rc.0", "@opentui/core@^0.4.3"],
       "files": [
         {
           "path": "registry/checkbox/core.ts",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/checkbox.ts"
         }
       ],
@@ -25,7 +25,7 @@
     },
     {
       "name": "react/checkbox",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Checkbox (React)",
       "description": "Editable React Checkbox recipe built on the OpenTUI UI foundation primitive.",
       "dependencies": [
@@ -39,7 +39,7 @@
       "files": [
         {
           "path": "registry/checkbox/react.tsx",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/checkbox.tsx"
         }
       ],
@@ -52,7 +52,7 @@
     },
     {
       "name": "solid/checkbox",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Checkbox (Solid)",
       "description": "Editable Solid Checkbox recipe built on the OpenTUI UI foundation primitive.",
       "dependencies": [
@@ -65,7 +65,7 @@
       "files": [
         {
           "path": "registry/checkbox/solid.tsx",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/checkbox.tsx"
         }
       ],
@@ -78,14 +78,14 @@
     },
     {
       "name": "core/switch",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Switch (Core)",
       "description": "Editable imperative Switch recipe built on the OpenTUI UI foundation primitive.",
       "dependencies": ["@opentui-ui/core@^0.0.3-rc.0", "@opentui/core@^0.4.3"],
       "files": [
         {
           "path": "registry/switch/core.ts",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/switch.ts"
         }
       ],
@@ -98,7 +98,7 @@
     },
     {
       "name": "react/switch",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Switch (React)",
       "description": "Editable React Switch recipe built on the OpenTUI UI foundation primitive.",
       "dependencies": [
@@ -112,7 +112,7 @@
       "files": [
         {
           "path": "registry/switch/react.tsx",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/switch.tsx"
         }
       ],
@@ -125,7 +125,7 @@
     },
     {
       "name": "solid/switch",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Switch (Solid)",
       "description": "Editable Solid Switch recipe built on the OpenTUI UI foundation primitive.",
       "dependencies": [
@@ -138,7 +138,7 @@
       "files": [
         {
           "path": "registry/switch/solid.tsx",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/switch.tsx"
         }
       ],
@@ -151,14 +151,14 @@
     },
     {
       "name": "core/button",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Button (Core)",
       "description": "Editable imperative Button recipe built on the OpenTUI UI foundation primitive.",
       "dependencies": ["@opentui-ui/core@^0.0.3-rc.0", "@opentui/core@^0.4.3"],
       "files": [
         {
           "path": "registry/button/core.ts",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/button.ts"
         }
       ],
@@ -171,7 +171,7 @@
     },
     {
       "name": "react/button",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Button (React)",
       "description": "Editable React Button recipe built on the OpenTUI UI foundation primitive.",
       "dependencies": [
@@ -185,7 +185,7 @@
       "files": [
         {
           "path": "registry/button/react.tsx",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/button.tsx"
         }
       ],
@@ -198,7 +198,7 @@
     },
     {
       "name": "solid/button",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Button (Solid)",
       "description": "Editable Solid Button recipe built on the OpenTUI UI foundation primitive.",
       "dependencies": [
@@ -211,7 +211,7 @@
       "files": [
         {
           "path": "registry/button/solid.tsx",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/button.tsx"
         }
       ],
@@ -224,14 +224,14 @@
     },
     {
       "name": "core/badge",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Badge (Core)",
       "description": "Editable imperative Badge recipe built directly from OpenTUI Renderables.",
       "dependencies": ["@opentui/core@^0.4.3"],
       "files": [
         {
           "path": "registry/badge/core.ts",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/badge.ts"
         }
       ],
@@ -244,7 +244,7 @@
     },
     {
       "name": "react/badge",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Badge (React)",
       "description": "Editable React Badge recipe built directly from OpenTUI elements.",
       "dependencies": [
@@ -256,7 +256,7 @@
       "files": [
         {
           "path": "registry/badge/react.tsx",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/badge.tsx"
         }
       ],
@@ -269,7 +269,7 @@
     },
     {
       "name": "solid/badge",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Badge (Solid)",
       "description": "Editable Solid Badge recipe built directly from OpenTUI elements.",
       "dependencies": [
@@ -280,7 +280,7 @@
       "files": [
         {
           "path": "registry/badge/solid.tsx",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/badge.tsx"
         }
       ],
@@ -293,14 +293,14 @@
     },
     {
       "name": "core/radio-group",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Radio Group (Core)",
       "description": "Editable imperative Radio and Radio Group recipe built on the OpenTUI UI collection primitive.",
       "dependencies": ["@opentui-ui/core@^0.0.3-rc.0", "@opentui/core@^0.4.3"],
       "files": [
         {
           "path": "registry/radio-group/core.ts",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/radio-group.ts"
         }
       ],
@@ -313,7 +313,7 @@
     },
     {
       "name": "react/radio-group",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Radio Group (React)",
       "description": "Editable React Radio and Radio Group recipe built on the OpenTUI UI collection primitive.",
       "dependencies": [
@@ -327,7 +327,7 @@
       "files": [
         {
           "path": "registry/radio-group/react.tsx",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/radio-group.tsx"
         }
       ],
@@ -340,7 +340,7 @@
     },
     {
       "name": "solid/radio-group",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Radio Group (Solid)",
       "description": "Editable Solid Radio and Radio Group recipe built on the OpenTUI UI collection primitive.",
       "dependencies": [
@@ -353,7 +353,7 @@
       "files": [
         {
           "path": "registry/radio-group/solid.tsx",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/radio-group.tsx"
         }
       ],
@@ -366,7 +366,7 @@
     },
     {
       "name": "core/input",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Input (Core)",
       "description": "Editable imperative Input recipe preserving OpenTUI-native editing and events.",
       "dependencies": ["@opentui-ui/core@^0.0.3-rc.0", "@opentui/core@^0.4.3"],
@@ -374,7 +374,7 @@
       "files": [
         {
           "path": "registry/input/core.ts",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/input.ts"
         }
       ],
@@ -387,7 +387,7 @@
     },
     {
       "name": "react/input",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Input (React)",
       "description": "Editable React Input recipe preserving OpenTUI-native editing and events.",
       "dependencies": [
@@ -402,7 +402,7 @@
       "files": [
         {
           "path": "registry/input/react.tsx",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/input.tsx"
         }
       ],
@@ -415,7 +415,7 @@
     },
     {
       "name": "solid/input",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Input (Solid)",
       "description": "Editable Solid Input recipe preserving OpenTUI-native editing and events.",
       "dependencies": [
@@ -429,7 +429,7 @@
       "files": [
         {
           "path": "registry/input/solid.tsx",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/input.tsx"
         }
       ],
@@ -442,14 +442,14 @@
     },
     {
       "name": "core/dialog",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Dialog (Core)",
       "description": "Editable imperative Dialog recipe built on the OpenTUI UI overlay primitive tracer.",
       "dependencies": ["@opentui-ui/core@^0.0.3-rc.0", "@opentui/core@^0.4.3"],
       "files": [
         {
           "path": "registry/dialog/core.ts",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/dialog.ts"
         }
       ],
@@ -460,7 +460,7 @@
     },
     {
       "name": "react/dialog",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Dialog (React)",
       "description": "Editable React Dialog recipe built on the OpenTUI UI overlay primitive tracer.",
       "dependencies": [
@@ -474,7 +474,7 @@
       "files": [
         {
           "path": "registry/dialog/react.tsx",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/dialog.tsx"
         }
       ],
@@ -485,7 +485,7 @@
     },
     {
       "name": "solid/dialog",
-      "type": "registry:item",
+      "type": "registry:ui",
       "title": "Dialog (Solid)",
       "description": "Editable Solid Dialog recipe built on the OpenTUI UI overlay primitive tracer.",
       "dependencies": [
@@ -498,7 +498,7 @@
       "files": [
         {
           "path": "registry/dialog/solid.tsx",
-          "type": "registry:file",
+          "type": "registry:ui",
           "target": "components/ui/dialog.tsx"
         }
       ],

--- a/registry.json
+++ b/registry.json
@@ -12,7 +12,7 @@
       "files": [
         {
           "path": "registry/checkbox/core.ts",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/checkbox.ts"
         }
       ],
@@ -39,7 +39,7 @@
       "files": [
         {
           "path": "registry/checkbox/react.tsx",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/checkbox.tsx"
         }
       ],
@@ -65,7 +65,7 @@
       "files": [
         {
           "path": "registry/checkbox/solid.tsx",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/checkbox.tsx"
         }
       ],
@@ -85,7 +85,7 @@
       "files": [
         {
           "path": "registry/switch/core.ts",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/switch.ts"
         }
       ],
@@ -112,7 +112,7 @@
       "files": [
         {
           "path": "registry/switch/react.tsx",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/switch.tsx"
         }
       ],
@@ -138,7 +138,7 @@
       "files": [
         {
           "path": "registry/switch/solid.tsx",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/switch.tsx"
         }
       ],
@@ -158,7 +158,7 @@
       "files": [
         {
           "path": "registry/button/core.ts",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/button.ts"
         }
       ],
@@ -185,7 +185,7 @@
       "files": [
         {
           "path": "registry/button/react.tsx",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/button.tsx"
         }
       ],
@@ -211,7 +211,7 @@
       "files": [
         {
           "path": "registry/button/solid.tsx",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/button.tsx"
         }
       ],
@@ -231,7 +231,7 @@
       "files": [
         {
           "path": "registry/badge/core.ts",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/badge.ts"
         }
       ],
@@ -256,7 +256,7 @@
       "files": [
         {
           "path": "registry/badge/react.tsx",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/badge.tsx"
         }
       ],
@@ -280,7 +280,7 @@
       "files": [
         {
           "path": "registry/badge/solid.tsx",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/badge.tsx"
         }
       ],
@@ -300,7 +300,7 @@
       "files": [
         {
           "path": "registry/radio-group/core.ts",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/radio-group.ts"
         }
       ],
@@ -327,7 +327,7 @@
       "files": [
         {
           "path": "registry/radio-group/react.tsx",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/radio-group.tsx"
         }
       ],
@@ -353,7 +353,7 @@
       "files": [
         {
           "path": "registry/radio-group/solid.tsx",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/radio-group.tsx"
         }
       ],
@@ -374,7 +374,7 @@
       "files": [
         {
           "path": "registry/input/core.ts",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/input.ts"
         }
       ],
@@ -402,7 +402,7 @@
       "files": [
         {
           "path": "registry/input/react.tsx",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/input.tsx"
         }
       ],
@@ -429,7 +429,7 @@
       "files": [
         {
           "path": "registry/input/solid.tsx",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/input.tsx"
         }
       ],
@@ -449,7 +449,7 @@
       "files": [
         {
           "path": "registry/dialog/core.ts",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/dialog.ts"
         }
       ],
@@ -474,7 +474,7 @@
       "files": [
         {
           "path": "registry/dialog/react.tsx",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/dialog.tsx"
         }
       ],
@@ -498,7 +498,7 @@
       "files": [
         {
           "path": "registry/dialog/solid.tsx",
-          "type": "registry:ui",
+          "type": "registry:file",
           "target": "components/ui/dialog.tsx"
         }
       ],


### PR DESCRIPTION
## Summary

- classify all OpenTUI UI registry recipes as `registry:ui`
- retain emitted recipe files as `registry:file` so shadcn installs the OpenTUI source verbatim instead of applying web-component transforms
- retain npm packages under `dependencies`; no `registryDependencies` are needed because these recipes do not import other copied registry items

## Validation

- `pnpm validate:registry:built --since=origin/main`
- all 21 Core, React, and Solid clean-consumer installations passed
- installed recipes remain byte-for-byte identical to their registry sources