### PR TITLE
Bind tuiparts.sh as the Worker's custom domain

### DIFF
--- a/apps/www/wrangler.jsonc
+++ b/apps/www/wrangler.jsonc
@@ -2,6 +2,10 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "tuiparts",
   "compatibility_date": "2026-07-14",
+  // Custom domain: wrangler creates the DNS record and provisions TLS on
+  // deploy. Requires the tuiparts.sh zone to be active on the same
+  // Cloudflare account.
+  "routes": [{ "pattern": "tuiparts.sh", "custom_domain": true }],
   "assets": {
     "directory": "./dist",
     "not_found_handling": "404-page"


### PR DESCRIPTION
One-line infra change: `routes: [{ pattern: "tuiparts.sh", custom_domain: true }]` so the domain binding lives in code, not dashboard state. wrangler auto-creates the DNS record and TLS cert on the first `pnpm deploy` after the zone is active. Verified via `wrangler deploy --dry-run` (232 assets, config valid).