### PR TITLE
Refresh documentation and landing page

### DIFF
--- a/apps/www/design.md
+++ b/apps/www/design.md
@@ -12,7 +12,8 @@ modern-minimal (dev-tool register)
 
 - Marketing pages (landing): **Dev-tool / CLI** — asymmetric hero (title left,
   live terminal demo right), trade statement, primitives split, one dark
-  graphite band (registry + catalog), hairline pillar row, closing CTA.
+  graphite band (registry + catalog), asymmetric hairline pillar row, closing
+  CTA.
 - Content pages (docs): Blume's built-in docs layout. Typography and token
   theming only — no enrichment, no custom sections.
 
@@ -69,8 +70,8 @@ page — a one-step elevation, not a floating lighter box):
   requests between snap to the nearer instance.
 - Display: Commit Mono 600–700, roman only
 - Body: Commit Mono 400
-- Mono roles as before — code, eyebrows, meta, kbd hints; UPPERCASE labels
-  at 0.12–0.14em tracking
+- Mono roles as before — code, status metadata, kbd hints; UPPERCASE labels at
+  0.12–0.14em tracking are reserved for status and genuinely ordinal content
 - Never subset below U+2500-259F: Figures must render from one face or
   box-drawing glyphs silently fall back mid-figure
 - Headings use `text-wrap: balance`; ledes use `text-wrap: pretty`
@@ -78,8 +79,10 @@ page — a one-step elevation, not a floating lighter box):
 
 ## Spacing
 
-Tailwind 4-pt scale. Landing sections breathe at py-20/py-24; hairlines
-(`--blume-border`) divide sections, not boxed cards.
+Tailwind 4-pt scale. The hero uses heavier bottom padding so it sits into the
+page; trade, primitives, and the graphite band use the py-20/py-24 baseline.
+Supporting pillars tighten to py-16/py-20; the closing CTA expands to
+py-24/py-28. Hairlines (`--blume-border`) divide sections, not boxed cards.
 
 ## Motion
 
@@ -87,8 +90,9 @@ Tailwind 4-pt scale. Landing sections breathe at py-20/py-24; hairlines
   `cubic-bezier(0.2, 0, 0, 1)` for icon cross-fades
 - Reveal: fade + 10px rise, 500ms, stagger ≤ 50ms, IntersectionObserver,
   plays once
-- Hero: one type-in of the demo command (steps), then static; one blinking
-  input caret persists (authentic terminal behavior)
+- Hero: one type-in of the demo command begins after 150ms; proof rows arrive
+  from 750–1150ms, then remain static; one blinking input caret persists
+  (authentic terminal behavior)
 - Press: `scale(0.97)`, 150ms, on every button-shaped element
 - Reduced motion: everything visible and static; the input caret still blinks
   is NOT allowed — all animation gates behind
@@ -99,6 +103,8 @@ Tailwind 4-pt scale. Landing sections breathe at py-20/py-24; hairlines
 
 - Copy buttons: clipboard + check cross-fade (opacity 0→1, scale 0.25→1,
   blur 4px→0), silent revert after 2s, `aria-live="polite"` announcement
+- Button-shaped controls use at least 40×40px targets and expand to 44×44px
+  for coarse pointers
 - Hover states gated behind hover-capable devices (Tailwind v4 default)
 - No celebratory toasts, no parallax, no autoplay loops beyond the caret
 
@@ -121,7 +127,7 @@ Tailwind 4-pt scale. Landing sections breathe at py-20/py-24; hairlines
 ## What pages MUST share
 
 - The wordmark, the cobalt accent (< 5% of any viewport), the single
-  Commit Mono face, the CTA voice, mono UPPERCASE eyebrow rhythm, hairline
+  Commit Mono face, the CTA voice, restrained metadata labels, and hairline
   section language.
 
 ## What pages MAY differ on

--- a/apps/www/docs/architecture.mdx
+++ b/apps/www/docs/architecture.mdx
@@ -52,11 +52,9 @@ Disabled controls reject focus and activation. Radio navigation skips
 unavailable items. Dialog coordinates renderer-scoped layers, topmost
 dismissal, focus containment, and restoration.
 
-:::note
 The complete ownership, event, part, lifecycle, and conformance rules live in
 [`FOUNDATION_PRIMITIVE_CONTRACT.md`](https://github.com/tuiparts/tuiparts/blob/main/FOUNDATION_PRIMITIVE_CONTRACT.md)
 in the repository.
-:::
 
 ## Parts, state, and refs
 

--- a/apps/www/docs/catalog/badge.mdx
+++ b/apps/www/docs/catalog/badge.mdx
@@ -1,15 +1,23 @@
 ---
 title: Badge
-description: A presentation-only status label composed from ordinary OpenTUI elements — no packaged behavior at all.
+description: A presentation-only status label composed from ordinary OpenTUI elements.
 ---
 
 <Badge>Recipe only</Badge>
 
-Badge has no reusable interaction behavior, so it is distributed only as
-editable registry source. The installed file composes ordinary OpenTUI
-elements — a `box` and a `text` — with a starter intent palette.
+A presentation-only status label composed from ordinary OpenTUI elements — a
+`box` and a `text` — with a starter intent palette. Badge is not interactive:
+it renders no focus, keyboard, or pointer behavior, so it is distributed only
+as editable registry source.
 
-## Install
+## Usage guidelines
+
+- **Use `Badge` for status, not actions.** For anything the user activates,
+  use `Button`.
+- **The recipe is the entire implementation.** Edit the palette map directly;
+  there is no package behind it.
+
+## Installation
 
 <CodeGroup>
 
@@ -27,7 +35,12 @@ pnpm dlx shadcn@4.13.0 add @tuiparts/core/badge
 
 </CodeGroup>
 
-## Usage
+The command above copies the recipe into `components/ui`. The file belongs to
+your application.
+
+## Anatomy
+
+Import the installed component and render it:
 
 ```tsx
 import { Badge } from "./components/ui/badge";
@@ -36,28 +49,29 @@ import { Badge } from "./components/ui/badge";
 <Badge label="Deprecated" intent="danger" size="comfortable" />
 ```
 
-## Props
+## API reference
 
 <TypeTable
   type={{
     label: {
       type: "string",
       required: true,
-      description: "The badge text.",
+      description: "Text rendered inside the badge.",
     },
     intent: {
       type: '"danger" | "neutral" | "success" | "warning"',
       default: '"neutral"',
-      description: "Starter background/foreground palette pairs.",
+      description:
+        "Which starter background and foreground palette pair to apply.",
     },
     size: {
       type: '"compact" | "comfortable"',
       default: '"compact"',
-      description: "Horizontal padding density.",
+      description: "Which horizontal padding density to apply.",
     },
     labelOptions: {
       type: "Omit<TextOptions, 'content'>",
-      description: "Extra OpenTUI text options for the label.",
+      description: "Extra OpenTUI text options applied to the label.",
     },
   }}
 />
@@ -68,4 +82,3 @@ Remaining props are ordinary OpenTUI `BoxOptions` applied to the root.
 
 Packages exist to version difficult behavior — state, focus, keys, overlays.
 Badge has none, so packaging it would only hide presentation behind an API.
-The recipe is the entire implementation; edit the palette map directly.

--- a/apps/www/docs/catalog/button.mdx
+++ b/apps/www/docs/catalog/button.mdx
@@ -1,16 +1,24 @@
 ---
 title: Button
-description: An activation primitive with pressed, focused, and disabled state, wrapped in an editable intent-and-size recipe.
+description: A focusable action that activates from the keyboard or pointer.
 ---
 
 <Badge variant="accent">Foundation</Badge>
 
-The Button recipe renders a filled, focusable action. Behavior — activation
-via Enter/Return, Space, and the primary pointer, plus focus and disabled
-handling — comes from the packaged primitive. The intent palette, sizing, and
-label rendering are yours to edit.
+A focusable action that activates on `Enter`, `Space`, or the primary pointer
+button. Activation, focus, and disabled handling come from the packaged
+primitive; the intent palette, sizing, and label rendering install as source
+you edit.
 
-## Install
+## Usage guidelines
+
+- **Install the recipe when you want a working button.** Compose
+  `ButtonPrimitive` directly when you are building your own component or
+  design system.
+- **Disabled buttons reject focus and activation.** Focus skips them when it
+  moves through the screen.
+
+## Installation
 
 <CodeGroup>
 
@@ -28,7 +36,12 @@ pnpm dlx shadcn@4.13.0 add @tuiparts/core/button
 
 </CodeGroup>
 
-## Usage
+The command above copies the recipe into `components/ui`. The file belongs to
+your application.
+
+## Anatomy
+
+Import the installed component and render it:
 
 ```tsx
 import { Button } from "./components/ui/button";
@@ -41,7 +54,17 @@ import { Button } from "./components/ui/button";
 />;
 ```
 
-## Props
+## Keyboard interactions
+
+| Key | Behavior |
+| --- | --- |
+| `Enter` | Activates the button. |
+| `Space` | Activates the button. |
+
+The primary pointer button also activates. To activate imperatively, call
+`press()` on the Renderable `ref`.
+
+## API reference
 
 The installed recipe adds presentation props on top of the primitive's
 `ButtonPrimitive.Props`:
@@ -51,31 +74,31 @@ The installed recipe adds presentation props on top of the primitive's
     label: {
       type: "string",
       required: true,
-      description: "The button's visible label.",
+      description: "Text rendered inside the button.",
     },
     intent: {
       type: '"neutral" | "primary"',
       default: '"primary"',
-      description: "Starter background palette. Edit or extend it locally.",
+      description:
+        "Which starter palette to apply. Edit or extend the palette map in the installed file.",
     },
     size: {
       type: '"compact" | "comfortable"',
       default: '"compact"',
-      description: "Horizontal padding density.",
+      description: "Which horizontal padding density to apply.",
     },
     disabled: {
       type: "boolean",
-      description: "Disabled buttons reject focus and activation.",
+      description:
+        "Whether the button is disabled. Disabled buttons reject focus and activation.",
     },
   }}
 />
 
 All remaining primitive props — layout, colors, and event callbacks — pass
-through to `ButtonPrimitive`.
+through to `ButtonPrimitive`. The render callback receives readonly
+`pressed`, `focused`, and `disabled` state, which the starter recipe maps to
+background colors.
 
-## Behavior
-
-- `press()` on the Renderable ref triggers activation imperatively.
-- Enter/Return, Space, and the primary pointer button activate.
-- The render callback receives readonly `pressed`, `focused`, and `disabled`
-  state, which the starter recipe maps to background colors.
+For the split between packaged behavior and installed presentation, see the
+[architecture page](/architecture).

--- a/apps/www/docs/catalog/checkbox.mdx
+++ b/apps/www/docs/catalog/checkbox.mdx
@@ -1,16 +1,23 @@
 ---
 title: Checkbox
-description: Root and Indicator parts over controlled or uncontrolled checked state, wrapped in an editable mark-and-label recipe.
+description: A toggle that renders a one-cell mark next to a label.
 ---
 
 <Badge variant="accent">Foundation</Badge>
 
-The Checkbox recipe renders a one-cell mark next to a label. Checked-state
+A toggle that renders a one-cell mark next to a label. Checked-state
 ownership, activation keys, focus, and the Indicator's visibility come from
-the packaged primitive; the mark glyph, tone palette, and label colors are
-consumer-owned.
+the packaged primitive; the mark glyph, tone palette, and label colors
+install as source you edit.
 
-## Install
+## Usage guidelines
+
+- **Use `Checkbox` for choices that are submitted together.** Prefer `Switch`
+  for a setting that takes effect immediately.
+- **Disabled checkboxes reject focus and activation.** Focus skips them when
+  it moves through the screen.
+
+## Installation
 
 <CodeGroup>
 
@@ -28,7 +35,12 @@ pnpm dlx shadcn@4.13.0 add @tuiparts/core/checkbox
 
 </CodeGroup>
 
-## Usage
+The command above copies the recipe into `components/ui`. The file belongs to
+your application.
+
+## Anatomy
+
+Import the installed component and render it:
 
 ```tsx
 import { Checkbox } from "./components/ui/checkbox";
@@ -40,37 +52,20 @@ import { Checkbox } from "./components/ui/checkbox";
 />;
 ```
 
-## Props
+## Keyboard interactions
 
-<TypeTable
-  type={{
-    label: {
-      type: "string",
-      required: true,
-      description: "Text rendered next to the mark.",
-    },
-    mark: {
-      type: "string",
-      default: '"✓"',
-      description:
-        "One terminal-cell mark; widen the editable mark cell for wider content.",
-    },
-    tone: {
-      type: '"accent" | "success"',
-      default: '"accent"',
-      description: "Starter mark color. Edit or extend it locally.",
-    },
-    disabled: {
-      type: "boolean",
-      description: "Disabled checkboxes reject focus and activation.",
-    },
-  }}
-/>
+| Key | Behavior |
+| --- | --- |
+| `Enter` | Toggles the checked state. |
+| `Space` | Toggles the checked state. |
 
-Controlled (`checked` + `onCheckedChange`) and uncontrolled (`defaultChecked`)
-ownership both pass through to `CheckboxPrimitive.Root`.
+The primary pointer button also toggles.
 
-## Composing the primitive directly
+## Examples
+
+### Composing the primitive directly
+
+Assemble the primitive's parts when the recipe's structure does not fit:
 
 ```tsx
 import { Checkbox as CheckboxPrimitive } from "@tuiparts/react/checkbox";
@@ -87,6 +82,55 @@ import { Checkbox as CheckboxPrimitive } from "@tuiparts/react/checkbox";
 </CheckboxPrimitive.Root>;
 ```
 
-The Indicator renders its children only while checked. Core callers can build
-the same structure with `CheckboxRootRenderable` and
+The Indicator renders its children only while checked. Core callers build the
+same structure with `CheckboxRootRenderable` and
 `CheckboxIndicatorRenderable`, sharing the Root's Store.
+
+## API reference
+
+The installed recipe adds presentation props and passes ownership props
+through to `CheckboxPrimitive.Root`:
+
+<TypeTable
+  type={{
+    label: {
+      type: "string",
+      required: true,
+      description: "Text rendered next to the mark.",
+    },
+    checked: {
+      type: "boolean",
+      description:
+        "Whether the checkbox is checked. Use with `onCheckedChange` to control the state.",
+    },
+    defaultChecked: {
+      type: "boolean",
+      description:
+        "Whether the checkbox is initially checked. To control the state, use the `checked` prop instead.",
+    },
+    onCheckedChange: {
+      type: "(checked: boolean) => void",
+      description: "Event handler called when the checked state changes.",
+    },
+    mark: {
+      type: "string",
+      default: '"✓"',
+      description:
+        "Which glyph to render as the checked mark. One terminal cell; widen the editable mark cell for wider content.",
+    },
+    tone: {
+      type: '"accent" | "success"',
+      default: '"accent"',
+      description:
+        "Which starter color to apply to the mark. Edit or extend it in the installed file.",
+    },
+    disabled: {
+      type: "boolean",
+      description:
+        "Whether the checkbox is disabled. Disabled checkboxes reject focus and activation.",
+    },
+  }}
+/>
+
+For the update workflow on installed recipes, see the
+[registry page](/registry).

--- a/apps/www/docs/catalog/dialog.mdx
+++ b/apps/www/docs/catalog/dialog.mdx
@@ -1,11 +1,12 @@
 ---
 title: Dialog
-description: A foundation overlay primitive with layered dismissal and focus containment, a preview recipe, and a production companion package.
+description: An overlay that takes focus and holds it until dismissed.
 ---
 
 <Badge variant="warning">Preview recipe</Badge>
 
-Dialog currently has three distinct surfaces:
+An overlay that takes focus and holds it until dismissed. Dialog currently
+has three distinct surfaces:
 
 - **`@tuiparts/{core,react,solid}/dialog`** — the foundation compound
   primitive.
@@ -14,20 +15,27 @@ Dialog currently has three distinct surfaces:
 - **`@tuiparts/dialog`** — the adopted companion package with manager,
   provider, theme, and async `prompt`/`confirm`/`alert`/`choice` conveniences.
 
-Installing the preview recipe does not replace the companion package.
+**Installing the preview recipe does not replace the companion package.**
+The two are independent surfaces over the same foundation behavior.
 
 ## The foundation primitive
 
-The compound primitive exposes `Dialog.Root`, `Trigger`, `Portal`, `Backdrop`,
-`Popup`, `Title`, `Description`, and `Close` parts over controlled or
-uncontrolled `open` state.
+The compound primitive exposes `Dialog.Root`, `Trigger`, `Portal`,
+`Backdrop`, `Popup`, `Title`, `Description`, and `Close` parts over
+controlled or uncontrolled `open` state. The package owns renderer-scoped
+layer coordination, topmost dismissal, focus containment, and focus
+restoration to the trigger on close.
 
-Behavior owned by the package:
+## Keyboard interactions
 
-- Renderer-scoped layer coordination and topmost dismissal.
-- Escape to dismiss; Tab containment inside the open popup.
-- Focus restoration to the trigger on close.
-- Trigger/Close activation via Enter/Return, Space, and the primary pointer.
+| Key | Behavior |
+| --- | --- |
+| `Esc` | Dismisses the topmost open dialog. |
+| `Tab` | Moves focus within the open popup; focus is contained. |
+| `Enter` | Activates the focused `Trigger` or `Close`. |
+| `Space` | Activates the focused `Trigger` or `Close`. |
+
+The primary pointer button also activates `Trigger` and `Close`.
 
 ## Install the preview recipe
 
@@ -47,11 +55,14 @@ pnpm dlx shadcn@4.13.0 add @tuiparts/core/dialog
 
 </CodeGroup>
 
+The command above copies the preview recipe into `components/ui`. The file
+belongs to your application.
+
 ## The companion package
 
 For production convenience APIs — imperative prompts, confirm/alert/choice
-flows, theming, and a managed container — use the independently versioned
-companion:
+flows, theming, and a managed container — install the independently
+versioned companion:
 
 ```bash
 pnpm add @tuiparts/dialog

--- a/apps/www/docs/catalog/index.mdx
+++ b/apps/www/docs/catalog/index.mdx
@@ -43,8 +43,6 @@ becomes source your application owns.
   </Card>
 </CardGroup>
 
-:::note
-Recipes are starting points. The palette, density, symbols, labels, and intent
-variants in each installed file are examples for you to edit, not package
-APIs.
-:::
+**Recipes are starting points.** The palette, density, symbols, labels, and
+intent variants in each installed file are examples for you to edit, not
+package APIs.

--- a/apps/www/docs/catalog/input.mdx
+++ b/apps/www/docs/catalog/input.mdx
@@ -1,15 +1,23 @@
 ---
 title: Input
-description: OpenTUI-native text editing with input, change, and submit events, wrapped in an editable visual-defaults recipe.
+description: A single-line text field with OpenTUI's native editing behavior.
 ---
 
 <Badge variant="accent">Foundation</Badge>
 
-The Input recipe applies editable visual defaults — text, placeholder, cursor,
-and focus colors — over the packaged Input primitive, which preserves
-OpenTUI's native editing behavior.
+A single-line text field with OpenTUI's native editing behavior. The recipe
+applies editable visual defaults — text, placeholder, cursor, and focus
+colors — over the packaged Input primitive.
 
-## Install
+## Usage guidelines
+
+- **Input keeps OpenTUI's native mutable buffer and event order.** It does
+  not implement browser-style controlled rollback; if you need strict
+  controlled-value semantics, layer them in your consumer-owned recipe.
+- **Programmatic `value` assignments that change the buffer fire `onInput`.**
+  Commit-style updates arrive through `onChange` instead.
+
+## Installation
 
 <CodeGroup>
 
@@ -27,7 +35,12 @@ pnpm dlx shadcn@4.13.0 add @tuiparts/core/input
 
 </CodeGroup>
 
-## Usage
+The command above copies the recipe into `components/ui`. The file belongs to
+your application.
+
+## Anatomy
+
+Import the installed component and render it:
 
 ```tsx
 import { Input } from "./components/ui/input";
@@ -39,25 +52,43 @@ import { Input } from "./components/ui/input";
 />;
 ```
 
-## Events
+## Keyboard interactions
 
-Input deliberately preserves OpenTUI's native mutable buffer and event order
-instead of inventing browser-style controlled rollback:
-
-| Event | Fires when |
+| Key | Behavior |
 | --- | --- |
-| `onInput` | The value changes — including changed programmatic assignments. |
-| `onChange` | A blur or submit commits the value. |
-| `onSubmit` | The user submits (Enter/Return). |
+| `Enter` | Submits the value and fires `onSubmit`. |
 
-:::note
-Programmatic `value` assignments that change the buffer invoke `onInput`,
-while `onChange` reports blur or submit commits. If you need strict
-controlled-value semantics, layer them in your consumer-owned recipe.
-:::
+Editing — cursor movement, insertion, and deletion — is OpenTUI's native
+input behavior.
 
-## Presentation
+## API reference
+
+<TypeTable
+  type={{
+    placeholder: {
+      type: "string",
+      description: "Text shown while the value is empty.",
+    },
+    onInput: {
+      type: "(value: string) => void",
+      description:
+        "Event handler called when the value changes, including programmatic assignments that change the buffer.",
+    },
+    onChange: {
+      type: "(value: string) => void",
+      description:
+        "Event handler called when a blur or submit commits the value.",
+    },
+    onSubmit: {
+      type: "(value: string) => void",
+      description: "Event handler called when the user submits with `Enter`.",
+    },
+  }}
+/>
 
 Every visual default in the installed file — `textColor`,
 `placeholderColor`, `cursorColor`, and the focused variants — is an ordinary
 OpenTUI property you can change or expose as variants.
+
+For the update workflow on installed recipes, see the
+[registry page](/registry).

--- a/apps/www/docs/catalog/radio-group.mdx
+++ b/apps/www/docs/catalog/radio-group.mdx
@@ -1,16 +1,24 @@
 ---
 title: Radio Group
-description: A collection primitive owning one value with roving arrow-key focus, wrapped in editable group and item recipes.
+description: A group of selectable options that owns a single value.
 ---
 
 <Badge variant="accent">Foundation</Badge>
 
-The Radio Group recipe installs two components: `RadioGroup`, which owns the
-collection value, and `RadioGroupItem`, which renders a selectable mark and
-label. Selection, arrow-key navigation, Home/End, and skipping unavailable
-items come from the packaged primitives.
+A group of selectable options that owns a single value. The recipe installs
+two components: `RadioGroup`, which owns the collection value, and
+`RadioGroupItem`, which renders a selectable mark and label. Selection,
+arrow-key navigation, and skipping unavailable items come from the packaged
+primitives.
 
-## Install
+## Usage guidelines
+
+- **Use a radio group when exactly one option must be selected.** For an
+  independent on/off choice, use `Checkbox` or `Switch` instead.
+- **Every item must belong to a group.** The group owns the single collection
+  value; items contribute to it.
+
+## Installation
 
 <CodeGroup>
 
@@ -28,7 +36,12 @@ pnpm dlx shadcn@4.13.0 add @tuiparts/core/radio-group
 
 </CodeGroup>
 
-## Usage
+The command above copies the recipe into `components/ui`. The file belongs to
+your application.
+
+## Anatomy
+
+Import the installed components and nest items inside the group:
 
 ```tsx
 import { RadioGroup, RadioGroupItem } from "./components/ui/radio-group";
@@ -40,18 +53,57 @@ import { RadioGroup, RadioGroupItem } from "./components/ui/radio-group";
 </RadioGroup>;
 ```
 
-## Props
+## Keyboard interactions
 
-`RadioGroup` passes through the primitive group props — `value`,
-`defaultValue`, `onValueChange`, and `disabled` — plus layout. Each
-`RadioGroupItem` adds:
+| Key | Behavior |
+| --- | --- |
+| `↑` `↓` `←` `→` | Moves focus and selection through the available items. |
+| `Home` | Moves focus and selection to the first available item. |
+| `End` | Moves focus and selection to the last available item. |
+| `Enter` | Selects the focused item. |
+| `Space` | Selects the focused item. |
+
+Unavailable items are skipped during navigation. The primary pointer button
+also selects.
+
+## API reference
+
+### RadioGroup
+
+<TypeTable
+  type={{
+    value: {
+      type: "string",
+      description:
+        "Value of the selected item. Use with `onValueChange` to control the group.",
+    },
+    defaultValue: {
+      type: "string",
+      description:
+        "Value selected initially. To control the group, use the `value` prop instead.",
+    },
+    onValueChange: {
+      type: "(value: string) => void",
+      description: "Event handler called when the selected value changes.",
+    },
+    disabled: {
+      type: "boolean",
+      description:
+        "Whether the whole group is disabled. Disabled groups reject focus and activation.",
+    },
+  }}
+/>
+
+Remaining group props are layout, passed through to the primitive.
+
+### RadioGroupItem
 
 <TypeTable
   type={{
     value: {
       type: "string",
       required: true,
-      description: "The value this item contributes to the group.",
+      description: "Value this item contributes to the group.",
     },
     label: {
       type: "string",
@@ -61,24 +113,22 @@ import { RadioGroup, RadioGroupItem } from "./components/ui/radio-group";
     mark: {
       type: "string",
       default: '"●"',
-      description: "One terminal-cell selection mark.",
+      description:
+        "Which glyph to render as the selection mark. One terminal cell.",
     },
     tone: {
       type: '"accent" | "success"',
       default: '"accent"',
-      description: "Starter mark color. Edit or extend it locally.",
+      description:
+        "Which starter color to apply to the mark. Edit or extend it in the installed file.",
     },
     disabled: {
       type: "boolean",
-      description: "Unavailable items are skipped during navigation.",
+      description:
+        "Whether the item is unavailable. Unavailable items are skipped during navigation.",
     },
   }}
 />
 
-## Behavior
-
-- The group owns exactly one value; every Radio must belong to a group.
-- Arrow keys move focus and selection through available items; Home and End
-  jump to the ends.
-- Enter/Return, Space, and the primary pointer select the focused item.
-- Controlled and uncontrolled value ownership are both supported.
+For the update workflow on installed recipes, see the
+[registry page](/registry).

--- a/apps/www/docs/catalog/switch.mdx
+++ b/apps/www/docs/catalog/switch.mdx
@@ -1,16 +1,22 @@
 ---
 title: Switch
-description: Root and Thumb parts with a movable thumb over a glyph track, wrapped in an editable density-and-symbols recipe.
+description: A toggle rendered as a thumb that slides along a glyph track.
 ---
 
 <Badge variant="accent">Foundation</Badge>
 
-The Switch recipe renders a thumb glyph that slides along a track when
-toggled. Checked-state ownership, activation keys, and focus come from the
-packaged primitive; the track width, symbol set, and label styling are
-consumer-owned.
+A toggle rendered as a thumb that slides along a glyph track. Checked-state
+ownership, activation keys, and focus come from the packaged primitive; the
+track width, symbol set, and label styling install as source you edit.
 
-## Install
+## Usage guidelines
+
+- **Use `Switch` for a setting that takes effect immediately.** Prefer
+  `Checkbox` for choices that are submitted together.
+- **Disabled switches reject focus and activation.** Focus skips them when it
+  moves through the screen.
+
+## Installation
 
 <CodeGroup>
 
@@ -28,7 +34,12 @@ pnpm dlx shadcn@4.13.0 add @tuiparts/core/switch
 
 </CodeGroup>
 
-## Usage
+The command above copies the recipe into `components/ui`. The file belongs to
+your application.
+
+## Anatomy
+
+Import the installed component and render it:
 
 ```tsx
 import { Switch } from "./components/ui/switch";
@@ -41,7 +52,24 @@ import { Switch } from "./components/ui/switch";
 />;
 ```
 
-## Props
+`Switch.Root` owns state and activation; `Switch.Thumb` is a passive part
+that positions itself from the shared Store. The starter recipe places the
+Thumb absolutely over a repeated track glyph — replace the glyphs or layout
+freely; the behavior does not depend on them.
+
+## Keyboard interactions
+
+| Key | Behavior |
+| --- | --- |
+| `Enter` | Toggles the checked state. |
+| `Space` | Toggles the checked state. |
+
+The primary pointer button also toggles.
+
+## API reference
+
+The installed recipe adds presentation props and passes ownership props
+through to `SwitchPrimitive.Root`:
 
 <TypeTable
   type={{
@@ -50,30 +78,39 @@ import { Switch } from "./components/ui/switch";
       required: true,
       description: "Text rendered next to the track.",
     },
+    checked: {
+      type: "boolean",
+      description:
+        "Whether the switch is on. Use with `onCheckedChange` to control the state.",
+    },
+    defaultChecked: {
+      type: "boolean",
+      description:
+        "Whether the switch is initially on. To control the state, use the `checked` prop instead.",
+    },
+    onCheckedChange: {
+      type: "(checked: boolean) => void",
+      description: "Event handler called when the checked state changes.",
+    },
     density: {
       type: '"compact" | "comfortable"',
       default: '"compact"',
-      description: "Track width and gap. Compact is 3 cells, comfortable 5.",
+      description:
+        "Which track density to apply. Compact is 3 cells wide, comfortable is 5.",
     },
     symbols: {
       type: '"round" | "ascii"',
       default: '"round"',
       description:
-        "Thumb and track glyph set — round (● ─) or pure ASCII (* -).",
+        "Which glyph set to render for the thumb and track — round (● ─) or pure ASCII (* -).",
     },
     disabled: {
       type: "boolean",
-      description: "Disabled switches reject focus and activation.",
+      description:
+        "Whether the switch is disabled. Disabled switches reject focus and activation.",
     },
   }}
 />
 
-Controlled (`checked` + `onCheckedChange`) and uncontrolled (`defaultChecked`)
-ownership both pass through to `SwitchPrimitive.Root`.
-
-## Parts
-
-`Switch.Root` owns state and activation; `Switch.Thumb` is a passive part that
-positions itself from the shared Store. The starter recipe places the Thumb
-absolutely over a repeated track glyph — replace the glyphs or layout freely,
-the behavior does not depend on them.
+For the update workflow on installed recipes, see the
+[registry page](/registry).

--- a/apps/www/docs/catalog/toast.mdx
+++ b/apps/www/docs/catalog/toast.mdx
@@ -1,21 +1,23 @@
 ---
 title: Toast
-description: The independently versioned Toast companion package — a global toast API and a Toaster container for OpenTUI apps.
+description: A companion package that renders transient notifications through a global toast API.
 ---
 
 <Badge variant="success">Companion package</Badge>
 
-Toast is an adopted companion product, not a foundation primitive or registry
-recipe. It retains its notification, theme, icon, React, and Solid APIs and
-versions independently from the foundation release line.
+A companion package that renders transient notifications through a global
+`toast` API and a `Toaster` container. Toast is an adopted companion product,
+not a foundation primitive or registry recipe; it retains its notification,
+theme, icon, React, and Solid APIs and versions independently from the
+foundation release line.
 
-## Install
+## Installation
 
 ```bash
 pnpm add @tuiparts/toast
 ```
 
-## Usage
+## Anatomy
 
 Mount a `Toaster` container once, then notify from anywhere with the global
 `toast` API:
@@ -31,8 +33,6 @@ The `ToasterRenderable` container manages notification layout and lifecycle
 inside your OpenTUI renderer, and the package ships React and Solid bindings
 alongside the Core API.
 
-:::note
-Neither `@tuiparts/toast` nor `@tuiparts/dialog` is re-exported by the
-foundation packages. They are supported, independently versioned products —
-installing foundation recipes never replaces them.
-:::
+**Installing foundation recipes never replaces the companions.** Neither
+`@tuiparts/toast` nor `@tuiparts/dialog` is re-exported by the foundation
+packages; both are supported, independently versioned products.

--- a/apps/www/docs/index.mdx
+++ b/apps/www/docs/index.mdx
@@ -1,58 +1,80 @@
 ---
 title: Introduction
-description: Composable, framework-neutral interaction primitives and editable UI recipes for OpenTUI.
+description: Composable interaction primitives and editable UI recipes for building terminal interfaces with OpenTUI.
 sidebar:
   order: 1
 ---
 
-tuiparts.sh is the primitive and recipe ecosystem for
-[OpenTUI](https://github.com/anomalyco/opentui) — composable interaction
-primitives and editable recipes for building terminal UIs in React, Solid, or
-imperative Core. It makes the same trade Base UI and shadcn/ui made on the
-web:
+tuiparts.sh is the component ecosystem for
+[OpenTUI](https://github.com/anomalyco/opentui), covering React, Solid, and
+imperative Core. Behavior ships as versioned packages. Presentation installs
+as source you own.
 
-> Package the difficult behavior. Copy the opinionated layer.
+You already know the difficult parts of a terminal UI, because they are the
+same in every app you build: focus that moves predictably, keys that activate
+the right control, overlays that dismiss in the right order, disabled controls
+that reject input. None of that is what makes your interface yours — but it is
+where the time goes, and where the bugs live. tuiparts.sh splits every
+component along that line.
 
-That trade ships in two foundation layers:
+## Packages own behavior
 
-1. **Versioned packages** own state, keyboard and pointer interaction, focus,
-   collections, overlays, lifecycle, public parts, and framework adapters.
-2. **Registry recipes** own glyphs, layout, colors, themes, semantic variants,
-   and convenience assembly — installed as source your application controls.
+State, focus, keyboard and pointer interaction, collections, overlays, and
+lifecycle ship as versioned npm packages: `@tuiparts/core` provides
+framework-neutral Stores and Renderables, and `@tuiparts/react` and
+`@tuiparts/solid` provide compound-part adapters over them. Upgrading a
+package delivers behavior fixes without touching your presentation code.
 
-Use a package primitive when you are building a component or design system.
-Install a registry recipe when you want a useful starting component whose
-layout, glyphs, colors, and convenience props you can edit.
+## Recipes install as source you own
 
-## Foundation packages
+Glyphs, palettes, layout, semantic variants, and convenience assembly install
+as plain TypeScript through the official shadcn CLI. The installed file lands
+in your project and belongs to your application — edit the palette map
+directly; there is no hidden theme runtime.
 
-| Package | Purpose |
-| --- | --- |
-| `@tuiparts/core` | Framework-neutral primitive state and Renderables |
-| `@tuiparts/react` | React compound-part adapters |
-| `@tuiparts/solid` | Solid compound-part adapters |
+## One vocabulary, three runtimes
 
-Button, Checkbox, Dialog, Input, RadioGroup, and Switch expose foundation
-behavior. Badge is distributed only as editable registry source because it has
-no reusable interaction behavior. `@tuiparts/dialog` and `@tuiparts/toast`
-are independently versioned companion products with higher-level APIs outside
-the foundation release line.
+The React and Solid adapters sit over the same Core Stores and Renderables,
+so the primitive vocabulary is identical wherever the runtimes permit it. You
+can also drive the Core layer imperatively, without a framework.
 
-## Principles
+## Parts, not style slots
 
-- **Open code** — recipes install as plain TypeScript in your project. Edit the
-  palette, glyphs, and layout directly; there is no hidden theme runtime.
-- **Composition** — primitives expose independently composable parts
-  (`Checkbox.Root`, `Checkbox.Indicator`), not style slots.
-- **Framework-neutral behavior** — the same Core Stores and Renderables power
-  the React and Solid adapters, and can be used imperatively.
-- **shadcn-compatible distribution** — recipes install and update through the
-  official shadcn CLI with the standard view/diff/add lifecycle.
+Primitives expose independently composable parts — `Checkbox.Root`,
+`Checkbox.Indicator` — rather than a single styled component with escape
+hatches. Recipes assemble those parts into convenient components you can take
+apart again.
+
+## FAQ
+
+**Should I compose a primitive or install a recipe?**
+
+Compose a package primitive when you are building your own component or
+design system. Install a registry recipe when you want a working component
+whose layout, glyphs, and colors you can edit.
+
+**Why is Badge not a package?**
+
+Badge has no interaction behavior to version, so packaging it would only hide
+presentation behind an API. It is distributed only as editable registry
+source.
+
+**What are `@tuiparts/dialog` and `@tuiparts/toast`?**
+
+Independently versioned companion packages with higher-level APIs —
+imperative prompts and global notifications — outside the foundation release
+line. Installing a foundation recipe does not replace either companion.
+
+**What happens to my edits when a recipe updates?**
+
+Nothing, until you act. Run the `diff` command to review upstream changes and
+merge the ones you want; an ordinary `add` asks before touching an existing
+file.
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Quickstart" href="/quickstart" icon="rocket">
+  <Card title="Quick start" href="/quickstart" icon="rocket">
     Install an adapter and render your first primitive.
   </Card>
   <Card title="Catalog" href="/catalog" icon="layout-grid">

--- a/apps/www/docs/quickstart.mdx
+++ b/apps/www/docs/quickstart.mdx
@@ -1,15 +1,17 @@
 ---
-title: Quickstart
-description: Install a framework adapter, compose a primitive, and install your first editable recipe.
+title: Quick start
+description: Install a runtime adapter, compose a primitive, and install your first editable recipe.
 sidebar:
   order: 2
 ---
 
-tuiparts.sh supports three runtimes — React, Solid, and imperative Core. Install
-one adapter and its OpenTUI peers, then either compose primitives directly or
-install editable recipes from the registry.
+tuiparts.sh supports three runtimes: React, Solid, and imperative Core. This
+page covers the shortest path through both layers — composing a packaged
+primitive and installing an editable recipe.
 
 ## Install a runtime
+
+Install the adapter for your runtime together with its OpenTUI peers:
 
 <CodeGroup>
 
@@ -29,14 +31,12 @@ pnpm add @tuiparts/core @opentui/core
 
 </CodeGroup>
 
-The React and Solid packages expose the same primitive vocabulary where their
-runtimes permit it. Core exposes the same behavior as Stores and Renderables.
+The three runtimes share one primitive vocabulary. React and Solid expose
+compound parts; Core exposes the same behavior as Stores and Renderables.
 
 ## Compose a primitive
 
-Compound framework primitives use Base UI-style module namespaces. Package
-exports stay clean; recipes conventionally alias them locally with a
-`Primitive` suffix.
+Import a primitive from its module namespace and assemble its parts:
 
 <CodeGroup>
 
@@ -72,19 +72,18 @@ root.add(indicator);
 
 </CodeGroup>
 
-State callbacks receive readonly primitive state. A `ref` points to the actual
-Core Renderable, so imperative actions do not require a wrapper handle.
-Framework consumers configure controlled props and callbacks; they do not
-construct or pass Core Stores.
+The render callback receives readonly primitive state, and a `ref` points at
+the actual Core Renderable, so imperative actions never need a wrapper
+handle. Recipes conventionally alias primitives locally with a `Primitive`
+suffix.
 
 ## Install a recipe
 
-Recipes are installed with the official shadcn CLI and become
-application-owned source.
+Recipes install through the official shadcn CLI and become source your
+application owns.
 
-1. **Configure shadcn**
-
-    Add the tuiparts.sh registry to your `components.json`:
+1. Add the registry namespace to `components.json` so the CLI can resolve
+   `@tuiparts` addresses:
 
     ```json title="components.json"
     {
@@ -95,17 +94,16 @@ application-owned source.
     }
     ```
 
-2. **Install the item for your runtime**
-
-    Choose the `core/*`, `react/*`, or `solid/*` item:
+2. Install the item for your runtime — `core/*`, `react/*`, or `solid/*`:
 
     ```bash
     pnpm dlx shadcn@4.13.0 add @tuiparts/react/checkbox
     ```
 
-3. **Use the installed recipe**
+    The command above copies the recipe into `components/ui` and installs its
+    declared dependencies.
 
-    The copied file lands in `components/ui` and belongs to your application:
+3. Import the installed component like any local file:
 
     ```tsx
     import { Checkbox } from "./components/ui/checkbox";
@@ -113,17 +111,15 @@ application-owned source.
     <Checkbox label="Enable notifications" defaultChecked />;
     ```
 
-:::tip
-The installed palette, density, symbols, labels, intent variants, and component
-assembly are starter choices rather than package APIs. Edit them directly or
-use them as the basis of another registry.
-:::
+**The installed file belongs to your application.** The palette, glyphs,
+labels, and variants inside it are starter choices, not package APIs — edit
+them directly or use them as the basis of your own registry.
 
 ## Next steps
 
 <CardGroup cols={2}>
   <Card title="Catalog" href="/catalog" icon="layout-grid">
-    The starter catalog: Button, Checkbox, Switch, RadioGroup, Input, Badge.
+    The starter catalog: Button, Checkbox, Switch, Radio Group, Input, Badge.
   </Card>
   <Card title="Registry lifecycle" href="/registry" icon="git-compare">
     Review upstream recipe changes without discarding local edits.

--- a/apps/www/docs/registry.mdx
+++ b/apps/www/docs/registry.mdx
@@ -38,9 +38,9 @@ You can also install any item by direct URL without configuring a namespace:
 pnpm dlx shadcn@4.13.0 add https://tuiparts.sh/r/react/checkbox.json
 ```
 
-The CLI installs declared dependencies and copies the recipe into
-`components/ui`. Running ordinary `add` against an existing file asks before
-replacement and defaults to preserving the local file.
+The command above installs the item's declared dependencies and copies the
+recipe into `components/ui`. Running an ordinary `add` against an existing
+file asks before replacement and defaults to preserving the local file.
 
 ## Catalog
 
@@ -76,9 +76,9 @@ compatible primitive and OpenTUI package ranges in `dependencies`.
 Package ranges are the compatibility contract. Registry metadata describes the
 source lifecycle; it does not replace package dependency resolution.
 
-## Discover and review updates
+## Review updates
 
-The current registry item is the upstream recipe revision. Inspect the current
+The current registry item is the upstream recipe revision. Inspect the
 upstream source and compare it with your installed file:
 
 ```bash
@@ -91,8 +91,9 @@ Review the diff and merge useful upstream changes into the consumer-owned
 file.
 
 :::warning
-Use `--overwrite` only when intentionally discarding local edits. Ordinary
-updates must never rely on unattended overwrite.
+**`--overwrite` discards your local edits.** Use it only when you intend to
+replace the installed file; ordinary updates must never rely on unattended
+overwrite.
 :::
 
 ## Primitive upgrades versus recipe updates

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -16,7 +16,7 @@
     "@shikijs/twoslash": "^4.2.0",
     "@tailwindcss/vite": "^4.0.0",
     "astro": "^7.0.2",
-    "blume": "^1.0.3"
+    "blume": "^1.0.4"
   },
   "devDependencies": {
     "wrangler": "^4.0.0"

--- a/apps/www/pages/index.astro
+++ b/apps/www/pages/index.astro
@@ -121,7 +121,7 @@ const pillars = [
 
   {/* ── Hero — title left, live terminal render right ── */}
   <section
-    class="mx-auto grid max-w-6xl items-center gap-12 px-6 pt-16 pb-20 lg:grid-cols-[minmax(0,10fr)_minmax(0,9fr)] lg:gap-16 lg:pt-24 lg:pb-24"
+    class="mx-auto grid max-w-6xl items-center gap-12 px-6 pt-14 pb-20 lg:grid-cols-[minmax(0,10fr)_minmax(0,9fr)] lg:gap-16 lg:pt-20 lg:pb-28"
   >
     <div>
       <p
@@ -148,7 +148,7 @@ const pillars = [
         >
         <a
           class="btn-outline press rounded-blume border border-border px-5 py-2.5 text-sm font-medium text-foreground"
-          href="/docs/catalog">Browse the Catalog</a
+          href="/docs/catalog">Browse the catalog</a
         >
       </div>
       <div
@@ -213,7 +213,7 @@ const pillars = [
           <div class="demo-line"><span class="t-dim">[ ]</span> Auto-install updates</div>
           <div class="demo-line demo-gap">Theme      <span class="t-dim">(</span><span class="t-signal">●</span><span class="t-dim">)</span> Dark   <span class="t-dim">( )</span> Light</div>
           <div class="demo-line demo-gap">Telemetry  <span class="t-dim">○──</span>  <span class="t-muted">off</span></div>
-          <div class="demo-line demo-gap"><span class="t-signal">┃</span> <span class="caret-input">▍</span><span class="t-muted">Search the Catalog…</span></div>
+          <div class="demo-line demo-gap"><span class="t-signal">┃</span> <span class="caret-input">▍</span><span class="t-muted">Search the catalog…</span></div>
           <div class="demo-line demo-gap"><span class="chip chip-solid"> Save changes </span>  <span class="chip chip-ghost"> Cancel </span></div>
           <div class="demo-line t-faint demo-gap">tab focus · space toggle · ↵ submit</div>
         </div>
@@ -224,16 +224,12 @@ const pillars = [
   {/* ── The trade — one statement, two owners ── */}
   <section class="border-t border-border">
     <div class="mx-auto max-w-6xl px-6 py-20 lg:py-24">
-      <p class="reveal font-mono text-xs tracking-[0.14em] text-muted-foreground uppercase">
-        The trade
-      </p>
       <h2
-        class="reveal mt-4 max-w-2xl text-balance font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl"
-        data-d="1"
+        class="reveal max-w-2xl text-balance font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl"
       >
         Package the difficult behavior. Copy the opinionated layer.
       </h2>
-      <p class="reveal mt-4 max-w-2xl text-pretty text-muted-foreground" data-d="2">
+      <p class="reveal mt-4 max-w-2xl text-pretty text-muted-foreground" data-d="1">
         The same split Base UI and shadcn/ui made on the web, applied to the
         terminal. Correctness-critical behavior is centralized and tested
         once; everything opinionated stays in code you can read and change.
@@ -297,11 +293,8 @@ const pillars = [
       class="mx-auto grid max-w-6xl items-center gap-12 px-6 py-20 lg:grid-cols-2 lg:gap-16 lg:py-24"
     >
       <div class="reveal">
-        <p class="font-mono text-xs tracking-[0.14em] text-muted-foreground uppercase">
-          Primitives
-        </p>
         <h2
-          class="mt-4 text-balance font-display text-3xl font-semibold tracking-tight text-foreground"
+          class="text-balance font-display text-3xl font-semibold tracking-tight text-foreground"
         >
           When you're building a system.
         </h2>
@@ -319,11 +312,11 @@ const pillars = [
             <span class="text-accent" aria-hidden="true">▪</span> real parts: Root, Indicator, Thumb, Popup
           </li>
           <li class="flex items-baseline gap-2.5 font-mono text-xs text-muted-foreground">
-            <span class="text-accent" aria-hidden="true">▪</span> controlled or uncontrolled — your call
+            <span class="text-accent" aria-hidden="true">▪</span> controlled or uncontrolled — you decide
           </li>
         </ul>
         <a class="link-arrow mt-8 inline-flex items-center gap-1.5 text-sm font-medium text-accent" href="/docs/quickstart"
-          >Read the quickstart <span class="arrow" aria-hidden="true">→</span></a
+          >Read the quick start <span class="arrow" aria-hidden="true">→</span></a
         >
       </div>
       <div class="reveal" data-d="1">
@@ -338,8 +331,7 @@ const pillars = [
       class="mx-auto grid max-w-6xl gap-14 px-6 py-20 lg:grid-cols-[minmax(0,10fr)_minmax(0,9fr)] lg:gap-20 lg:py-24"
     >
       <div class="reveal">
-        <p class="band-eyebrow">Registry</p>
-        <h2 class="mt-4 text-balance font-display text-3xl font-semibold tracking-tight">
+        <h2 class="text-balance font-display text-3xl font-semibold tracking-tight">
           When you want a head start.
         </h2>
         <p class="band-muted mt-4 text-pretty leading-7">
@@ -394,7 +386,9 @@ const pillars = [
         >
       </div>
       <div class="reveal" data-d="1">
-        <p class="band-eyebrow">Starter catalog</p>
+        <h3 class="font-display text-base font-semibold text-[var(--tp-graphite-ink)]">
+          Starter catalog
+        </h3>
         <ol class="band-list mt-5">
           {
             catalog.map((item, index) => (
@@ -418,23 +412,26 @@ const pillars = [
     </div>
   </section>
 
-  {/* ── Pillars — three points, hairline-divided, no boxes ── */}
-  <section class="mx-auto max-w-6xl px-6 py-20 lg:py-24">
-    <div class="grid gap-12 sm:grid-cols-3 sm:gap-0">
+  {/* ── Pillars — asymmetric, hairline-divided, no boxes ── */}
+  <section class="mx-auto max-w-6xl px-6 py-16 lg:py-20">
+    <div class="grid gap-10 lg:grid-cols-[1.35fr_1fr_1fr] lg:gap-0">
       {
         pillars.map((pillar, index) => (
           <div
             class:list={[
               "reveal",
-              index > 0 && "sm:border-l sm:border-border sm:pl-10",
-              index < pillars.length - 1 && "sm:pr-10",
+              index === 0 && "lg:pr-14",
+              index > 0 && "lg:border-l lg:border-border lg:pl-10",
+              index === 1 && "lg:pr-10",
             ]}
             data-d={String(index)}
           >
-            <p class="font-mono text-xs tracking-[0.14em] text-accent uppercase">
-              {String(index + 1).padStart(2, "0")}
-            </p>
-            <h3 class="mt-3 text-balance font-display text-lg font-semibold text-foreground">
+            <h3
+              class:list={[
+                "text-balance font-display font-semibold text-foreground",
+                index === 0 ? "text-xl" : "text-lg",
+              ]}
+            >
               {pillar.title}
             </h3>
             <p class="mt-3 text-pretty text-sm leading-6 text-muted-foreground">{pillar.body}</p>
@@ -446,7 +443,7 @@ const pillars = [
 
   {/* ── Closing CTA ── */}
   <section class="border-t border-border">
-    <div class="mx-auto max-w-4xl px-6 py-20 text-center lg:py-24">
+    <div class="mx-auto max-w-4xl px-6 py-24 text-center lg:py-28">
       <h2
         class="reveal mx-auto max-w-2xl text-balance font-display text-3xl font-semibold tracking-tight text-foreground sm:text-4xl"
       >
@@ -458,7 +455,7 @@ const pillars = [
       </p>
       <div class="reveal mt-8 flex flex-wrap items-center justify-center gap-3" data-d="2">
         <a class="btn-solid press rounded-blume px-5 py-2.5 text-sm font-medium" href="/docs/quickstart"
-          >Quickstart</a
+          >Quick start</a
         >
         <a
           class="btn-outline press rounded-blume border border-border px-5 py-2.5 text-sm font-medium text-foreground"
@@ -489,7 +486,7 @@ const pillars = [
               <a class="footer-link" href="/docs">Introduction</a>
             </li>
             <li>
-              <a class="footer-link" href="/docs/quickstart">Quickstart</a>
+              <a class="footer-link" href="/docs/quickstart">Quick start</a>
             </li>
             <li>
               <a class="footer-link" href="/docs/catalog">Catalog</a>
@@ -543,7 +540,8 @@ const pillars = [
   /* Hallmark · genre: modern-minimal · macrostructure: dev-tool/CLI · theme: cobalt-deep
      · enrichment: Tier-A CSS art (TUI instrument pane) · nav: blume-default
      · footer: Ft3 (docs-root allowance) · design-system: design.md · designed-as-app
-     · pre-emit critique: P4 H5 E4 S5 R4 V4 */
+     · contrast: pass (40–41) · responsive: pass (34, 49–57)
+     · pre-emit critique: P5 H5 E5 S5 R5 V5 */
 
   /* ── CTAs ─────────────────────────────────────────────────────────── */
 
@@ -556,6 +554,9 @@ const pillars = [
   }
 
   .btn-solid {
+    display: inline-flex;
+    min-height: 2.5rem;
+    align-items: center;
     background: var(--blume-action);
     color: var(--blume-action-foreground);
     transition:
@@ -568,6 +569,9 @@ const pillars = [
   }
 
   .btn-outline {
+    display: inline-flex;
+    min-height: 2.5rem;
+    align-items: center;
     transition:
       border-color 150ms ease,
       background-color 150ms ease,
@@ -599,6 +603,11 @@ const pillars = [
   }
 
   /* ── Copy button — clipboard ⇢ check cross-fade ───────────────────── */
+
+  .copy-btn {
+    min-width: 2.5rem;
+    min-height: 2.5rem;
+  }
 
   .copy-btn svg {
     transition:
@@ -635,8 +644,8 @@ const pillars = [
     border: 1px solid var(--tp-graphite-rule);
     border-radius: 10px;
     box-shadow:
-      0 1px 2px oklch(0.24 0.02 258 / 0.06),
-      0 12px 32px oklch(0.24 0.02 258 / 0.08);
+      0 1px 2px var(--tp-demo-shadow-near),
+      0 12px 32px var(--tp-demo-shadow-far);
     overflow: hidden;
   }
 
@@ -743,17 +752,17 @@ const pillars = [
     color: var(--tp-graphite-ink);
   }
 
-  /* Type-in plays once, rows rise in after it, one caret keeps blinking. */
+  /* Type-in plays once, rows follow promptly, one caret keeps blinking. */
   @media (prefers-reduced-motion: no-preference) {
     .typed {
       width: 0;
-      animation: typing 1s steps(20, end) 0.4s forwards;
+      animation: typing 800ms steps(20, end) 150ms forwards;
     }
 
     .caret-cmd {
       animation:
-        blink 0.8s step-end 3,
-        vanish 1ms linear 1.6s forwards;
+        blink 650ms step-end 2,
+        vanish 1ms linear 1.05s forwards;
     }
 
     .caret-input {
@@ -763,35 +772,35 @@ const pillars = [
     .demo-ui > * {
       opacity: 0;
       transform: translateY(6px);
-      animation: rise 400ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+      animation: rise 300ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
     }
 
     .demo-ui > *:nth-child(1) {
-      animation-delay: 1.55s;
+      animation-delay: 0.75s;
     }
     .demo-ui > *:nth-child(2) {
-      animation-delay: 1.6s;
+      animation-delay: 0.8s;
     }
     .demo-ui > *:nth-child(3) {
-      animation-delay: 1.65s;
+      animation-delay: 0.85s;
     }
     .demo-ui > *:nth-child(4) {
-      animation-delay: 1.7s;
+      animation-delay: 0.9s;
     }
     .demo-ui > *:nth-child(5) {
-      animation-delay: 1.75s;
+      animation-delay: 0.95s;
     }
     .demo-ui > *:nth-child(6) {
-      animation-delay: 1.8s;
+      animation-delay: 1s;
     }
     .demo-ui > *:nth-child(7) {
-      animation-delay: 1.85s;
+      animation-delay: 1.05s;
     }
     .demo-ui > *:nth-child(8) {
-      animation-delay: 1.9s;
+      animation-delay: 1.1s;
     }
     .demo-ui > *:nth-child(9) {
-      animation-delay: 1.95s;
+      animation-delay: 1.15s;
     }
   }
 
@@ -826,14 +835,6 @@ const pillars = [
     background: var(--tp-graphite);
     border-block: 1px solid var(--tp-graphite-rule);
     color: var(--tp-graphite-ink);
-  }
-
-  .band-eyebrow {
-    font-family: var(--font-mono);
-    font-size: 0.75rem;
-    letter-spacing: 0.14em;
-    text-transform: uppercase;
-    color: var(--tp-signal);
   }
 
   .band-muted {
@@ -940,13 +941,25 @@ const pillars = [
       transform 150ms cubic-bezier(0.23, 1, 0.32, 1);
   }
 
-  @media (max-width: 480px) {
+  @media (max-width: 30rem) {
     .band-parts {
       display: none;
     }
 
     .band-row {
       grid-template-columns: 2.25rem minmax(0, 1fr) 1.25rem;
+    }
+  }
+
+  @media (pointer: coarse) {
+    .btn-solid,
+    .btn-outline,
+    .copy-btn {
+      min-height: 2.75rem;
+    }
+
+    .copy-btn {
+      min-width: 2.75rem;
     }
   }
 

--- a/apps/www/theme.css
+++ b/apps/www/theme.css
@@ -71,6 +71,9 @@
   --tp-graphite-faint: oklch(0.635 0.015 256);
   --tp-signal: oklch(0.72 0.15 252);
   --tp-signal-ink: oklch(0.16 0.014 260);
+  --tp-demo-shadow-near: oklch(0.24 0.02 258 / 0.06);
+  --tp-demo-shadow-far: oklch(0.24 0.02 258 / 0.08);
+  --tp-selection: oklch(0.52 0.19 257 / 0.18);
 
   /* Single-face rule: every role renders Commit Mono; IBM Plex Mono is the
      decreed fallback (docs/brand/typography.md) — the var() resolves to the
@@ -97,6 +100,7 @@
   --blume-code-background: oklch(0.165 0.014 258);
 
   --tp-action-hover: oklch(0.75 0.14 253);
+  --tp-selection: oklch(0.7 0.145 253 / 0.28);
 }
 
 /* Base niceties: no sideways scroll ever, crisper text on macOS,
@@ -110,15 +114,40 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+/* Blume owns the header markup. Keep its compact chrome while ensuring every
+   icon action has a truthful pointer target. */
+:where(
+  [data-blume-search-open],
+  [data-blume-theme-toggle],
+  [data-blume-nav-toggle],
+  [data-blume-header] a[aria-label]
+) {
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+}
+
+@media (pointer: coarse) {
+  :where(
+    [data-blume-search-open],
+    [data-blume-theme-toggle],
+    [data-blume-nav-toggle],
+    [data-blume-header] a[aria-label]
+  ) {
+    min-width: 2.75rem;
+    min-height: 2.75rem;
+  }
+}
+
 ::selection {
-  background: oklch(0.52 0.19 257 / 0.18);
+  background: var(--tp-selection);
 }
 
-:root[data-theme="dark"] ::selection {
-  background: oklch(0.7 0.145 253 / 0.28);
+/* Display text keeps its measure even with long package or product names. */
+:where(h1, h2, h3) {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
-/* Headings wrap without orphans. */
 .prose :where(h1, h2, h3) {
   text-wrap: balance;
 }

--- a/apps/www/theme.css
+++ b/apps/www/theme.css
@@ -122,8 +122,15 @@ body {
   [data-blume-nav-toggle],
   [data-blume-header] a[aria-label]
 ) {
-  min-width: 2.5rem;
   min-height: 2.5rem;
+}
+
+:where(
+  [data-blume-theme-toggle],
+  [data-blume-nav-toggle],
+  [data-blume-header] a[aria-label]
+) {
+  min-width: 2.5rem;
 }
 
 @media (pointer: coarse) {
@@ -133,8 +140,15 @@ body {
     [data-blume-nav-toggle],
     [data-blume-header] a[aria-label]
   ) {
-    min-width: 2.75rem;
     min-height: 2.75rem;
+  }
+
+  :where(
+    [data-blume-theme-toggle],
+    [data-blume-nav-toggle],
+    [data-blume-header] a[aria-label]
+  ) {
+    min-width: 2.75rem;
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,13 +67,13 @@ importers:
         version: 4.3.1(typescript@6.0.3)
       '@tailwindcss/vite':
         specifier: ^4.0.0
-        version: 4.3.2(vite@8.1.4(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.3.2(vite@8.1.5(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       astro:
         specifier: ^7.0.2
         version: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.9)(@vercel/functions@3.7.5(ws@8.21.0))(jiti@2.7.0)(yaml@2.9.0)
       blume:
-        specifier: ^1.0.3
-        version: 1.0.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@shikijs/themes@4.3.1)(@types/node@25.0.9)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@vercel/functions@3.7.5(ws@8.21.0))(esbuild@0.28.1)(prettier@3.9.5)(vite@8.1.4(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(ws@8.21.0)(yaml@2.9.0)
+        specifier: ^1.0.4
+        version: 1.0.4(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@shikijs/themes@4.3.1)(@types/node@25.0.9)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@vercel/functions@3.7.5(ws@8.21.0))(esbuild@0.28.1)(prettier@3.9.5)(vite@8.1.5(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(ws@8.21.0)(yaml@2.9.0)
     devDependencies:
       wrangler:
         specifier: ^4.0.0
@@ -356,8 +356,8 @@ importers:
 
 packages:
 
-  '@ai-sdk/gateway@2.0.112':
-    resolution: {integrity: sha512-M58LfWXTTmwDqYJNDxGfzlAyXDAg8iV2gPq2ZvIGlIZzJ9oTA7yX85lVFEZ0Owc/Gm+j/sVUczu0tnvc575jpg==}
+  '@ai-sdk/gateway@2.0.113':
+    resolution: {integrity: sha512-UtMn9SAqB4FFy/QJsDrjl+n0srO0qJ6m7QI+CmGis1s7gppUwpeMmtx04F5NDPs/rravNkIOVf5UpK4m+ifyZg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1874,46 +1874,46 @@ packages:
       rollup:
         optional: true
 
-  '@scalar/astro@0.4.9':
-    resolution: {integrity: sha512-GfcqviMFZM9arUfW7R6B6xwpKFGzFQSCEwMZX/whax1D6nRLu0om5quU8shIoRzA/+qypfSy81ZO9Cq9Y/1L/A==}
+  '@scalar/astro@0.4.10':
+    resolution: {integrity: sha512-P8pZw1YEZTN4qgON0UsD9Wa6gcrqqCilplRSo68YM8HkhflJrqrTKGVSfL8OaSv2EifSpYoKXWLqUZMeS72aJg==}
     engines: {node: '>=22'}
     peerDependencies:
       astro: ^4.0.0 || ^5.0.0
 
-  '@scalar/client-side-rendering@0.3.2':
-    resolution: {integrity: sha512-HXgfSnSQSLaTZupSmN2w4O1Gv0wXdFl+GtrZHQEoNQ4HSzgCtk9fKcmSVxaZiPjyx6eon/x3Ic+Ka5T4tXskyA==}
+  '@scalar/client-side-rendering@0.3.3':
+    resolution: {integrity: sha512-QMTKZdwtSSV619jV1jKeRCOd358cgJqRBTHQ663CF7EUCZ354qH4js883K3RYg5/eO4oWxOuka308KIj0sZ/Kg==}
     engines: {node: '>=22'}
 
-  '@scalar/helpers@0.9.0':
-    resolution: {integrity: sha512-M34CLRCttqC1bXthI/QSzQj0s5C6nrU2PFWf/vOT3RpycbiGDGQbqR+5RfFzpOIQvRqbHfNdcRbeiZBw+vCbkQ==}
+  '@scalar/helpers@0.9.1':
+    resolution: {integrity: sha512-UKSLIPfN++f+zzbsZ+F6I0lNrR4yX4PtokjHgGwGiHapxT5VJqAF4zFTIP2KCd27XG7KnAIA7qq62O4xRBxc6w==}
     engines: {node: '>=22'}
 
-  '@scalar/json-magic@0.12.17':
-    resolution: {integrity: sha512-Vw2nrUDIjhvMP6vxFtkiiFlabJ6SyTtfn1BsOxgnr1hIB+/rkngMguiDzl5em21VjyfFGIoADia+QWKM2hdcdA==}
+  '@scalar/json-magic@0.12.18':
+    resolution: {integrity: sha512-3oZr+jUUiwD3C+x2CROBtlyIUnwt9ScRhFfczuOTPZlD7Pnb5cyTTfkiHbxxU4qd66ij0Z3JA4X/Nj0OADyEiA==}
     engines: {node: '>=22'}
 
-  '@scalar/openapi-parser@0.28.8':
-    resolution: {integrity: sha512-BO98D3TLfKNL80UnE1sIAmI6DQRmOaH0AHnlAooTn1sQjNbRDaeHyRO53EEjo7HjFEdHeQtiRzoXmMB4jvt8AA==}
+  '@scalar/openapi-parser@0.28.9':
+    resolution: {integrity: sha512-AYmqO7dR6zc1TSVhW5BpwY0nUMfG5JuF85/8YXn5ZXcCvjgoJu8dbxX52vIGK9rRwSn07HXCdKk7KPIF4xfOTA==}
     engines: {node: '>=22'}
 
-  '@scalar/openapi-types@0.9.1':
-    resolution: {integrity: sha512-gkGhSkxSzADaBiNg+ZAbJuwj+ZUmzP2Pg9CWZ7ZP+0fck2WjPeDDM7aAbouAm0aQQMF9xBjSPXSA9a/qTHYaTw==}
+  '@scalar/openapi-types@0.9.2':
+    resolution: {integrity: sha512-J0SZkNPgCrsFN0Rv8sRqZpDOQcRV44TCT82LsQcyWmcglTr7qtXukDmMlIyXs7JDd+DoPLbT2ea65bEHRs2W2g==}
     engines: {node: '>=22'}
 
-  '@scalar/openapi-upgrader@0.2.9':
-    resolution: {integrity: sha512-D5b0rGLLZgmkO9mdW2j/ND1KBlH1u3RCpr87HPxv9P9ZSr6PtM5iLqFOJq0ACiaHjY2mikCrxgDmnUEhTzRpHQ==}
+  '@scalar/openapi-upgrader@0.2.10':
+    resolution: {integrity: sha512-FRYwCl4IXRi7yAF5/3Jho0jc2akTZfr/vRTYMjhm+96Fq0LaEuHJAvPcSkkU+j3IWGie6LaCQMZTngcSjoIzgA==}
     engines: {node: '>=22'}
 
-  '@scalar/schemas@0.7.2':
-    resolution: {integrity: sha512-6Ble6WcbiKgD3ypIva+wgZv1qIClmeEjXA6jrOo1bKpYUu6sh4e89LZxDK+LULa2jQl/2O5GEaa6aZ0ImlpkHg==}
+  '@scalar/schemas@0.7.3':
+    resolution: {integrity: sha512-B6S/zUptiRfMsmMy92u/LefpULus1h0q3od9l5xgZc+pslkfFhfFns+QsU0UJX3Lqp3tTsf64c3tIRqH7cZgVA==}
     engines: {node: '>=22'}
 
-  '@scalar/types@0.16.2':
-    resolution: {integrity: sha512-QAlCtDVRsX/UV1N9ctLqPsKQy84eceFf4dMnTZM0JhaRfwS/Ovwp8oFf3POSpqQILNiqLFZLE6IV6p/5rNoAag==}
+  '@scalar/types@0.16.3':
+    resolution: {integrity: sha512-8TVNlK8AdvIekrapAoEVwy+IVRbMTSDYnpprskAJV4XanmZ52Kru6RmS6d+tbEBfMo2dTgQ9cV9P0kqsAu/AuA==}
     engines: {node: '>=22'}
 
-  '@scalar/validation@0.6.0':
-    resolution: {integrity: sha512-tpmmG+/xRE2Kn9RpflU3AIyZv08v10+E1ZrJCx7z6+/91zHVxy0M73kC1LT4/8PbYNt85ywyC8+n+D99JdMcGA==}
+  '@scalar/validation@0.6.1':
+    resolution: {integrity: sha512-XeJ+pvxag0rguuRT6hxNSXIsxleB8Gcs6WQ55vFRkB4qo2CCO+wIli+uipzM3pILu5cP7agcL3pgADiZzd1ZNg==}
     engines: {node: '>=20'}
 
   '@sec-ant/readable-stream@0.4.1':
@@ -2603,8 +2603,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ai@5.0.213:
-    resolution: {integrity: sha512-QCPMxXxV/I+nXVYyQru62Izx8cU5UmPDkooJmYy1+kBvhT/hDH/n33th/SAE73A2kRXIUO1cFdvhZ0XCRPdWaw==}
+  ai@5.0.214:
+    resolution: {integrity: sha512-rn7nDP4p/919WW8qRwjB01y3rCX7aSOQHGRaqIHf+vgvr4ypoHNE+KJPGp37bR2wQJL3rB4JzrQwKTEPj891YQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2773,8 +2773,8 @@ packages:
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
 
-  blume@1.0.3:
-    resolution: {integrity: sha512-rPp+KSFBjxlz7SodQt2h4AbZygQrcYn+p+WR+3NctkJcIIs+OXlqXACv7iFAzLDk774Cb5uo7LrQ5/3/GyQ2uA==}
+  blume@1.0.4:
+    resolution: {integrity: sha512-sJmmm3MJ1am+4ubZPXlrgE4rx4vn+N92Aqyo9zxDL5+T4a3w5Hpv0FqxF3iMlv6qYOHp+Ts7d72rx348SePxSg==}
     engines: {node: '>=22.12.0'}
     hasBin: true
     peerDependencies:
@@ -5414,6 +5414,9 @@ packages:
   tailwindcss@4.3.2:
     resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
 
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
+
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
@@ -5798,6 +5801,49 @@ packages:
       yaml:
         optional: true
 
+  vite@8.1.5:
+    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitefu@1.1.3:
     resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
     peerDependencies:
@@ -5957,8 +6003,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@7.5.11:
-    resolution: {integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==}
+  ws@7.5.12:
+    resolution: {integrity: sha512-1xGnbYN3zbog9CwuNDQULNRrTCLIn46/WmpR1f0w6PsCYQHkylZr5vkd6kfMZYV6pRnQkcPNRyiA8LsrNKyhpg==}
     engines: {node: '>=8.3.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -6087,7 +6133,7 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/gateway@2.0.112(zod@3.25.76)':
+  '@ai-sdk/gateway@2.0.113(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 2.0.3
       '@ai-sdk/provider-utils': 3.0.29(zod@3.25.76)
@@ -6311,12 +6357,12 @@ snapshots:
       '@astrojs/internal-helpers': 0.10.1
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
-      '@vitejs/plugin-react': 5.2.0(vite@8.1.4(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitejs/plugin-react': 5.2.0(vite@8.1.5(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       devalue: 5.8.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       ultrahtml: 1.7.0
-      vite: 8.1.4(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -7685,31 +7731,31 @@ snapshots:
       estree-walker: 2.0.2
       picomatch: 4.0.5
 
-  '@scalar/astro@0.4.9(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.9)(@vercel/functions@3.7.5(ws@8.21.0))(jiti@2.7.0)(yaml@2.9.0))':
+  '@scalar/astro@0.4.10(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.9)(@vercel/functions@3.7.5(ws@8.21.0))(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
-      '@scalar/client-side-rendering': 0.3.2
+      '@scalar/client-side-rendering': 0.3.3
       astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.9)(@vercel/functions@3.7.5(ws@8.21.0))(jiti@2.7.0)(yaml@2.9.0)
 
-  '@scalar/client-side-rendering@0.3.2':
+  '@scalar/client-side-rendering@0.3.3':
     dependencies:
-      '@scalar/schemas': 0.7.2
-      '@scalar/types': 0.16.2
-      '@scalar/validation': 0.6.0
+      '@scalar/schemas': 0.7.3
+      '@scalar/types': 0.16.3
+      '@scalar/validation': 0.6.1
 
-  '@scalar/helpers@0.9.0': {}
+  '@scalar/helpers@0.9.1': {}
 
-  '@scalar/json-magic@0.12.17':
+  '@scalar/json-magic@0.12.18':
     dependencies:
-      '@scalar/helpers': 0.9.0
+      '@scalar/helpers': 0.9.1
       pathe: 2.0.3
       yaml: 2.9.0
 
-  '@scalar/openapi-parser@0.28.8':
+  '@scalar/openapi-parser@0.28.9':
     dependencies:
-      '@scalar/helpers': 0.9.0
-      '@scalar/json-magic': 0.12.17
-      '@scalar/openapi-types': 0.9.1
-      '@scalar/openapi-upgrader': 0.2.9
+      '@scalar/helpers': 0.9.1
+      '@scalar/json-magic': 0.12.18
+      '@scalar/openapi-types': 0.9.2
+      '@scalar/openapi-upgrader': 0.2.10
       ajv: 8.20.0
       ajv-draft-04: 1.0.0(ajv@8.20.0)
       ajv-formats: 3.0.1(ajv@8.20.0)
@@ -7717,25 +7763,25 @@ snapshots:
       leven: 4.1.0
       yaml: 2.9.0
 
-  '@scalar/openapi-types@0.9.1': {}
+  '@scalar/openapi-types@0.9.2': {}
 
-  '@scalar/openapi-upgrader@0.2.9':
+  '@scalar/openapi-upgrader@0.2.10':
     dependencies:
-      '@scalar/openapi-types': 0.9.1
+      '@scalar/openapi-types': 0.9.2
 
-  '@scalar/schemas@0.7.2':
+  '@scalar/schemas@0.7.3':
     dependencies:
-      '@scalar/helpers': 0.9.0
-      '@scalar/validation': 0.6.0
+      '@scalar/helpers': 0.9.1
+      '@scalar/validation': 0.6.1
 
-  '@scalar/types@0.16.2':
+  '@scalar/types@0.16.3':
     dependencies:
-      '@scalar/helpers': 0.9.0
+      '@scalar/helpers': 0.9.1
       nanoid: 5.1.16
       type-fest: 5.8.0
       zod: 4.4.3
 
-  '@scalar/validation@0.6.0': {}
+  '@scalar/validation@0.6.1': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -7864,17 +7910,17 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
 
-  '@tailwindcss/typography@0.5.20(tailwindcss@4.3.2)':
+  '@tailwindcss/typography@0.5.20(tailwindcss@4.3.3)':
     dependencies:
       postcss-selector-parser: 6.0.10
-      tailwindcss: 4.3.2
+      tailwindcss: 4.3.3
 
-  '@tailwindcss/vite@4.3.2(vite@8.1.4(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.2(vite@8.1.5(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.2
       '@tailwindcss/oxide': 4.3.2
       tailwindcss: 4.3.2
-      vite: 8.1.4(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
 
   '@takumi-rs/core-darwin-arm64@1.8.7':
     optional: true
@@ -8201,7 +8247,7 @@ snapshots:
     optionalDependencies:
       ajv: 6.15.0
 
-  '@vitejs/plugin-react@5.2.0(vite@8.1.4(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@8.1.5(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -8209,7 +8255,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 8.1.4(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 8.1.5(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8354,9 +8400,9 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@5.0.213(zod@3.25.76):
+  ai@5.0.214(zod@3.25.76):
     dependencies:
-      '@ai-sdk/gateway': 2.0.112(zod@3.25.76)
+      '@ai-sdk/gateway': 2.0.113(zod@3.25.76)
       '@ai-sdk/provider': 2.0.3
       '@ai-sdk/provider-utils': 3.0.29(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
@@ -8601,7 +8647,7 @@ snapshots:
 
   blake3-wasm@2.1.5: {}
 
-  blume@1.0.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@shikijs/themes@4.3.1)(@types/node@25.0.9)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@vercel/functions@3.7.5(ws@8.21.0))(esbuild@0.28.1)(prettier@3.9.5)(vite@8.1.4(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(ws@8.21.0)(yaml@2.9.0):
+  blume@1.0.4(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@shikijs/themes@4.3.1)(@types/node@25.0.9)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(@vercel/functions@3.7.5(ws@8.21.0))(esbuild@0.28.1)(prettier@3.9.5)(vite@8.1.5(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(ws@8.21.0)(yaml@2.9.0):
     dependencies:
       '@astrojs/check': 0.9.9(prettier@3.9.5)(typescript@6.0.3)
       '@astrojs/markdown-satteri': 0.3.4
@@ -8616,17 +8662,17 @@ snapshots:
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       '@orama/orama': 3.1.18
       '@pierre/diffs': 1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@scalar/astro': 0.4.9(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.9)(@vercel/functions@3.7.5(ws@8.21.0))(jiti@2.7.0)(yaml@2.9.0))
-      '@scalar/openapi-parser': 0.28.8
-      '@scalar/openapi-types': 0.9.1
+      '@scalar/astro': 0.4.10(astro@7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.9)(@vercel/functions@3.7.5(ws@8.21.0))(jiti@2.7.0)(yaml@2.9.0))
+      '@scalar/openapi-parser': 0.28.9
+      '@scalar/openapi-types': 0.9.2
       '@shikijs/transformers': 4.3.1
       '@shikijs/twoslash': 4.3.1(typescript@6.0.3)
-      '@tailwindcss/typography': 0.5.20(tailwindcss@4.3.2)
-      '@tailwindcss/vite': 4.3.2(vite@8.1.4(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@tailwindcss/typography': 0.5.20(tailwindcss@4.3.3)
+      '@tailwindcss/vite': 4.3.2(vite@8.1.5(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@takumi-rs/core': 1.8.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@takumi-rs/helpers': 1.8.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@vercel/analytics': 2.0.1(react@19.2.7)
-      ai: 5.0.213(zod@3.25.76)
+      ai: 5.0.214(zod@3.25.76)
       astro: 7.0.9(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.0.9)(@vercel/functions@3.7.5(ws@8.21.0))(jiti@2.7.0)(yaml@2.9.0)
       babel-plugin-react-compiler: 1.0.0
       citty: 0.1.6
@@ -8647,7 +8693,7 @@ snapshots:
       satteri: 0.9.5
       shiki: 4.3.1
       simple-icons: 13.21.0
-      tailwindcss: 4.3.2
+      tailwindcss: 4.3.3
       tinyglobby: 0.2.17
       typescript: 6.0.3
       undici: 8.7.0
@@ -11131,7 +11177,7 @@ snapshots:
   react-devtools-core@7.0.1:
     dependencies:
       shell-quote: 1.10.0
-      ws: 7.5.11
+      ws: 7.5.12
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11782,6 +11828,8 @@ snapshots:
 
   tailwindcss@4.3.2: {}
 
+  tailwindcss@4.3.3: {}
+
   tapable@2.3.3: {}
 
   tar@7.5.20:
@@ -12073,6 +12121,20 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
+  vite@8.1.5(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.19
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.0.9
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      yaml: 2.9.0
+
   vitefu@1.1.3(vite@8.1.4(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.1.4(@types/node@25.0.9)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
@@ -12234,7 +12296,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@7.5.11: {}
+  ws@7.5.12: {}
 
   ws@8.21.0: {}
 


### PR DESCRIPTION
## Summary

- rewrite the foundation, catalog, quickstart, and registry documentation
- refine the landing-page hierarchy, spacing, motion, and responsive presentation
- upgrade Blume to 1.0.4
- preserve Blume’s desktop search width while maintaining accessible header hit targets

## Validation

- `pnpm --filter www build`
- `./node_modules/.bin/biome check apps/www/theme.css`
- production/local visual comparison with agent-browser