### PR TITLE
Rebrand domain and wordmark: tui.parts -> tuiparts.sh

### DIFF
--- a/.changeset/fresh-react-peers.md
+++ b/.changeset/fresh-react-peers.md
@@ -2,6 +2,6 @@
 "@tuiparts/react": patch
 ---
 
-Stop declaring `ws` as a tui.parts peer. Applications install the React
+Stop declaring `ws` as a tuiparts.sh peer. Applications install the React
 adapter and its OpenTUI/React peers without duplicating an upstream runtime
 concern in this package or registry recipes.

--- a/.changeset/rebrand-scope-rename.md
+++ b/.changeset/rebrand-scope-rename.md
@@ -5,7 +5,7 @@
 ---
 
 Renamed the npm scope from `@opentui-ui` to `@tuiparts`. The project is now
-tui.parts — the primitive and recipe ecosystem for OpenTUI. Package behavior
+tuiparts.sh — the primitive and recipe ecosystem for OpenTUI. Package behavior
 and APIs are unchanged; only the name moved. The final `@opentui-ui/*`
 releases are deprecated with pointers to their `@tuiparts/*` successors.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 **Updated:** 2026-07-15
 ## OVERVIEW
 
-tui.parts — the primitive and recipe ecosystem for OpenTUI (npm scope
+tuiparts.sh — the primitive and recipe ecosystem for OpenTUI (npm scope
 `@tuiparts`). The monorepo is built around framework-neutral Core behavior,
 React/Solid compound-part adapters, and shadcn-compatible consumer-owned
 recipes written with plain TypeScript and native OpenTUI properties.

--- a/PRIMITIVES_AND_RECIPES.md
+++ b/PRIMITIVES_AND_RECIPES.md
@@ -1,8 +1,8 @@
-# tui.parts Primitives And Recipes
+# tuiparts.sh Primitives And Recipes
 
 ## Direction
 
-tui.parts separates difficult packaged behavior from opinionated,
+tuiparts.sh separates difficult packaged behavior from opinionated,
 consumer-owned presentation.
 
 This is the formal product architecture for foundation v1.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tui.parts
+# tuiparts.sh
 
 The primitive and recipe ecosystem for
 [OpenTUI](https://github.com/anomalyco/opentui).
@@ -20,7 +20,7 @@ Parts for terminal interfaces. Some assembly encouraged.
   1. Root   2. Indicator
 ```
 
-tui.parts ships in two halves:
+tuiparts.sh ships in two halves:
 
 - **Primitives** — npm packages that own the difficult, unstyled behavior:
   state, focus, keyboard and pointer handling, overlays, collections. Every
@@ -119,7 +119,7 @@ typechecks every exported subpath, and executes representative runtime imports.
 
 ## Attribution
 
-tui.parts is an independent project built for OpenTUI. It is not affiliated
+tuiparts.sh is an independent project built for OpenTUI. It is not affiliated
 with, or endorsed by, the OpenTUI project.
 
 ## License

--- a/apps/www/README.md
+++ b/apps/www/README.md
@@ -1,6 +1,6 @@
 # www
 
-The tui.parts website: landing page, docs, and shadcn-compatible registry
+The tuiparts.sh website: landing page, docs, and shadcn-compatible registry
 host, built with [Blume](https://useblume.dev).
 
 ## Structure
@@ -35,4 +35,4 @@ The site is a fully static build. Two options:
 
 After the production domain exists, update `deployment.site` in
 `blume.config.ts` and the registry URLs in `docs/quickstart.mdx` and
-`docs/registry.mdx` (currently `https://tui.parts`).
+`docs/registry.mdx` (currently `https://tuiparts.sh`).

--- a/apps/www/blume.config.ts
+++ b/apps/www/blume.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from "blume";
 
 export default defineConfig({
-  title: "tui.parts",
+  title: "tuiparts.sh",
   description:
     "The primitive and recipe ecosystem for OpenTUI. Package the difficult behavior. Copy the opinionated layer.",
   logo: {
     image: "/logo.svg",
-    text: "tui.parts",
+    text: "tuiparts.sh",
   },
 
   // Docs mount at /docs; the site root is the custom landing page.
@@ -66,6 +66,6 @@ export default defineConfig({
   deployment: {
     output: "static",
     // TODO: replace with the production domain once it exists.
-    site: "https://tui.parts",
+    site: "https://tuiparts.sh",
   },
 });

--- a/apps/www/design.md
+++ b/apps/www/design.md
@@ -1,4 +1,4 @@
-# Design — tui.parts docs site
+# Design — tuiparts.sh docs site
 
 A locked design system for `apps/www`. Every page redesign reads this file
 before emitting code. Do not regenerate per page — extend or amend this file

--- a/apps/www/docs/architecture.mdx
+++ b/apps/www/docs/architecture.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-tui.parts splits every component into behavior that is packaged and
+tuiparts.sh splits every component into behavior that is packaged and
 presentation that is copied.
 
 ## Two layers

--- a/apps/www/docs/index.mdx
+++ b/apps/www/docs/index.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 1
 ---
 
-tui.parts is the primitive and recipe ecosystem for
+tuiparts.sh is the primitive and recipe ecosystem for
 [OpenTUI](https://github.com/anomalyco/opentui) — composable interaction
 primitives and editable recipes for building terminal UIs in React, Solid, or
 imperative Core. It makes the same trade Base UI and shadcn/ui made on the

--- a/apps/www/docs/quickstart.mdx
+++ b/apps/www/docs/quickstart.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 2
 ---
 
-tui.parts supports three runtimes — React, Solid, and imperative Core. Install
+tuiparts.sh supports three runtimes — React, Solid, and imperative Core. Install
 one adapter and its OpenTUI peers, then either compose primitives directly or
 install editable recipes from the registry.
 
@@ -84,13 +84,13 @@ application-owned source.
 
 1. **Configure shadcn**
 
-    Add the tui.parts registry to your `components.json`:
+    Add the tuiparts.sh registry to your `components.json`:
 
     ```json title="components.json"
     {
       "$schema": "https://ui.shadcn.com/schema.json",
       "registries": {
-        "@tuiparts": "https://tui.parts/r/{name}.json"
+        "@tuiparts": "https://tuiparts.sh/r/{name}.json"
       }
     }
     ```

--- a/apps/www/docs/registry.mdx
+++ b/apps/www/docs/registry.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 4
 ---
 
-The tui.parts registry distributes editable recipe source through the
+The tuiparts.sh registry distributes editable recipe source through the
 official shadcn CLI. It is hosted on this site: every item is a static JSON
 payload at `/r/<framework>/<name>.json`.
 
@@ -21,7 +21,7 @@ Add the registry namespace to your project's `components.json`:
 {
   "$schema": "https://ui.shadcn.com/schema.json",
   "registries": {
-    "@tuiparts": "https://tui.parts/r/{name}.json"
+    "@tuiparts": "https://tuiparts.sh/r/{name}.json"
   }
 }
 ```
@@ -35,7 +35,7 @@ pnpm dlx shadcn@4.13.0 add @tuiparts/react/checkbox
 You can also install any item by direct URL without configuring a namespace:
 
 ```bash
-pnpm dlx shadcn@4.13.0 add https://tui.parts/r/react/checkbox.json
+pnpm dlx shadcn@4.13.0 add https://tuiparts.sh/r/react/checkbox.json
 ```
 
 The CLI installs declared dependencies and copies the recipe into

--- a/apps/www/pages/index.astro
+++ b/apps/www/pages/index.astro
@@ -113,7 +113,7 @@ const pillars = [
   siteUrl={config.site}
   ogEnabled={config.og.enabled}
   page={{
-    title: "tui.parts — The foundation for your terminal UI",
+    title: "tuiparts.sh — The foundation for your terminal UI",
     description: config.description,
   }}
 >
@@ -198,7 +198,7 @@ const pillars = [
     <figure
       class="demo m-0"
       role="img"
-      aria-label="Terminal running settings.tsx built with tui.parts: a checkbox list, a radio-group theme picker, a switch, a focused search input, and Save and Cancel buttons."
+      aria-label="Terminal running settings.tsx built with tuiparts.sh: a checkbox list, a radio-group theme picker, a switch, a focused search input, and Save and Cancel buttons."
     >
       <div class="demo-bar">
         <span class="demo-file">demo/settings.tsx</span>
@@ -473,7 +473,7 @@ const pillars = [
       class="mx-auto flex max-w-6xl flex-col items-start justify-between gap-10 px-6 py-14 sm:flex-row"
     >
       <div class="max-w-xs">
-        <p class="font-display text-sm font-semibold text-foreground">tui.parts</p>
+        <p class="font-display text-sm font-semibold text-foreground">tuiparts.sh</p>
         <p class="mt-2 text-pretty text-sm text-muted-foreground">
           Terminal primitives and editable recipes for OpenTUI.
         </p>

--- a/apps/www/public/icon.svg
+++ b/apps/www/public/icon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-  <title>tui.parts</title>
+  <title>tuiparts.sh</title>
   <rect width="24" height="24" fill="#0B0E15" />
   <path d="M8 6.5l3 3L16.5 3" stroke="#3B82F6" stroke-width="2" />
   <rect x="5" y="13" width="14" height="9" stroke="#ECEEF2" stroke-width="2" />

--- a/apps/www/public/logo.svg
+++ b/apps/www/public/logo.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-  <title>tui.parts — checkbox, exploded view</title>
+  <title>tuiparts.sh — checkbox, exploded view</title>
   <path d="M8 6.5l3 3L16.5 3" stroke="#2D62E4" stroke-width="2" />
   <rect x="5" y="13" width="14" height="9" stroke="currentColor" stroke-width="2" />
 </svg>

--- a/docs/adr/0001-react-primitive-store-adaptation.md
+++ b/docs/adr/0001-react-primitive-store-adaptation.md
@@ -4,7 +4,7 @@ status: accepted
 
 # Use Core Stores for React early state without consumer wiring
 
-tui.parts exposes Base UI-style primitive modules to React and Solid consumers,
+tuiparts.sh exposes Base UI-style primitive modules to React and Solid consumers,
 while Core owns framework-neutral behavior. React automatically creates a Core
 Store before the OpenTUI reconciler constructs the corresponding Renderable.
 The later Root uses that exact Store. Consumers configure Root props and do not

--- a/docs/brand/README.md
+++ b/docs/brand/README.md
@@ -1,20 +1,20 @@
-# tui.parts Brand System
+# tuiparts.sh Brand System
 
-Working brand reference for tui.parts — the primitive and recipe ecosystem
+Working brand reference for tuiparts.sh — the primitive and recipe ecosystem
 for OpenTUI. Derived from the 2026-07-15 brand handoff. Where this document
 and the handoff disagree, this document wins: it carries the amendments
 (registry URL shape, mascot name, typeface).
 
 ## The name
 
-- The brand is written `tui.parts` — always lowercase, always with the dot.
+- The brand is written `tuiparts.sh` — always lowercase, always with the dot.
   The domain is the wordmark.
 - The npm scope and handle form is `@tuiparts`.
 - Pronunciation is documented once, in the root README, and never again.
 - The descriptor accompanies the brand wherever honesty matters:
   "The primitive and recipe ecosystem for OpenTUI."
 - Tagline: "Parts for terminal interfaces. Some assembly encouraged."
-- Attribution is mandatory: tui.parts is an independent project and is not
+- Attribution is mandatory: tuiparts.sh is an independent project and is not
   affiliated with, or endorsed by, the OpenTUI project.
 
 ## Voice
@@ -107,7 +107,7 @@ PART NO. r/react/checkbox.json
 ```
 
 The Catalog manifest is served at `/r/registry.json`; consumers register the
-namespace once: `@tuiparts = https://tui.parts/r/{name}.json`.
+namespace once: `@tuiparts = https://tuiparts.sh/r/{name}.json`.
 
 ## Applications
 

--- a/docs/brand/figures.md
+++ b/docs/brand/figures.md
@@ -2,7 +2,7 @@
 
 Rules for producing `FIG. N` box-drawing schematics. A Figure is any
 captioned box-drawing diagram, including every Kit appearance. Figures are
-the signature graphic system of tui.parts: exploded views of real
+the signature graphic system of tuiparts.sh: exploded views of real
 Primitives, labeled with real Part names.
 
 ## The hard requirement

--- a/docs/brand/kit.md
+++ b/docs/brand/kit.md
@@ -1,6 +1,6 @@
 # Kit — Mascot Sheet
 
-Kit is the tui.parts mascot: an assembly robot built entirely from
+Kit is the tuiparts.sh mascot: an assembly robot built entirely from
 box-drawing characters. The mascot is literally made of parts, which is the
 product thesis in creature form. A "kit" is a set of parts you assemble
 yourself.

--- a/docs/brand/logomark.md
+++ b/docs/brand/logomark.md
@@ -39,7 +39,7 @@ is a checkbox; the exploded checkbox is the brand.
 
 ## Wordmark
 
-`tui.parts` set in Commit Mono, lowercase, with the dot. The domain is the
+`tuiparts.sh` set in Commit Mono, lowercase, with the dot. The domain is the
 wordmark.
 
 Dot treatments:
@@ -60,20 +60,20 @@ Primary (vertical, brand contexts) — the wordmark takes the caption slot:
         1 ─╌╌ ┌─┐
               └─┘
 
-  tui.parts
+  tuiparts.sh
 ```
 
 Wordmark with descriptor (anywhere honesty matters):
 
 ```
-tui.parts
+tuiparts.sh
 The primitive and recipe ecosystem for OpenTUI.
 ```
 
 Launch line (single-line contexts):
 
 ```
-tui.parts — Parts for terminal interfaces. Some assembly encouraged.
+tuiparts.sh — Parts for terminal interfaces. Some assembly encouraged.
 ```
 
 ## Clearspace and minimums

--- a/docs/brand/tokens.css
+++ b/docs/brand/tokens.css
@@ -1,4 +1,4 @@
-/* tui.parts design tokens — generated from tokens.json. Edit tokens.json first. */
+/* tuiparts.sh design tokens — generated from tokens.json. Edit tokens.json first. */
 :root {
   --tp-color-bg: #0d1117;
   --tp-color-bg-surface: #161b22;

--- a/docs/foundation.md
+++ b/docs/foundation.md
@@ -1,6 +1,6 @@
-# tui.parts Foundation
+# tuiparts.sh Foundation
 
-tui.parts has two Foundation layers:
+tuiparts.sh has two Foundation layers:
 
 1. Versioned packages provide reusable terminal behavior.
 2. Registry recipes copy editable presentation into your application.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @tuiparts/core
 
-Framework-neutral OpenTUI behavior for the tui.parts Foundation.
+Framework-neutral OpenTUI behavior for the tuiparts.sh Foundation.
 
 New to the package/recipe split? Start with the
 [foundation guide](https://github.com/tuiparts/tuiparts/blob/main/docs/foundation.md).

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,6 +1,6 @@
 # @tuiparts/react
 
-The React Adapter for the tui.parts Foundation.
+The React Adapter for the tuiparts.sh Foundation.
 
 New to package primitives and editable recipes? Start with the
 [foundation guide](https://github.com/tuiparts/tuiparts/blob/main/docs/foundation.md).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tuiparts/react",
   "version": "0.0.3-rc.0",
-  "description": "React Adapter for tui.parts Primitives",
+  "description": "React Adapter for tuiparts.sh Primitives",
   "author": "Matt Simpson",
   "license": "MIT",
   "sideEffects": [

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,6 +1,6 @@
 # @tuiparts/solid
 
-The Solid Adapter for the tui.parts Foundation.
+The Solid Adapter for the tuiparts.sh Foundation.
 
 New to package primitives and editable recipes? Start with the
 [foundation guide](https://github.com/tuiparts/tuiparts/blob/main/docs/foundation.md).

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tuiparts/solid",
   "version": "0.0.3-rc.0",
-  "description": "Solid Adapter for tui.parts Primitives",
+  "description": "Solid Adapter for tuiparts.sh Primitives",
   "author": "Matt Simpson",
   "license": "MIT",
   "sideEffects": [

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,7 +2,7 @@
   "name": "@tuiparts/utils",
   "version": "0.0.1",
   "private": true,
-  "description": "Shared utilities and types for tui.parts packages",
+  "description": "Shared utilities and types for tuiparts.sh packages",
   "author": "Matt Simpson",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @tuiparts/utils
  *
- * Shared utilities and types for tui.parts packages
+ * Shared utilities and types for tuiparts.sh packages
  */
 
 // Types

--- a/packages/utils/src/types/index.ts
+++ b/packages/utils/src/types/index.ts
@@ -1,5 +1,5 @@
 /**
- * Shared type definitions for tui.parts packages
+ * Shared type definitions for tuiparts.sh packages
  */
 
 /**

--- a/packages/utils/src/utils/index.ts
+++ b/packages/utils/src/utils/index.ts
@@ -1,5 +1,5 @@
 /**
- * Shared utility functions for tui.parts packages
+ * Shared utility functions for tuiparts.sh packages
  */
 
 // Opacity utilities

--- a/registry.json
+++ b/registry.json
@@ -1,13 +1,13 @@
 {
   "$schema": "https://ui.shadcn.com/schema/registry.json",
   "name": "tuiparts",
-  "homepage": "https://tui.parts",
+  "homepage": "https://tuiparts.sh",
   "items": [
     {
       "name": "core/checkbox",
       "type": "registry:ui",
       "title": "Checkbox (Core)",
-      "description": "Editable imperative Checkbox Recipe built on the tui.parts Foundation Primitive.",
+      "description": "Editable imperative Checkbox Recipe built on the tuiparts.sh Foundation Primitive.",
       "dependencies": ["@tuiparts/core@^0.0.3-rc.0", "@opentui/core@^0.4.3"],
       "files": [
         {
@@ -27,7 +27,7 @@
       "name": "react/checkbox",
       "type": "registry:ui",
       "title": "Checkbox (React)",
-      "description": "Editable React Checkbox Recipe built on the tui.parts Foundation Primitive.",
+      "description": "Editable React Checkbox Recipe built on the tuiparts.sh Foundation Primitive.",
       "dependencies": [
         "@tuiparts/react@^0.0.3-rc.0",
         "@tuiparts/core@^0.0.3-rc.0",
@@ -54,7 +54,7 @@
       "name": "solid/checkbox",
       "type": "registry:ui",
       "title": "Checkbox (Solid)",
-      "description": "Editable Solid Checkbox Recipe built on the tui.parts Foundation Primitive.",
+      "description": "Editable Solid Checkbox Recipe built on the tuiparts.sh Foundation Primitive.",
       "dependencies": [
         "@tuiparts/solid@^0.0.3-rc.0",
         "@tuiparts/core@^0.0.3-rc.0",
@@ -80,7 +80,7 @@
       "name": "core/switch",
       "type": "registry:ui",
       "title": "Switch (Core)",
-      "description": "Editable imperative Switch Recipe built on the tui.parts Foundation Primitive.",
+      "description": "Editable imperative Switch Recipe built on the tuiparts.sh Foundation Primitive.",
       "dependencies": ["@tuiparts/core@^0.0.3-rc.0", "@opentui/core@^0.4.3"],
       "files": [
         {
@@ -100,7 +100,7 @@
       "name": "react/switch",
       "type": "registry:ui",
       "title": "Switch (React)",
-      "description": "Editable React Switch Recipe built on the tui.parts Foundation Primitive.",
+      "description": "Editable React Switch Recipe built on the tuiparts.sh Foundation Primitive.",
       "dependencies": [
         "@tuiparts/react@^0.0.3-rc.0",
         "@tuiparts/core@^0.0.3-rc.0",
@@ -127,7 +127,7 @@
       "name": "solid/switch",
       "type": "registry:ui",
       "title": "Switch (Solid)",
-      "description": "Editable Solid Switch Recipe built on the tui.parts Foundation Primitive.",
+      "description": "Editable Solid Switch Recipe built on the tuiparts.sh Foundation Primitive.",
       "dependencies": [
         "@tuiparts/solid@^0.0.3-rc.0",
         "@tuiparts/core@^0.0.3-rc.0",
@@ -153,7 +153,7 @@
       "name": "core/button",
       "type": "registry:ui",
       "title": "Button (Core)",
-      "description": "Editable imperative Button Recipe built on the tui.parts Foundation Primitive.",
+      "description": "Editable imperative Button Recipe built on the tuiparts.sh Foundation Primitive.",
       "dependencies": ["@tuiparts/core@^0.0.3-rc.0", "@opentui/core@^0.4.3"],
       "files": [
         {
@@ -173,7 +173,7 @@
       "name": "react/button",
       "type": "registry:ui",
       "title": "Button (React)",
-      "description": "Editable React Button Recipe built on the tui.parts Foundation Primitive.",
+      "description": "Editable React Button Recipe built on the tuiparts.sh Foundation Primitive.",
       "dependencies": [
         "@tuiparts/react@^0.0.3-rc.0",
         "@tuiparts/core@^0.0.3-rc.0",
@@ -200,7 +200,7 @@
       "name": "solid/button",
       "type": "registry:ui",
       "title": "Button (Solid)",
-      "description": "Editable Solid Button Recipe built on the tui.parts Foundation Primitive.",
+      "description": "Editable Solid Button Recipe built on the tuiparts.sh Foundation Primitive.",
       "dependencies": [
         "@tuiparts/solid@^0.0.3-rc.0",
         "@tuiparts/core@^0.0.3-rc.0",
@@ -295,7 +295,7 @@
       "name": "core/radio-group",
       "type": "registry:ui",
       "title": "Radio Group (Core)",
-      "description": "Editable imperative Radio and Radio Group Recipe built on the tui.parts collection Primitive.",
+      "description": "Editable imperative Radio and Radio Group Recipe built on the tuiparts.sh collection Primitive.",
       "dependencies": ["@tuiparts/core@^0.0.3-rc.0", "@opentui/core@^0.4.3"],
       "files": [
         {
@@ -315,7 +315,7 @@
       "name": "react/radio-group",
       "type": "registry:ui",
       "title": "Radio Group (React)",
-      "description": "Editable React Radio and Radio Group Recipe built on the tui.parts collection Primitive.",
+      "description": "Editable React Radio and Radio Group Recipe built on the tuiparts.sh collection Primitive.",
       "dependencies": [
         "@tuiparts/react@^0.0.3-rc.0",
         "@tuiparts/core@^0.0.3-rc.0",
@@ -342,7 +342,7 @@
       "name": "solid/radio-group",
       "type": "registry:ui",
       "title": "Radio Group (Solid)",
-      "description": "Editable Solid Radio and Radio Group Recipe built on the tui.parts collection Primitive.",
+      "description": "Editable Solid Radio and Radio Group Recipe built on the tuiparts.sh collection Primitive.",
       "dependencies": [
         "@tuiparts/solid@^0.0.3-rc.0",
         "@tuiparts/core@^0.0.3-rc.0",
@@ -444,7 +444,7 @@
       "name": "core/dialog",
       "type": "registry:ui",
       "title": "Dialog (Core)",
-      "description": "Editable imperative Dialog Recipe built on the tui.parts overlay Primitive tracer.",
+      "description": "Editable imperative Dialog Recipe built on the tuiparts.sh overlay Primitive tracer.",
       "dependencies": ["@tuiparts/core@^0.0.3-rc.0", "@opentui/core@^0.4.3"],
       "files": [
         {
@@ -462,7 +462,7 @@
       "name": "react/dialog",
       "type": "registry:ui",
       "title": "Dialog (React)",
-      "description": "Editable React Dialog Recipe built on the tui.parts overlay Primitive tracer.",
+      "description": "Editable React Dialog Recipe built on the tuiparts.sh overlay Primitive tracer.",
       "dependencies": [
         "@tuiparts/react@^0.0.3-rc.0",
         "@tuiparts/core@^0.0.3-rc.0",
@@ -487,7 +487,7 @@
       "name": "solid/dialog",
       "type": "registry:ui",
       "title": "Dialog (Solid)",
-      "description": "Editable Solid Dialog Recipe built on the tui.parts overlay Primitive tracer.",
+      "description": "Editable Solid Dialog Recipe built on the tuiparts.sh overlay Primitive tracer.",
       "dependencies": [
         "@tuiparts/solid@^0.0.3-rc.0",
         "@tuiparts/core@^0.0.3-rc.0",

--- a/registry/README.md
+++ b/registry/README.md
@@ -1,6 +1,6 @@
 # Foundation Recipe Catalog
 
-The tui.parts registry distributes editable recipe source through the shadcn
+The tuiparts.sh registry distributes editable recipe source through the shadcn
 CLI. Installed files belong to the consuming project. The registry does not
 maintain a second package manager, recipe lockfile, or automatic merge engine.
 Deployed catalog items are served at `/r/{adapter}/{recipe}.json` (for
@@ -75,7 +75,7 @@ do not run this build command.
 ## Discover And Review Updates
 
 The current registry item is the upstream recipe revision. Its Git commit, tag,
-or deployed registry version identifies the exact upstream source; tui.parts
+or deployed registry version identifies the exact upstream source; tuiparts.sh
 does not write hidden revision state into the consumer's project.
 
 Inspect the current upstream source and compare it with the installed file:


### PR DESCRIPTION
**Stacked on #35** — retarget to `main` after #35 merges.

The tui.parts domain was lost; tuiparts.sh was purchased. Per the brand decree (**the domain is the wordmark**, `docs/brand/logomark.md`), the name follows the domain everywhere — keeping the old name would advertise a domain a squatter now controls.

## Sweep

- **Brand copy**: root/package/registry READMEs, AGENTS.md, ADR 0001, `docs/foundation.md`, `PRIMITIVES_AND_RECIPES.md`, pending changesets
- **Brand system** (`docs/brand/`): wordmark, lockups, launch line, figure captions, tokens.css
- **Site**: blume config (title, logo text, `deployment.site`), page copy, SVG titles, docs mdx, design.md
- **Registry**: `registry.json` homepage + descriptions; `public/r` regenerated via `sync:registry` (generator output verified identical to the swept files)
- **Packages**: descriptions in react/solid/utils `package.json`, utils source comments

Unaffected: npm scope `@tuiparts`, GitHub org `tuiparts/tuiparts`, historical CHANGELOGs (decree).

Verified: lint, typecheck, tests, registry validation, isolated docs build — zero `tui.parts` references remain in tracked source.