### PR TITLE
feat(theme): consumer-owned theming system, token contract, and preset catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,12 @@ benchmarks
 # throwaway prototypes (local only, per decree)
 prototypes/
 assets/
+
+# fixtures (regenerated from registry source, not tracked)
+fixtures/
+fixtures/.registry/
+fixtures/.tarballs/
+fixtures/demo/node_modules/
+fixtures/demo/components/
+fixtures/demo/themes/
+fixtures/demo/pnpm-lock.yaml

--- a/apps/www/docs/catalog/badge.mdx
+++ b/apps/www/docs/catalog/badge.mdx
@@ -6,7 +6,8 @@ description: A presentation-only status label composed from ordinary OpenTUI ele
 <Badge>Recipe only</Badge>
 
 A presentation-only status label composed from ordinary OpenTUI elements — a
-`box` and a `text` — with a starter intent palette. Badge is not interactive:
+`box` and a `text` — with intents mapped to [theme tokens](/theming). Badge
+is not interactive:
 it renders no focus, keyboard, or pointer behavior, so it is distributed only
 as editable registry source.
 
@@ -14,8 +15,8 @@ as editable registry source.
 
 - **Use `Badge` for status, not actions.** For anything the user activates,
   use `Button`.
-- **The recipe is the entire implementation.** Edit the palette map directly;
-  there is no package behind it.
+- **The recipe is the entire implementation.** Edit the intent-to-token map
+  directly; there is no package behind it.
 
 ## Installation
 
@@ -62,7 +63,7 @@ import { Badge } from "./components/ui/badge";
       type: '"danger" | "neutral" | "success" | "warning"',
       default: '"neutral"',
       description:
-        "Which starter background and foreground palette pair to apply.",
+        "Which theme token pair to apply: success, warning, destructive, or surface/foreground for neutral.",
     },
     size: {
       type: '"compact" | "comfortable"',

--- a/apps/www/docs/catalog/button.mdx
+++ b/apps/www/docs/catalog/button.mdx
@@ -80,7 +80,7 @@ The installed recipe adds presentation props on top of the primitive's
       type: '"neutral" | "primary"',
       default: '"primary"',
       description:
-        "Which starter palette to apply. Edit or extend the palette map in the installed file.",
+        "Which theme tokens the resting state uses: primary or surface. Edit or extend the mapping in the installed file.",
     },
     size: {
       type: '"compact" | "comfortable"',
@@ -98,7 +98,9 @@ The installed recipe adds presentation props on top of the primitive's
 All remaining primitive props — layout, colors, and event callbacks — pass
 through to `ButtonPrimitive`. The render callback receives readonly
 `pressed`, `focused`, and `disabled` state, which the starter recipe maps to
-background colors.
+[theme tokens](/theming): `focus` for the focused background, a
+`tint`-derived shade of it for the pressed flash, and the `disabled` pair for
+disabled controls.
 
 For the split between packaged behavior and installed presentation, see the
 [architecture page](/architecture).

--- a/apps/www/docs/catalog/index.mdx
+++ b/apps/www/docs/catalog/index.mdx
@@ -36,6 +36,10 @@ becomes source your application owns.
   <Card title="Badge" href="/catalog/badge" icon="tag">
     Presentation-only status label composed from ordinary OpenTUI elements.
   </Card>
+  <Card title="Theme" href="/theming" icon="palette">
+    The consumer-owned token contract, store, and preset themes every recipe
+    reads from.
+  </Card>
 </CardGroup>
 
 ## Preview and companions
@@ -49,6 +53,7 @@ becomes source your application owns.
   </Card>
 </CardGroup>
 
-**Recipes are starting points.** The palette, density, symbols, labels, and
-intent variants in each installed file are examples for you to edit, not
-package APIs.
+**Recipes are starting points.** Colors, density, and symbols resolve from
+the consumer-owned [theme file](/theming) installed alongside every recipe;
+labels and intent variants live directly in each installed file. All of it is
+example source for you to edit, not package APIs.

--- a/apps/www/docs/index.mdx
+++ b/apps/www/docs/index.mdx
@@ -28,9 +28,10 @@ package delivers behavior fixes without touching your presentation code.
 ## Recipes install as source you own
 
 Glyphs, palettes, layout, semantic variants, and convenience assembly install
-as plain TypeScript through the official shadcn CLI. The installed file lands
-in your project and belongs to your application — edit the palette map
-directly; there is no hidden theme runtime.
+as plain TypeScript through the official shadcn CLI. The installed files land
+in your project and belong to your application — every recipe reads its
+colors and glyphs from a consumer-owned [theme file](/theming) installed
+alongside it; there is no hidden theme runtime.
 
 ## One vocabulary, three runtimes
 
@@ -82,6 +83,9 @@ file.
   </Card>
   <Card title="Architecture" href="/architecture" icon="blocks">
     Understand primitives, recipes, and who owns what.
+  </Card>
+  <Card title="Theming" href="/theming" icon="palette">
+    The token contract, live theme switching, and preset themes.
   </Card>
   <Card title="Registry" href="/registry" icon="package">
     Configure shadcn and manage consumer-owned updates.

--- a/apps/www/docs/quickstart.mdx
+++ b/apps/www/docs/quickstart.mdx
@@ -111,15 +111,20 @@ application owns.
     <Checkbox label="Enable notifications" defaultChecked />;
     ```
 
-**The installed file belongs to your application.** The palette, glyphs,
-labels, and variants inside it are starter choices, not package APIs — edit
-them directly or use them as the basis of your own registry.
+**The installed files belong to your application.** Installing any recipe
+also installs the consumer-owned [theme file](/theming) it reads its colors
+and glyphs from. Labels and variants live in the recipe itself. All of it is
+starter source, not package APIs — edit it directly or use it as the basis
+of your own registry.
 
 ## Next steps
 
 <CardGroup cols={2}>
   <Card title="Catalog" href="/catalog" icon="layout-grid">
     The starter catalog: Button, Checkbox, Switch, Toggle, Toggle Group, Radio Group, Input, Badge.
+  </Card>
+  <Card title="Theming" href="/theming" icon="palette">
+    Tokens, live theme switching, and the out-of-the-box preset themes.
   </Card>
   <Card title="Registry lifecycle" href="/registry" icon="git-compare">
     Review upstream recipe changes without discarding local edits.

--- a/apps/www/docs/registry.mdx
+++ b/apps/www/docs/registry.mdx
@@ -2,7 +2,7 @@
 title: Registry
 description: The shadcn-compatible registry hosted on this site — configuration, the install lifecycle, and consumer-owned updates.
 sidebar:
-  order: 4
+  order: 5
 ---
 
 The tuiparts.sh registry distributes editable recipe source through the
@@ -57,10 +57,22 @@ Each foundation recipe is available as `core/<name>`, `react/<name>`, and
 | RadioGroup/Radio | Radio collection and selectable parts | `RadioGroup`, `RadioGroupItem` |
 | Input | Native OpenTUI input behavior | `Input` |
 | Badge | None; presentation-only recipe | `Badge` |
+| Toggle | Standalone pressed-state primitive | `Toggle` |
+| ToggleGroup/Toggle | Single or multiple selection and roving focus | `ToggleGroup`, `ToggleGroupItem` |
+| Theme | None; consumer-owned token contract and store | `Tokens`, `theme`, `createThemeStore`, `tint` (+ `useTheme` in React/Solid) |
+
+Framework-neutral preset themes are additionally available as
+`theme-<name>` — currently `theme-cobalt-deep`, `theme-ascii`,
+`theme-catppuccin`, `theme-gruvbox`, and `theme-rosepine`. They install to
+`themes/<name>.ts` and serve one file to all three runtimes; see
+[Theming](/theming).
 
 React and Solid recipes expose the same installed names and props where their
 runtime semantics permit. Core recipes expose equivalent imperative factory
-functions and install ordinary `.ts` source rather than framework JSX.
+functions and install ordinary `.ts` source rather than framework JSX. Every
+recipe declares its runtime's `theme` item in `registryDependencies`, so
+installing any recipe also installs the consumer-owned
+`components/ui/theme.ts`.
 
 The registry also contains a validated preview Dialog recipe, but it is not
 part of this starter catalog. The already-adopted `@tuiparts/dialog` and

--- a/apps/www/docs/theming.mdx
+++ b/apps/www/docs/theming.mdx
@@ -1,6 +1,6 @@
 ---
 title: Theming
-description: The consumer-owned token contract, the theme store API, the out-of-the-box themes, and how to build your own.
+description: A guide to theming recipes with the consumer-owned token contract.
 sidebar:
   order: 4
 ---
@@ -44,7 +44,7 @@ export interface Tokens {
   };
   glyphs: {
     check: string; // "✓"
-    radio: string; // "o"
+    radio: string; // "●"
     thumb: string; // "●"
     track: string; // "─"
   };
@@ -79,7 +79,7 @@ remount:
 | `theme.register(name, definition)` | Adds or replaces a named theme at runtime. |
 | `theme.override(partial)` | Applies a top-priority partial overlay (or clears it with `undefined`). |
 | `theme.follow(renderer)` | Keeps `"system"` mode in sync with the terminal's live light/dark signal. |
-| `tint(base, overlay, alpha)` | Blends two colors; the blessed way to derive interaction-state shades. |
+| `tint(base, overlay, alpha)` | Blends two colors to derive interaction-state shades. |
 
 Snapshots resolve eagerly as `base ⊕ theme.tokens ⊕ theme[mode] ⊕ override`:
 missing keys at any layer fall through to the layer below.
@@ -119,7 +119,7 @@ const unsubscribe = theme.subscribe(() => {
 
 ## Modes and `"system"`
 
-`"system"` follows your **terminal's** colors, not the operating system's
+`"system"` follows your terminal's colors, not the operating system's
 appearance setting. OpenTUI queries the terminal for its background color,
 derives dark or light from its luminance, and emits a live `theme_mode` event
 when the terminal reports a change. Wire it up once at startup:
@@ -165,7 +165,7 @@ theme.register("catppuccin", catppuccin);
 theme.setActive("catppuccin");
 ```
 
-Presets are `DeepPartial` overrides merged over **your** base theme, not
+Presets are `DeepPartial` overrides merged over your base theme, not
 full token sets: anything a preset does not define falls back to your
 defaults, so a glyph-only preset like ASCII changes no colors, and your own
 token extensions never break a preset install.

--- a/apps/www/docs/theming.mdx
+++ b/apps/www/docs/theming.mdx
@@ -1,0 +1,236 @@
+---
+title: Theming
+description: The consumer-owned token contract, the theme store API, the out-of-the-box themes, and how to build your own.
+sidebar:
+  order: 4
+---
+
+Every recipe reads its colors, glyphs, and density from one consumer-owned
+theme file instead of hard-coding literals. Installing any recipe also
+installs `components/ui/theme.ts` — it is declared as a registry dependency
+of every item — plus a small `components/ui/use-theme.tsx` binding in React
+and Solid. It is the terminal analog of shadcn's `globals.css` and
+`lib/utils.ts`.
+
+There is no packaged theme runtime. The installed file contains the whole
+mechanism: the `Tokens` contract, a small subscription store, and a default
+theme built from ANSI-indexed colors. Editing it is the supported
+customization path, and the shadcn diff workflow updates it like any recipe.
+
+## The token contract
+
+`Tokens` is a small, flat, semantic vocabulary — shadcn-sized, not a
+per-component style sheet:
+
+```ts title="components/ui/theme.ts (excerpt)"
+export interface Tokens {
+  colors: {
+    background: ColorInput;
+    surface: ColorInput;
+    foreground: ColorInput;
+    mutedForeground: ColorInput;
+    border: ColorInput;
+    focus: ColorInput;
+    primary: ColorInput;
+    primaryForeground: ColorInput;
+    destructive: ColorInput;
+    destructiveForeground: ColorInput;
+    success: ColorInput;
+    successForeground: ColorInput;
+    warning: ColorInput;
+    warningForeground: ColorInput;
+    disabled: ColorInput;
+    disabledForeground: ColorInput;
+  };
+  glyphs: {
+    check: string; // "✓"
+    radio: string; // "o"
+    thumb: string; // "●"
+    track: string; // "─"
+  };
+  borders: {
+    style: "single" | "rounded" | "double" | "heavy";
+  };
+  density: {
+    paddingX: number;
+    comfortablePaddingX: number;
+  };
+}
+```
+
+Intent colors ship as background/foreground pairs (`primary` /
+`primaryForeground`), so recipes never guess label contrast. Interaction
+states that are not in the vocabulary — a pressed flash, a backdrop scrim, a
+focus emphasis — are derived in recipe code with the `tint` helper rather
+than authored as extra tokens.
+
+## The store
+
+`theme.ts` exports an app-wide store singleton. Every installed recipe
+subscribes to it, so changing the theme restyles live components without a
+remount:
+
+| Member | Behavior |
+| --- | --- |
+| `theme.get()` | The current resolved `Tokens` snapshot — deep-frozen and referentially stable until the next change. |
+| `theme.subscribe(fn)` | Notifies on every change; returns an unsubscribe function. |
+| `theme.setActive(name)` | Switches the active named theme. Returns `false` for unknown names. |
+| `theme.setMode(mode)` | `"system" \| "dark" \| "light"` — selects which per-mode overlay applies. |
+| `theme.register(name, definition)` | Adds or replaces a named theme at runtime. |
+| `theme.override(partial)` | Applies a top-priority partial overlay (or clears it with `undefined`). |
+| `theme.follow(renderer)` | Keeps `"system"` mode in sync with the terminal's live light/dark signal. |
+| `tint(base, overlay, alpha)` | Blends two colors; the blessed way to derive interaction-state shades. |
+
+Snapshots resolve eagerly as `base ⊕ theme.tokens ⊕ theme[mode] ⊕ override`:
+missing keys at any layer fall through to the layer below.
+
+React and Solid recipes read the store through the installed `useTheme()`
+binding; Core recipes call `theme.get()` and `theme.subscribe` directly:
+
+<CodeGroup>
+
+```tsx React
+import { useTheme } from "./components/ui/use-theme";
+
+function StatusLine() {
+  const tokens = useTheme();
+  return <text content="ready" fg={tokens.colors.mutedForeground} />;
+}
+```
+
+```tsx Solid
+import { useTheme } from "./components/ui/use-theme";
+
+function StatusLine() {
+  const tokens = useTheme();
+  return <text content="ready" fg={tokens().colors.mutedForeground} />;
+}
+```
+
+```ts Core
+import { theme } from "./components/ui/theme";
+
+const unsubscribe = theme.subscribe(() => {
+  label.fg = theme.get().colors.mutedForeground;
+});
+```
+
+</CodeGroup>
+
+## Modes and `"system"`
+
+`"system"` follows your **terminal's** colors, not the operating system's
+appearance setting. OpenTUI queries the terminal for its background color,
+derives dark or light from its luminance, and emits a live `theme_mode` event
+when the terminal reports a change. Wire it up once at startup:
+
+```tsx title="index.tsx"
+const renderer = await createCliRenderer({ exitOnCtrlC: true });
+theme.follow(renderer);
+```
+
+Terminals that switch their palette with the OS appearance (Ghostty, iTerm2,
+and others) propagate that switch live; every subscribed component restyles
+in place. If the terminal never answers the query, `"system"` falls back to
+dark.
+
+## Out-of-the-box themes
+
+The default theme, `terminal`, is built entirely from ANSI-indexed and
+default-intent colors — your app inherits the palette, background, and
+transparency the terminal user already configured, with zero hex literals.
+
+Preset themes are framework-neutral registry items that install to
+`themes/<name>.ts` and serve all three runtimes:
+
+| Preset | Item | Dark | Light |
+| --- | --- | --- | --- |
+| Cobalt Deep | `theme-cobalt-deep` | tuiparts.sh brand graphite/amber | Light brand variant |
+| Catppuccin | `theme-catppuccin` | Mocha | Latte |
+| Gruvbox | `theme-gruvbox` | Gruvbox dark | Gruvbox light |
+| Rosé Pine | `theme-rosepine` | Main | Dawn |
+| ASCII | `theme-ascii` | Glyph-only compatibility preset (`x`, `*`, `-`) for terminals without Unicode | — |
+
+Install a preset, register it, and switch to it:
+
+```bash
+pnpm dlx shadcn@4.13.0 add @tuiparts/theme-catppuccin
+```
+
+```ts
+import { theme } from "./components/ui/theme";
+import { catppuccin } from "./themes/catppuccin";
+
+theme.register("catppuccin", catppuccin);
+theme.setActive("catppuccin");
+```
+
+Presets are `DeepPartial` overrides merged over **your** base theme, not
+full token sets: anything a preset does not define falls back to your
+defaults, so a glyph-only preset like ASCII changes no colors, and your own
+token extensions never break a preset install.
+
+## Custom themes
+
+The theme file is yours; there are three tiers of customization, and none of
+them involve configuration.
+
+**Edit the defaults.** Changing a value in the installed `terminal` theme
+changes every recipe at once — the single-source-of-truth edit shadcn users
+make in `globals.css`.
+
+**Write a theme definition.** A theme is shared token overrides plus optional
+per-mode overlays. Register it at startup or load it at runtime — the store
+does not care where the definition came from, which is the seam for
+user-supplied theme files:
+
+```ts title="themes/midnight.ts"
+import type { ThemeDefinition } from "../components/ui/theme";
+
+export const midnight: ThemeDefinition = {
+  tokens: {
+    colors: {
+      background: "#0B0E15",
+      primary: "#7AA2F7",
+      primaryForeground: "#0B0E15",
+    },
+  },
+  light: {
+    colors: {
+      background: "#E9EDF4",
+      primary: "#2D62E4",
+      primaryForeground: "#FFFFFF",
+    },
+  },
+};
+```
+
+**Extend the contract.** Because you own the `Tokens` interface, app-specific
+tokens are ordinary edits — add a `colors.sidebar` or a `glyphs.spinner` and
+it flows through the same resolve/subscribe pipeline with full type safety.
+Presets remain compatible: they are partial by construction.
+
+**Or reshape it entirely.** Removing or renaming a token is a type-guided
+refactor, not a breaking change: recipes read tokens as plain property access
+(`tokens.colors.focus`), never string lookups, so `tsc` lists every recipe
+line that referenced the old name — all consumer-owned source you edit in
+place. An installed preset that set the removed token surfaces the same way.
+The packaged primitives contain no styling and never read tokens, so no
+change to your contract can break a package. Design-system builders composing
+raw primitives can go further still: `createThemeStore` and the merge
+mechanics are shape-agnostic, so you can keep the store, modes, and
+`follow(renderer)` under a token vocabulary of your own — or skip the theme
+item entirely and bring your own system.
+
+Persisting the user's choice, theme-picker UIs, and config-directory theme
+loading are consumer-side patterns built on `theme.subscribe` and
+`theme.register`; the registry deliberately ships none of them.
+
+## Updating the theme file
+
+The theme item updates through the same consumer-owned lifecycle as every
+recipe — diff first, merge what you want:
+
+```bash
+pnpm dlx shadcn@4.13.0 add @tuiparts/react/theme --diff
+```

--- a/docs/adr/0006-theming-ships-as-registry-source.md
+++ b/docs/adr/0006-theming-ships-as-registry-source.md
@@ -1,0 +1,79 @@
+---
+status: accepted
+---
+
+# Theming ships as Registry source
+
+## Context
+
+Recipes previously hard-coded every color, glyph, and density value as
+literals in each installed file. Consumers wanting a coherent visual identity
+had to hand-edit every recipe and keep the values consistent by discipline
+alone; the catalog had no way to ship ready-made themes, and apps could not
+respect the terminal user's palette or light/dark preference even though
+OpenTUI reports both (`renderer.themeMode`, the `theme_mode` event, indexed
+colors via `RGBA.fromIndex`).
+
+The Foundation Primitive Contract already assigns presentation to recipes:
+primitives must not choose colors, glyphs, or themes. Any theming design
+therefore had to live on the recipe side of that boundary.
+
+## Decision
+
+The entire theming system is consumer-owned Registry source. There is no
+`@tuiparts/*/theme` package export and no contract amendment.
+
+- The `theme` catalog item installs one file (`components/ui/theme.ts`)
+  containing the semantic token contract (`Tokens`), a small subscription
+  store with eager resolution
+  (`base ⊕ active.tokens ⊕ active[mode] ⊕ override` into a frozen snapshot,
+  referentially stable until the next change — the contract's existing State
+  idiom), platform mode-following (`theme.follow(renderer)` over the
+  `theme_mode` event with `mode: "system" | "dark" | "light"`), runtime
+  registration (`theme.register`), and the `tint` blend helper. The React and
+  Solid items add a `useTheme` binding over the same store, installed as a
+  separate small file beside the shared store source
+  (`components/ui/use-theme.tsx`).
+- The default theme uses ANSI-indexed colors and a default-intent background,
+  so installed recipes inherit the terminal user's palette and transparency.
+- Preset themes (`theme-<name>`) are framework-neutral `DeepPartial<Tokens>`
+  files installed to `themes/<name>.ts`. They import the consumer's own
+  `ThemeDefinition` type, so everything a preset specifies is type-checked by
+  the consumer's compiler, missing keys fall back to the consumer's base, and
+  consumer token extensions never break a preset install.
+- Every recipe item declares its adapter's theme item in
+  `registryDependencies`, so installing any recipe guarantees the theme file
+  exists; recipes read tokens instead of literals and derive interaction
+  states from few tokens plus structural affordances rather than per-intent
+  ramps.
+
+Rejected alternatives: a packaged core theme primitive with a
+`createThemeContext` factory (a pub-sub plus deep-merge is not difficult
+behavior — "package the difficult behavior, copy the opinionated layer");
+AsyncLocalStorage (construction-time capture is useless for retained
+renderable trees); full-`Tokens` preset implementations (break under consumer
+token extensions); per-intent state-ramp token matrices (weld the contract to
+one interaction-state model and make presets large); a runtime JSON theme
+format with reference resolution (our presets are compile-time TypeScript,
+so named constants and the compiler already provide references and validation).
+
+Deferred, recorded to avoid re-derivation: a palette-derived system theme
+generator over `renderer.getPalette` (synthesizes surface/border/muted ramps
+ANSI-16 has no slots for) and luminance-based mode fallback for terminals
+that never answer the theme-mode query.
+
+## Consequences
+
+- The Foundation Primitive Contract is untouched; that the design required
+  zero contract changes is evidence it sits at the right layer.
+- Customization is editing an owned file, not configuring a hidden runtime;
+  adding a ThemeProvider, subtree scoping, persistence, or theme-file
+  discovery later is a consumer-side edit, and `theme.register` is the seam
+  runtime theme loading builds on.
+- The theme item is a Recipe in catalog vocabulary: it packages no behavior.
+- Registry validation treats theme and preset items like every other catalog
+  item: isolated strict consumers, byte-identical install checks, and runtime
+  smokes through public renderable properties.
+- A versioned theme-contract package is reconsidered only when a second,
+  independent registry demonstrates genuine reuse of the contract — the same
+  extraction rule the contract applies to shared infrastructure.

--- a/docs/adr/0006-theming-ships-as-registry-source.md
+++ b/docs/adr/0006-theming-ships-as-registry-source.md
@@ -45,7 +45,15 @@ The entire theming system is consumer-owned Registry source. There is no
   `registryDependencies`, so installing any recipe guarantees the theme file
   exists; recipes read tokens instead of literals and derive interaction
   states from few tokens plus structural affordances rather than per-intent
-  ramps.
+  ramps. Preset items declare the Core theme item for the same reason: a
+  preset installed on its own imports a `ThemeDefinition` that must exist.
+- The glyph tokens are `check`, `radio`, `thumb`, and `track` rather than the
+  `radioOn`/`radioOff`/`thumbOn`/`thumbOff` pairs the design sketch proposed.
+  Off-states are structural in every recipe — an Indicator part renders only
+  when its store reports checked, and the Switch thumb moves rather than
+  swapping symbol — so an off-glyph token would have had no reader. Switch
+  needs a `track` fill the pairs did not cover. Each token names the glyph
+  the recipe actually draws.
 
 Rejected alternatives: a packaged core theme primitive with a
 `createThemeContext` factory (a pub-sub plus deep-merge is not difficult

--- a/docs/foundation.md
+++ b/docs/foundation.md
@@ -118,11 +118,19 @@ The starter catalog provides `core/*`, `react/*`, and `solid/*` items for:
 - Badge
 - Toggle
 - ToggleGroup
+- Theme (token contract, store, and terminal default read by every recipe)
 
-The copied file belongs to your application. Its palette, density, symbols,
-labels, intent variants, native OpenTUI properties, and component assembly are
-starter choices rather than package APIs. Edit them directly or use them as
-the basis of another registry.
+Framework-neutral preset themes (`theme-cobalt-deep`, `theme-ascii`) install
+as `themes/<name>.ts` partial overrides of your theme file.
+
+The copied file belongs to your application. Recipes read palette, density,
+and symbol choices as tokens from the consumer-owned theme file installed
+beside them (every recipe declares the theme item in `registryDependencies`);
+labels, intent variants, native OpenTUI properties, and component assembly
+live in each recipe. All of it is starter source rather than package API —
+edit it directly or use it as the basis of another registry. There is no
+packaged theme runtime; see ADR
+[0006](adr/0006-theming-ships-as-registry-source.md).
 
 Primitive package upgrades deliver behavior fixes. Recipe updates are optional
 source integrations. Review upstream recipe changes without discarding local

--- a/docs/foundation.md
+++ b/docs/foundation.md
@@ -120,8 +120,9 @@ The starter catalog provides `core/*`, `react/*`, and `solid/*` items for:
 - ToggleGroup
 - Theme (token contract, store, and terminal default read by every recipe)
 
-Framework-neutral preset themes (`theme-cobalt-deep`, `theme-ascii`) install
-as `themes/<name>.ts` partial overrides of your theme file.
+Framework-neutral preset themes (`theme-cobalt-deep`, `theme-ascii`,
+`theme-catppuccin`, `theme-gruvbox`, `theme-rosepine`) install as
+`themes/<name>.ts` partial overrides of your theme file.
 
 The copied file belongs to your application. Recipes read palette, density,
 and symbol choices as tokens from the consumer-owned theme file installed

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
     "changeset:status": "changeset status",
     "validate:release-scope": "node scripts/validate-foundation-release.mjs",
     "validate:foundation": "pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm validate:packages:built && pnpm validate:registry:built && pnpm validate:release-scope",
-    "create": "./scripts/create-package.sh"
+    "create": "./scripts/create-package.sh",
+    "fixtures:setup": "node fixtures/setup.mjs",
+    "fixtures:dev": "pnpm --dir fixtures/demo dev"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.5",

--- a/registry.json
+++ b/registry.json
@@ -765,6 +765,7 @@
       "title": "Cobalt Deep Theme",
       "description": "Truecolor tuiparts.sh brand preset applied as a partial override of the installed theme contract.",
       "dependencies": [],
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"],
       "files": [
         {
           "path": "registry/theme/themes/cobalt-deep.ts",
@@ -785,6 +786,7 @@
       "title": "ASCII Theme",
       "description": "ASCII-glyph preset for fonts and terminals without Unicode coverage, applied as a partial override.",
       "dependencies": [],
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"],
       "files": [
         {
           "path": "registry/theme/themes/ascii.ts",
@@ -805,6 +807,7 @@
       "title": "Catppuccin Theme",
       "description": "Catppuccin Mocha/Latte.",
       "dependencies": [],
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"],
       "files": [
         {
           "path": "registry/theme/themes/catppuccin.ts",
@@ -825,6 +828,7 @@
       "title": "Gruvbox Theme",
       "description": "Gruvbox dark/light.",
       "dependencies": [],
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"],
       "files": [
         {
           "path": "registry/theme/themes/gruvbox.ts",
@@ -845,6 +849,7 @@
       "title": "Rosé Pine Theme",
       "description": "Rosé Pine/Dawn.",
       "dependencies": [],
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"],
       "files": [
         {
           "path": "registry/theme/themes/rosepine.ts",

--- a/registry.json
+++ b/registry.json
@@ -21,7 +21,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"]
     },
     {
       "name": "react/checkbox",
@@ -48,7 +49,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/react/theme.json"]
     },
     {
       "name": "solid/checkbox",
@@ -74,7 +76,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/solid/theme.json"]
     },
     {
       "name": "core/switch",
@@ -94,7 +97,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"]
     },
     {
       "name": "react/switch",
@@ -121,7 +125,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/react/theme.json"]
     },
     {
       "name": "solid/switch",
@@ -147,7 +152,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/solid/theme.json"]
     },
     {
       "name": "core/button",
@@ -167,7 +173,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"]
     },
     {
       "name": "react/button",
@@ -194,7 +201,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/react/theme.json"]
     },
     {
       "name": "solid/button",
@@ -220,7 +228,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/solid/theme.json"]
     },
     {
       "name": "core/badge",
@@ -240,7 +249,8 @@
         "primitiveStatus": "recipe",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"]
     },
     {
       "name": "react/badge",
@@ -265,7 +275,8 @@
         "primitiveStatus": "recipe",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/react/theme.json"]
     },
     {
       "name": "solid/badge",
@@ -289,7 +300,8 @@
         "primitiveStatus": "recipe",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/solid/theme.json"]
     },
     {
       "name": "core/radio-group",
@@ -309,7 +321,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"]
     },
     {
       "name": "react/radio-group",
@@ -336,7 +349,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/react/theme.json"]
     },
     {
       "name": "solid/radio-group",
@@ -362,7 +376,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/solid/theme.json"]
     },
     {
       "name": "core/input",
@@ -383,7 +398,8 @@
         "primitiveStatus": "tracer",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"]
     },
     {
       "name": "react/input",
@@ -411,7 +427,8 @@
         "primitiveStatus": "tracer",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/react/theme.json"]
     },
     {
       "name": "solid/input",
@@ -438,7 +455,8 @@
         "primitiveStatus": "tracer",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/solid/theme.json"]
     },
     {
       "name": "core/dialog",
@@ -456,7 +474,8 @@
       "meta": {
         "framework": "core",
         "primitiveStatus": "tracer"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"]
     },
     {
       "name": "react/dialog",
@@ -481,7 +500,8 @@
       "meta": {
         "framework": "react",
         "primitiveStatus": "tracer"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/react/theme.json"]
     },
     {
       "name": "solid/dialog",
@@ -505,7 +525,8 @@
       "meta": {
         "framework": "solid",
         "primitiveStatus": "tracer"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/solid/theme.json"]
     },
     {
       "name": "core/toggle",
@@ -525,7 +546,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"]
     },
     {
       "name": "react/toggle",
@@ -552,7 +574,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/react/theme.json"]
     },
     {
       "name": "solid/toggle",
@@ -578,7 +601,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/solid/theme.json"]
     },
     {
       "name": "core/toggle-group",
@@ -598,7 +622,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"]
     },
     {
       "name": "react/toggle-group",
@@ -625,7 +650,8 @@
         "primitiveStatus": "foundation",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
-      }
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/react/theme.json"]
     },
     {
       "name": "solid/toggle-group",
@@ -649,6 +675,186 @@
       "meta": {
         "framework": "solid",
         "primitiveStatus": "foundation",
+        "sourceOwnership": "consumer",
+        "updateStrategy": "shadcn-diff"
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/solid/theme.json"]
+    },
+    {
+      "name": "core/theme",
+      "type": "registry:ui",
+      "title": "Theme (Core)",
+      "description": "Editable imperative theme contract, store, and terminal default read by every tuiparts.sh recipe.",
+      "dependencies": ["@opentui/core@^0.4.3"],
+      "files": [
+        {
+          "path": "registry/theme/theme.ts",
+          "type": "registry:file",
+          "target": "components/ui/theme.ts"
+        }
+      ],
+      "meta": {
+        "framework": "core",
+        "primitiveStatus": "recipe",
+        "sourceOwnership": "consumer",
+        "updateStrategy": "shadcn-diff"
+      }
+    },
+    {
+      "name": "react/theme",
+      "type": "registry:ui",
+      "title": "Theme (React)",
+      "description": "Editable React theme contract, store, and terminal default read by every tuiparts.sh recipe.",
+      "dependencies": [
+        "@opentui/core@^0.4.3",
+        "@opentui/react@^0.4.3",
+        "react@^19.2.0"
+      ],
+      "devDependencies": ["@types/react@^19.2.0"],
+      "files": [
+        {
+          "path": "registry/theme/theme.ts",
+          "type": "registry:file",
+          "target": "components/ui/theme.ts"
+        },
+        {
+          "path": "registry/theme/react.tsx",
+          "type": "registry:file",
+          "target": "components/ui/use-theme.tsx"
+        }
+      ],
+      "meta": {
+        "framework": "react",
+        "primitiveStatus": "recipe",
+        "sourceOwnership": "consumer",
+        "updateStrategy": "shadcn-diff"
+      }
+    },
+    {
+      "name": "solid/theme",
+      "type": "registry:ui",
+      "title": "Theme (Solid)",
+      "description": "Editable Solid theme contract, store, and terminal default read by every tuiparts.sh recipe.",
+      "dependencies": [
+        "@opentui/core@^0.4.3",
+        "@opentui/solid@^0.4.3",
+        "solid-js@1.9.12"
+      ],
+      "files": [
+        {
+          "path": "registry/theme/theme.ts",
+          "type": "registry:file",
+          "target": "components/ui/theme.ts"
+        },
+        {
+          "path": "registry/theme/solid.tsx",
+          "type": "registry:file",
+          "target": "components/ui/use-theme.tsx"
+        }
+      ],
+      "meta": {
+        "framework": "solid",
+        "primitiveStatus": "recipe",
+        "sourceOwnership": "consumer",
+        "updateStrategy": "shadcn-diff"
+      }
+    },
+    {
+      "name": "theme-cobalt-deep",
+      "type": "registry:ui",
+      "title": "Cobalt Deep Theme",
+      "description": "Truecolor tuiparts.sh brand preset applied as a partial override of the installed theme contract.",
+      "dependencies": [],
+      "files": [
+        {
+          "path": "registry/theme/themes/cobalt-deep.ts",
+          "type": "registry:file",
+          "target": "themes/cobalt-deep.ts"
+        }
+      ],
+      "meta": {
+        "framework": "neutral",
+        "primitiveStatus": "recipe",
+        "sourceOwnership": "consumer",
+        "updateStrategy": "shadcn-diff"
+      }
+    },
+    {
+      "name": "theme-ascii",
+      "type": "registry:ui",
+      "title": "ASCII Theme",
+      "description": "ASCII-glyph preset for fonts and terminals without Unicode coverage, applied as a partial override.",
+      "dependencies": [],
+      "files": [
+        {
+          "path": "registry/theme/themes/ascii.ts",
+          "type": "registry:file",
+          "target": "themes/ascii.ts"
+        }
+      ],
+      "meta": {
+        "framework": "neutral",
+        "primitiveStatus": "recipe",
+        "sourceOwnership": "consumer",
+        "updateStrategy": "shadcn-diff"
+      }
+    },
+    {
+      "name": "theme-catppuccin",
+      "type": "registry:ui",
+      "title": "Catppuccin Theme",
+      "description": "Catppuccin Mocha/Latte.",
+      "dependencies": [],
+      "files": [
+        {
+          "path": "registry/theme/themes/catppuccin.ts",
+          "type": "registry:file",
+          "target": "themes/catppuccin.ts"
+        }
+      ],
+      "meta": {
+        "framework": "neutral",
+        "primitiveStatus": "recipe",
+        "sourceOwnership": "consumer",
+        "updateStrategy": "shadcn-diff"
+      }
+    },
+    {
+      "name": "theme-gruvbox",
+      "type": "registry:ui",
+      "title": "Gruvbox Theme",
+      "description": "Gruvbox dark/light.",
+      "dependencies": [],
+      "files": [
+        {
+          "path": "registry/theme/themes/gruvbox.ts",
+          "type": "registry:file",
+          "target": "themes/gruvbox.ts"
+        }
+      ],
+      "meta": {
+        "framework": "neutral",
+        "primitiveStatus": "recipe",
+        "sourceOwnership": "consumer",
+        "updateStrategy": "shadcn-diff"
+      }
+    },
+    {
+      "name": "theme-rosepine",
+      "type": "registry:ui",
+      "title": "Rosé Pine Theme",
+      "description": "Rosé Pine/Dawn.",
+      "dependencies": [],
+      "files": [
+        {
+          "path": "registry/theme/themes/rosepine.ts",
+          "type": "registry:file",
+          "target": "themes/rosepine.ts"
+        }
+      ],
+      "meta": {
+        "framework": "neutral",
+        "primitiveStatus": "recipe",
         "sourceOwnership": "consumer",
         "updateStrategy": "shadcn-diff"
       }

--- a/registry/README.md
+++ b/registry/README.md
@@ -22,6 +22,12 @@ Each foundation recipe is available as `core/<name>`, `react/<name>`, and
 | Badge | None; presentation-only recipe | `Badge` |
 | Toggle | Standalone pressed-state primitive | `Toggle` |
 | ToggleGroup/Toggle | Single or multiple selection and roving focus | `ToggleGroup`, `ToggleGroupItem` |
+| Theme | None; consumer-owned token contract and store | `Tokens`, `theme`, `createThemeStore`, `tint` (+ `useTheme` in React/Solid) |
+
+Framework-neutral preset themes are additionally available as `theme-<name>`
+(currently `theme-cobalt-deep`, `theme-ascii`, `theme-catppuccin`,
+`theme-gruvbox`, and `theme-rosepine`); they install to `themes/<name>.ts`
+and serve one file to all three adapters.
 
 React and Solid recipes expose the same installed names and props where their
 runtime semantics permit. Core recipes expose equivalent imperative factory
@@ -93,6 +99,36 @@ Review the diff and merge useful upstream changes into the consumer-owned file.
 Use `--overwrite` only when intentionally discarding local edits. Ordinary
 updates must never rely on unattended overwrite.
 
+## Theming
+
+Every recipe reads its colors, glyphs, and density from the consumer-owned
+theme file rather than hard-coding literals. Recipe items declare their
+adapter's `theme` item in `registryDependencies`, so installing any recipe
+also installs `components/ui/theme.ts` (plus a small
+`components/ui/use-theme.tsx` binding in React and Solid) — the terminal
+analog of `globals.css` plus `lib/utils.ts`.
+
+The installed theme file contains the whole mechanism: the `Tokens` contract,
+a small subscription store, and a default theme built from ANSI-indexed
+colors so apps inherit the terminal user's own palette and transparency.
+There is no packaged theme runtime (see ADR 0006). The lifecycle is:
+
+- **Customize** by editing the file: change default tokens, or extend the
+  `Tokens` interface with app-specific tokens that flow through the same
+  pipeline.
+- **Add presets** with `shadcn add theme-<name>`, then register them in one
+  line (`themes: { "cobalt-deep": cobaltDeep }`). Presets are
+  `DeepPartial<Tokens>` overrides merged over the consumer's base: missing
+  keys fall back, and consumer token extensions never break a preset install.
+- **Switch and adapt** at runtime with `theme.setActive(name)` and
+  `theme.setMode("system" | "dark" | "light")`; `theme.follow(renderer)`
+  keeps system mode in sync with the terminal's live light/dark signal.
+  Persisting the choice or discovering user-supplied theme files are
+  consumer-side patterns built on `theme.subscribe` and `theme.register`;
+  the registry ships neither.
+- **Update** the theme file like any recipe, through the shadcn diff
+  workflow.
+
 ## Primitive Upgrades Versus Recipe Updates
 
 Primitive packages own behavior, state, focus, keyboard and pointer handling,
@@ -106,17 +142,22 @@ shadcn's diff workflow.
 
 ## Consumer-Owned Presentation
 
-Starter palettes, density choices, labels, marks, and symbol sets live directly
-in the installed files. They are examples that consumers can edit or replace,
-not package APIs or dependencies on a hidden theme runtime.
+Starter palettes, density choices, and symbol sets live in the consumer-owned
+theme file; recipes read them as tokens from that sibling installed source,
+and labels plus per-instance marks stay directly in each recipe. All of it is
+example source that consumers edit or replace, not package APIs or
+dependencies on a hidden theme runtime.
 
 ## Verification
 
 `pnpm validate:registry` verifies the catalog's dependencies, lifecycle
 metadata, and matching React/Solid vocabulary. It builds every registry item
-with the pinned official shadcn CLI, installs all 27 items into isolated strict
-consumers with bounded concurrency, type-checks them, and runs their runtime
-smokes. React Checkbox additionally applies a local edit, creates a newer
+with the pinned official shadcn CLI, installs every adapter item into an
+isolated strict consumer with bounded concurrency (30 consumers; the
+framework-neutral preset items install and byte-compare inside the three
+theme consumers, whose smokes exercise them), resolves each recipe's theme
+`registryDependencies` from the locally built registry, type-checks
+everything, and runs the runtime smokes. React Checkbox additionally applies a local edit, creates a newer
 upstream payload, verifies `--diff` shows both changes, and proves ordinary
 `add` does not overwrite the local source; that installer behavior is
 framework-independent.

--- a/registry/badge/core.ts
+++ b/registry/badge/core.ts
@@ -5,6 +5,7 @@ import {
   type TextOptions,
   TextRenderable,
 } from "@opentui/core";
+import { type Tokens, theme } from "./theme";
 
 export type BadgeIntent = "danger" | "neutral" | "success" | "warning";
 export type BadgeSize = "compact" | "comfortable";
@@ -16,37 +17,64 @@ export interface BadgeOptions extends BoxOptions {
   size?: BadgeSize;
 }
 
-const palettes = {
-  danger: { background: "#991B1B", foreground: "#FEF2F2" },
-  neutral: { background: "#404040", foreground: "#F5F5F5" },
-  success: { background: "#166534", foreground: "#F0FDF4" },
-  warning: { background: "#854D0E", foreground: "#FFFBEB" },
-} as const;
+const palettes = (colors: Tokens["colors"]) => ({
+  danger: {
+    background: colors.destructive,
+    foreground: colors.destructiveForeground,
+  },
+  neutral: { background: colors.surface, foreground: colors.foreground },
+  success: { background: colors.success, foreground: colors.successForeground },
+  warning: {
+    background: colors.warning,
+    foreground: colors.warningForeground,
+  },
+});
+
+class BadgeRecipeRenderable extends BoxRenderable {
+  private readonly unsubscribeTheme: () => void;
+
+  constructor(ctx: RenderContext, options: BadgeOptions) {
+    const {
+      intent = "neutral",
+      label,
+      labelOptions,
+      size = "compact",
+      ...rootOptions
+    } = options;
+    const tokens = theme.get();
+    super(ctx, {
+      paddingX:
+        size === "comfortable"
+          ? tokens.density.comfortablePaddingX
+          : tokens.density.paddingX,
+      ...rootOptions,
+    });
+    const text = new TextRenderable(ctx, {
+      content: label,
+      ...labelOptions,
+    });
+    this.add(text);
+
+    const applyStyle = (tokens: Readonly<Tokens>) => {
+      const palette = palettes(tokens.colors)[intent];
+      if (rootOptions.backgroundColor === undefined)
+        this.backgroundColor = palette.background;
+      if (labelOptions?.fg === undefined) text.fg = palette.foreground;
+    };
+    applyStyle(tokens);
+    this.unsubscribeTheme = theme.subscribe(() => applyStyle(theme.get()));
+  }
+
+  override destroy(): void {
+    this.unsubscribeTheme();
+    super.destroy();
+  }
+}
 
 /** Consumer-owned imperative recipe composed from ordinary OpenTUI Renderables. */
 export function createBadge(
   ctx: RenderContext,
   options: BadgeOptions,
 ): BoxRenderable {
-  const {
-    intent = "neutral",
-    label,
-    labelOptions,
-    size = "compact",
-    ...rootOptions
-  } = options;
-  const palette = palettes[intent];
-  const root = new BoxRenderable(ctx, {
-    backgroundColor: palette.background,
-    paddingX: size === "comfortable" ? 2 : 1,
-    ...rootOptions,
-  });
-  root.add(
-    new TextRenderable(ctx, {
-      content: label,
-      fg: palette.foreground,
-      ...labelOptions,
-    }),
-  );
-  return root;
+  return new BadgeRecipeRenderable(ctx, options);
 }

--- a/registry/badge/core.ts
+++ b/registry/badge/core.ts
@@ -17,7 +17,7 @@ export interface BadgeOptions extends BoxOptions {
   size?: BadgeSize;
 }
 
-const palettes = (colors: Tokens["colors"]) => ({
+const paletteFor = (colors: Tokens["colors"]) => ({
   danger: {
     background: colors.destructive,
     foreground: colors.destructiveForeground,
@@ -56,7 +56,7 @@ class BadgeRecipeRenderable extends BoxRenderable {
     this.add(text);
 
     const applyStyle = (tokens: Readonly<Tokens>) => {
-      const palette = palettes(tokens.colors)[intent];
+      const palette = paletteFor(tokens.colors)[intent];
       if (rootOptions.backgroundColor === undefined)
         this.backgroundColor = palette.background;
       if (labelOptions?.fg === undefined) text.fg = palette.foreground;

--- a/registry/badge/react.tsx
+++ b/registry/badge/react.tsx
@@ -1,6 +1,8 @@
 /** @jsxImportSource @opentui/react */
 
 import type { BoxOptions, TextOptions } from "@opentui/core";
+import type { Tokens } from "./theme";
+import { useTheme } from "./use-theme";
 
 export type BadgeIntent = "danger" | "neutral" | "success" | "warning";
 export type BadgeSize = "compact" | "comfortable";
@@ -12,12 +14,18 @@ export interface BadgeProps extends BoxOptions {
   size?: BadgeSize;
 }
 
-const palettes = {
-  danger: { background: "#991B1B", foreground: "#FEF2F2" },
-  neutral: { background: "#404040", foreground: "#F5F5F5" },
-  success: { background: "#166534", foreground: "#F0FDF4" },
-  warning: { background: "#854D0E", foreground: "#FFFBEB" },
-} as const;
+const palettes = (colors: Tokens["colors"]) => ({
+  danger: {
+    background: colors.destructive,
+    foreground: colors.destructiveForeground,
+  },
+  neutral: { background: colors.surface, foreground: colors.foreground },
+  success: { background: colors.success, foreground: colors.successForeground },
+  warning: {
+    background: colors.warning,
+    foreground: colors.warningForeground,
+  },
+});
 
 /** Consumer-owned React recipe composed from ordinary OpenTUI elements. */
 export function Badge({
@@ -27,12 +35,17 @@ export function Badge({
   size = "compact",
   ...root
 }: BadgeProps) {
-  const palette = palettes[intent];
+  const tokens = useTheme();
+  const palette = palettes(tokens.colors)[intent];
 
   return (
     <box
       backgroundColor={palette.background}
-      paddingX={size === "comfortable" ? 2 : 1}
+      paddingX={
+        size === "comfortable"
+          ? tokens.density.comfortablePaddingX
+          : tokens.density.paddingX
+      }
       {...root}
     >
       <text content={label} fg={palette.foreground} {...labelOptions} />

--- a/registry/badge/react.tsx
+++ b/registry/badge/react.tsx
@@ -14,7 +14,7 @@ export interface BadgeProps extends BoxOptions {
   size?: BadgeSize;
 }
 
-const palettes = (colors: Tokens["colors"]) => ({
+const paletteFor = (colors: Tokens["colors"]) => ({
   danger: {
     background: colors.destructive,
     foreground: colors.destructiveForeground,
@@ -36,7 +36,7 @@ export function Badge({
   ...root
 }: BadgeProps) {
   const tokens = useTheme();
-  const palette = palettes(tokens.colors)[intent];
+  const palette = paletteFor(tokens.colors)[intent];
 
   return (
     <box

--- a/registry/badge/smoke/core.test.ts
+++ b/registry/badge/smoke/core.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import type { TextRenderable } from "@opentui/core";
+import { parseColor, type TextRenderable } from "@opentui/core";
 import {
   createTestRenderer,
   type TestRendererSetup,
 } from "@opentui/core/testing";
 import { createBadge } from "./components/ui/badge";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -32,5 +33,38 @@ describe("installed Core Badge recipe", () => {
     expect(badge.backgroundColor.toInts()).toEqual([18, 52, 86, 255]);
     const label = badge.getChildren()[0] as TextRenderable;
     expect(label.fg.toInts()).toEqual([171, 205, 239, 255]);
+  });
+
+  it("restyles from the theme store on theme switch", async () => {
+    theme.register("smoke", {
+      tokens: {
+        colors: {
+          surface: "#123456",
+          foreground: "#654321",
+          warning: "#ABCDEF",
+          warningForeground: "#FEDCBA",
+        },
+      },
+    });
+    setup = await createTestRenderer({ width: 30, height: 3 });
+    const badge = createBadge(setup.renderer, { label: "Theme" });
+    const alert = createBadge(setup.renderer, {
+      intent: "warning",
+      label: "Warn",
+    });
+    setup.renderer.root.add(badge);
+    setup.renderer.root.add(alert);
+    await setup.renderOnce();
+
+    theme.setActive("smoke");
+    expect(badge.backgroundColor.equals(parseColor("#123456"))).toBe(true);
+    const label = badge.getChildren()[0] as TextRenderable;
+    expect(label.fg.equals(parseColor("#654321"))).toBe(true);
+    expect(alert.backgroundColor.equals(parseColor("#ABCDEF"))).toBe(true);
+    const alertLabel = alert.getChildren()[0] as TextRenderable;
+    expect(alertLabel.fg.equals(parseColor("#FEDCBA"))).toBe(true);
+
+    theme.setActive("terminal");
+    expect(badge.backgroundColor.equals(parseColor("#123456"))).toBe(false);
   });
 });

--- a/registry/badge/smoke/react.test.tsx
+++ b/registry/badge/smoke/react.test.tsx
@@ -1,11 +1,16 @@
 /** @jsxImportSource @opentui/react */
 
 import { afterEach, expect, test } from "bun:test";
-import type { BoxRenderable, TextRenderable } from "@opentui/core";
+import {
+  type BoxRenderable,
+  parseColor,
+  type TextRenderable,
+} from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import { act } from "react";
 import { Badge } from "./components/ui/badge";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -37,4 +42,27 @@ test("installed React Badge recipe owns presentation and accepts native override
   );
   expect(badge.backgroundColor.toInts()).toEqual([18, 52, 86, 255]);
   expect(label.fg.toInts()).toEqual([171, 205, 239, 255]);
+});
+
+test("restyles the rendered badge on theme switch", async () => {
+  theme.register("smoke", { tokens: { colors: { surface: "#123456" } } });
+  setup = await testRender(<Badge id="themed" label="Theme" />, {
+    width: 30,
+    height: 3,
+  });
+  const badge = setup.renderer.root.findDescendantById(
+    "themed",
+  ) as BoxRenderable;
+
+  await act(async () => {
+    theme.setActive("smoke");
+  });
+  await setup.waitFor(() =>
+    badge.backgroundColor.equals(parseColor("#123456")),
+  );
+
+  expect(setup.renderer.root.findDescendantById("themed")).toBe(badge);
+  await act(async () => {
+    theme.setActive("terminal");
+  });
 });

--- a/registry/badge/smoke/solid.test.tsx
+++ b/registry/badge/smoke/solid.test.tsx
@@ -1,10 +1,15 @@
 /** @jsxImportSource @opentui/solid */
 
 import { afterEach, describe, expect, it } from "bun:test";
-import type { BoxRenderable, TextRenderable } from "@opentui/core";
+import {
+  type BoxRenderable,
+  parseColor,
+  type TextRenderable,
+} from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/solid";
 import { Badge } from "./components/ui/badge";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -39,5 +44,24 @@ describe("installed Solid Badge recipe", () => {
     );
     expect(badge.backgroundColor.toInts()).toEqual([18, 52, 86, 255]);
     expect(label.fg.toInts()).toEqual([171, 205, 239, 255]);
+  });
+
+  it("restyles the rendered badge on theme switch", async () => {
+    theme.register("smoke", { tokens: { colors: { surface: "#123456" } } });
+    setup = await testRender(() => <Badge id="themed" label="Theme" />, {
+      width: 30,
+      height: 3,
+    });
+    const badge = setup.renderer.root.findDescendantById(
+      "themed",
+    ) as BoxRenderable;
+
+    theme.setActive("smoke");
+    await setup.waitFor(() =>
+      badge.backgroundColor.equals(parseColor("#123456")),
+    );
+
+    expect(setup.renderer.root.findDescendantById("themed")).toBe(badge);
+    theme.setActive("terminal");
   });
 });

--- a/registry/badge/solid.tsx
+++ b/registry/badge/solid.tsx
@@ -15,7 +15,7 @@ export interface BadgeProps extends BoxOptions {
   size?: BadgeSize;
 }
 
-const palettes = (colors: Tokens["colors"]) => ({
+const paletteFor = (colors: Tokens["colors"]) => ({
   danger: {
     background: colors.destructive,
     foreground: colors.destructiveForeground,
@@ -37,7 +37,7 @@ export function Badge(props: BadgeProps) {
     "size",
   ]);
   const tokens = useTheme();
-  const palette = () => palettes(tokens().colors)[recipe.intent ?? "neutral"];
+  const palette = () => paletteFor(tokens().colors)[recipe.intent ?? "neutral"];
 
   return (
     <box

--- a/registry/badge/solid.tsx
+++ b/registry/badge/solid.tsx
@@ -2,6 +2,8 @@
 
 import type { BoxOptions, TextOptions } from "@opentui/core";
 import { splitProps } from "solid-js";
+import type { Tokens } from "./theme";
+import { useTheme } from "./use-theme";
 
 export type BadgeIntent = "danger" | "neutral" | "success" | "warning";
 export type BadgeSize = "compact" | "comfortable";
@@ -13,12 +15,18 @@ export interface BadgeProps extends BoxOptions {
   size?: BadgeSize;
 }
 
-const palettes = {
-  danger: { background: "#991B1B", foreground: "#FEF2F2" },
-  neutral: { background: "#404040", foreground: "#F5F5F5" },
-  success: { background: "#166534", foreground: "#F0FDF4" },
-  warning: { background: "#854D0E", foreground: "#FFFBEB" },
-} as const;
+const palettes = (colors: Tokens["colors"]) => ({
+  danger: {
+    background: colors.destructive,
+    foreground: colors.destructiveForeground,
+  },
+  neutral: { background: colors.surface, foreground: colors.foreground },
+  success: { background: colors.success, foreground: colors.successForeground },
+  warning: {
+    background: colors.warning,
+    foreground: colors.warningForeground,
+  },
+});
 
 /** Consumer-owned Solid recipe composed from ordinary OpenTUI elements. */
 export function Badge(props: BadgeProps) {
@@ -28,12 +36,17 @@ export function Badge(props: BadgeProps) {
     "labelOptions",
     "size",
   ]);
-  const palette = () => palettes[recipe.intent ?? "neutral"];
+  const tokens = useTheme();
+  const palette = () => palettes(tokens().colors)[recipe.intent ?? "neutral"];
 
   return (
     <box
       backgroundColor={palette().background}
-      paddingX={recipe.size === "comfortable" ? 2 : 1}
+      paddingX={
+        recipe.size === "comfortable"
+          ? tokens().density.comfortablePaddingX
+          : tokens().density.paddingX
+      }
       {...root}
     >
       <text

--- a/registry/button/core.ts
+++ b/registry/button/core.ts
@@ -22,8 +22,6 @@ class ButtonRecipeRenderable extends ButtonRenderable {
     const tokens = theme.get();
     const intent = options.intent ?? "primary";
     super(ctx, {
-      backgroundColor:
-        intent === "primary" ? tokens.colors.primary : tokens.colors.surface,
       disabled: options.disabled,
       onPress: options.onPress,
       paddingX:
@@ -31,10 +29,7 @@ class ButtonRecipeRenderable extends ButtonRenderable {
           ? tokens.density.comfortablePaddingX
           : tokens.density.paddingX,
     });
-    const label = new TextRenderable(ctx, {
-      content: options.label,
-      fg: tokens.colors.primaryForeground,
-    });
+    const label = new TextRenderable(ctx, { content: options.label });
     this.add(label);
 
     const applyStyle = (tokens: Readonly<Tokens>, state: ButtonState) => {

--- a/registry/button/core.ts
+++ b/registry/button/core.ts
@@ -4,6 +4,7 @@ import {
   ButtonRenderable,
   type ButtonState,
 } from "@tuiparts/core/button";
+import { type Tokens, theme, tint } from "./theme";
 
 export interface ButtonOptions {
   disabled?: boolean;
@@ -13,43 +14,56 @@ export interface ButtonOptions {
   size?: "compact" | "comfortable";
 }
 
-const backgrounds = {
-  neutral: "#404040",
-  primary: "#2563EB",
-} as const;
-
 class ButtonRecipeRenderable extends ButtonRenderable {
   private readonly unsubscribeRecipe: () => void;
+  private readonly unsubscribeTheme: () => void;
 
   constructor(ctx: RenderContext, options: ButtonOptions) {
+    const tokens = theme.get();
     const intent = options.intent ?? "primary";
     super(ctx, {
-      backgroundColor: backgrounds[intent],
+      backgroundColor:
+        intent === "primary" ? tokens.colors.primary : tokens.colors.surface,
       disabled: options.disabled,
       onPress: options.onPress,
-      paddingX: options.size === "comfortable" ? 2 : 1,
+      paddingX:
+        options.size === "comfortable"
+          ? tokens.density.comfortablePaddingX
+          : tokens.density.paddingX,
     });
     const label = new TextRenderable(ctx, {
       content: options.label,
-      fg: "#F5F5F5",
+      fg: tokens.colors.primaryForeground,
     });
     this.add(label);
 
-    const applyState = (state: ButtonState) => {
+    const applyStyle = (tokens: Readonly<Tokens>, state: ButtonState) => {
       this.backgroundColor = state.disabled
-        ? "#262626"
+        ? tokens.colors.disabled
         : state.pressed
-          ? "#1D4ED8"
+          ? tint(tokens.colors.focus, tokens.colors.foreground, 0.3)
           : state.focused
-            ? "#3B82F6"
-            : backgrounds[intent];
-      label.fg = state.disabled ? "#737373" : "#F5F5F5";
+            ? tokens.colors.focus
+            : intent === "primary"
+              ? tokens.colors.primary
+              : tokens.colors.surface;
+      label.fg = state.disabled
+        ? tokens.colors.disabledForeground
+        : intent === "primary"
+          ? tokens.colors.primaryForeground
+          : tokens.colors.foreground;
     };
-    applyState(this.getState());
-    this.unsubscribeRecipe = this.subscribe(applyState);
+    applyStyle(tokens, this.getState());
+    this.unsubscribeTheme = theme.subscribe(() =>
+      applyStyle(theme.get(), this.getState()),
+    );
+    this.unsubscribeRecipe = this.subscribe((state) =>
+      applyStyle(theme.get(), state),
+    );
   }
 
   override destroy(): void {
+    this.unsubscribeTheme();
     this.unsubscribeRecipe();
     super.destroy();
   }

--- a/registry/button/react.tsx
+++ b/registry/button/react.tsx
@@ -1,17 +1,14 @@
 /** @jsxImportSource @opentui/react */
 
 import { Button as ButtonPrimitive } from "@tuiparts/react/button";
+import { tint } from "./theme";
+import { useTheme } from "./use-theme";
 
 export interface ButtonProps extends Omit<ButtonPrimitive.Props, "children"> {
   intent?: "neutral" | "primary";
   label: string;
   size?: "compact" | "comfortable";
 }
-
-const backgrounds = {
-  neutral: "#404040",
-  primary: "#2563EB",
-} as const;
 
 /** Consumer-owned React recipe installed on packaged Button behavior. */
 export function Button({
@@ -21,6 +18,7 @@ export function Button({
   disabled,
   ...props
 }: ButtonProps) {
+  const tokens = useTheme();
   return (
     <ButtonPrimitive
       backgroundColor="transparent"
@@ -31,16 +29,31 @@ export function Button({
         <box
           backgroundColor={
             state.disabled
-              ? "#262626"
+              ? tokens.colors.disabled
               : state.pressed
-                ? "#1D4ED8"
+                ? tint(tokens.colors.focus, tokens.colors.foreground, 0.3)
                 : state.focused
-                  ? "#3B82F6"
-                  : backgrounds[intent]
+                  ? tokens.colors.focus
+                  : intent === "primary"
+                    ? tokens.colors.primary
+                    : tokens.colors.surface
           }
-          paddingX={size === "comfortable" ? 2 : 1}
+          paddingX={
+            size === "comfortable"
+              ? tokens.density.comfortablePaddingX
+              : tokens.density.paddingX
+          }
         >
-          <text content={label} fg={state.disabled ? "#737373" : "#F5F5F5"} />
+          <text
+            content={label}
+            fg={
+              state.disabled
+                ? tokens.colors.disabledForeground
+                : intent === "primary"
+                  ? tokens.colors.primaryForeground
+                  : tokens.colors.foreground
+            }
+          />
         </box>
       )}
     </ButtonPrimitive>

--- a/registry/button/smoke/core.test.ts
+++ b/registry/button/smoke/core.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { parseColor } from "@opentui/core";
 import {
   createTestRenderer,
   type TestRendererSetup,
 } from "@opentui/core/testing";
 import type { ButtonPressDetails } from "@tuiparts/core/button";
 import { createButton } from "./components/ui/button";
+import { theme, tint } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -46,5 +48,40 @@ describe("installed Core Button recipe", () => {
     button.press();
     expect(button.focused).toBe(false);
     expect(presses).toBe(0);
+  });
+
+  it("derives a pressed shade distinct from the focus color", async () => {
+    theme.register("smoke-pressed", {
+      tokens: { colors: { focus: "#0000FF", foreground: "#FFFFFF" } },
+    });
+    theme.setActive("smoke-pressed");
+    setup = await createTestRenderer({ width: 30, height: 3 });
+    const button = createButton(setup.renderer, { label: "Press" });
+    setup.renderer.root.add(button);
+
+    button.focus();
+    expect(button.backgroundColor.equals(parseColor("#0000FF"))).toBe(true);
+
+    button.store.setPressed(true);
+    expect(button.backgroundColor.equals(tint("#0000FF", "#FFFFFF", 0.3))).toBe(
+      true,
+    );
+    expect(button.backgroundColor.equals(parseColor("#0000FF"))).toBe(false);
+
+    theme.setActive("terminal");
+  });
+
+  it("restyles from the theme store on theme switch", async () => {
+    theme.register("smoke", { tokens: { colors: { primary: "#123456" } } });
+    setup = await createTestRenderer({ width: 30, height: 3 });
+    const button = createButton(setup.renderer, { label: "Theme" });
+    setup.renderer.root.add(button);
+    await setup.renderOnce();
+
+    theme.setActive("smoke");
+    expect(button.backgroundColor.equals(parseColor("#123456"))).toBe(true);
+
+    theme.setActive("terminal");
+    expect(button.backgroundColor.equals(parseColor("#123456"))).toBe(false);
   });
 });

--- a/registry/button/smoke/react.test.tsx
+++ b/registry/button/smoke/react.test.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @opentui/react */
 
 import { afterEach, expect, test } from "bun:test";
+import { type BoxRenderable, parseColor } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import type {
@@ -9,6 +10,7 @@ import type {
 } from "@tuiparts/core/button";
 import { act } from "react";
 import { Button } from "./components/ui/button";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -50,4 +52,28 @@ test("installed React Button recipe runtime smoke", async () => {
   disabled.press();
   expect(presses).toEqual([{ source: "imperative" }]);
   expect(disabled.focused).toBe(false);
+});
+
+test("restyles rendered buttons on theme switch", async () => {
+  theme.register("smoke", { tokens: { colors: { primary: "#123456" } } });
+  setup = await testRender(<Button id="themed" label="Theme" />, {
+    width: 30,
+    height: 3,
+  });
+  const root = setup.renderer.root.findDescendantById(
+    "themed",
+  ) as ButtonRenderable;
+  const surface = root.getChildren()[0] as BoxRenderable;
+
+  await act(async () => {
+    theme.setActive("smoke");
+  });
+  await setup.waitFor(() =>
+    surface.backgroundColor.equals(parseColor("#123456")),
+  );
+
+  expect(setup.renderer.root.findDescendantById("themed")).toBe(root);
+  await act(async () => {
+    theme.setActive("terminal");
+  });
 });

--- a/registry/button/smoke/solid.test.tsx
+++ b/registry/button/smoke/solid.test.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @opentui/solid */
 
 import { afterEach, describe, expect, it } from "bun:test";
+import { type BoxRenderable, parseColor } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/solid";
 import type {
@@ -8,6 +9,7 @@ import type {
   ButtonRenderable,
 } from "@tuiparts/core/button";
 import { Button } from "./components/ui/button";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -52,5 +54,25 @@ describe("installed Solid Button recipe", () => {
     disabled.press();
     expect(presses).toEqual([{ source: "imperative" }]);
     expect(disabled.focused).toBe(false);
+  });
+
+  it("restyles rendered buttons on theme switch", async () => {
+    theme.register("smoke", { tokens: { colors: { primary: "#123456" } } });
+    setup = await testRender(() => <Button id="themed" label="Theme" />, {
+      width: 30,
+      height: 3,
+    });
+    const root = setup.renderer.root.findDescendantById(
+      "themed",
+    ) as ButtonRenderable;
+    const surface = root.getChildren()[0] as BoxRenderable;
+
+    theme.setActive("smoke");
+    await setup.waitFor(() =>
+      surface.backgroundColor.equals(parseColor("#123456")),
+    );
+
+    expect(setup.renderer.root.findDescendantById("themed")).toBe(root);
+    theme.setActive("terminal");
   });
 });

--- a/registry/button/solid.tsx
+++ b/registry/button/solid.tsx
@@ -2,17 +2,14 @@
 
 import { Button as ButtonPrimitive } from "@tuiparts/solid/button";
 import { splitProps } from "solid-js";
+import { tint } from "./theme";
+import { useTheme } from "./use-theme";
 
 export interface ButtonProps extends Omit<ButtonPrimitive.Props, "children"> {
   intent?: "neutral" | "primary";
   label: string;
   size?: "compact" | "comfortable";
 }
-
-const backgrounds = {
-  neutral: "#404040",
-  primary: "#2563EB",
-} as const;
 
 /** Consumer-owned Solid recipe installed on packaged Button behavior. */
 export function Button(props: ButtonProps) {
@@ -22,6 +19,7 @@ export function Button(props: ButtonProps) {
     "label",
     "size",
   ]);
+  const tokens = useTheme();
 
   return (
     <ButtonPrimitive
@@ -33,18 +31,30 @@ export function Button(props: ButtonProps) {
         <box
           backgroundColor={
             state.disabled
-              ? "#262626"
+              ? tokens().colors.disabled
               : state.pressed
-                ? "#1D4ED8"
+                ? tint(tokens().colors.focus, tokens().colors.foreground, 0.3)
                 : state.focused
-                  ? "#3B82F6"
-                  : backgrounds[recipe.intent ?? "primary"]
+                  ? tokens().colors.focus
+                  : (recipe.intent ?? "primary") === "primary"
+                    ? tokens().colors.primary
+                    : tokens().colors.surface
           }
-          paddingX={recipe.size === "comfortable" ? 2 : 1}
+          paddingX={
+            recipe.size === "comfortable"
+              ? tokens().density.comfortablePaddingX
+              : tokens().density.paddingX
+          }
         >
           <text
             content={recipe.label}
-            fg={state.disabled ? "#737373" : "#F5F5F5"}
+            fg={
+              state.disabled
+                ? tokens().colors.disabledForeground
+                : (recipe.intent ?? "primary") === "primary"
+                  ? tokens().colors.primaryForeground
+                  : tokens().colors.foreground
+            }
           />
         </box>
       )}

--- a/registry/checkbox/core.ts
+++ b/registry/checkbox/core.ts
@@ -7,6 +7,7 @@ import {
   CheckboxIndicatorRenderable,
   CheckboxRootRenderable,
 } from "@tuiparts/core/checkbox";
+import { type Tokens, theme } from "./theme";
 
 export interface CheckboxOptions {
   checked?: boolean;
@@ -18,37 +19,60 @@ export interface CheckboxOptions {
   onCheckedChange?: (checked: boolean) => void;
 }
 
+class CheckboxRecipeRenderable extends CheckboxRootRenderable {
+  private readonly unsubscribeTheme: () => void;
+
+  constructor(ctx: RenderContext, options: CheckboxOptions) {
+    const tokens = theme.get();
+    super(ctx, {
+      backgroundColor: "transparent",
+      checked: options.checked,
+      defaultChecked: options.defaultChecked,
+      disabled: options.disabled,
+      flexDirection: "row",
+      gap: 1,
+      onCheckedChange: options.onCheckedChange,
+    });
+    const markCell = new BoxRenderable(ctx, { width: 1 });
+    const indicator = new CheckboxIndicatorRenderable(ctx, {
+      store: this.store,
+    });
+    const mark = new TextRenderable(ctx, {
+      content: options.mark ?? tokens.glyphs.check,
+      fg: tokens.colors.primary,
+    });
+    indicator.add(mark);
+    markCell.add(indicator);
+    this.add(markCell);
+    const label = new TextRenderable(ctx, {
+      content: options.label,
+      fg: options.disabled
+        ? tokens.colors.disabledForeground
+        : tokens.colors.foreground,
+    });
+    this.add(label);
+
+    const applyStyle = (tokens: Readonly<Tokens>) => {
+      mark.content = options.mark ?? tokens.glyphs.check;
+      mark.fg = tokens.colors.primary;
+      label.fg = options.disabled
+        ? tokens.colors.disabledForeground
+        : tokens.colors.foreground;
+    };
+    applyStyle(tokens);
+    this.unsubscribeTheme = theme.subscribe(() => applyStyle(theme.get()));
+  }
+
+  override destroy(): void {
+    this.unsubscribeTheme();
+    super.destroy();
+  }
+}
+
 /** Consumer-owned imperative recipe using packaged Checkbox behavior. */
 export function createCheckbox(
   ctx: RenderContext,
   options: CheckboxOptions,
 ): CheckboxRootRenderable {
-  const root = new CheckboxRootRenderable(ctx, {
-    backgroundColor: "transparent",
-    checked: options.checked,
-    defaultChecked: options.defaultChecked,
-    disabled: options.disabled,
-    flexDirection: "row",
-    gap: 1,
-    onCheckedChange: options.onCheckedChange,
-  });
-  const markCell = new BoxRenderable(ctx, { width: 1 });
-  const indicator = new CheckboxIndicatorRenderable(ctx, {
-    store: root.store,
-  });
-  indicator.add(
-    new TextRenderable(ctx, {
-      content: options.mark ?? "✓",
-      fg: "#3B82F6",
-    }),
-  );
-  markCell.add(indicator);
-  root.add(markCell);
-  root.add(
-    new TextRenderable(ctx, {
-      content: options.label,
-      fg: options.disabled ? "#737373" : "#E5E5E5",
-    }),
-  );
-  return root;
+  return new CheckboxRecipeRenderable(ctx, options);
 }

--- a/registry/checkbox/react.tsx
+++ b/registry/checkbox/react.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @opentui/react */
 
-import { RGBA } from "@opentui/core";
 import { Checkbox as CheckboxPrimitive } from "@tuiparts/react/checkbox";
 import { useTheme } from "./use-theme";
 
@@ -22,7 +21,7 @@ export function Checkbox({
 }: CheckboxProps) {
   const tokens = useTheme();
   const markColor =
-    tone === "success" ? RGBA.fromIndex(2) : tokens.colors.primary;
+    tone === "success" ? tokens.colors.success : tokens.colors.primary;
 
   return (
     <CheckboxPrimitive.Root

--- a/registry/checkbox/react.tsx
+++ b/registry/checkbox/react.tsx
@@ -1,6 +1,8 @@
 /** @jsxImportSource @opentui/react */
 
+import { RGBA } from "@opentui/core";
 import { Checkbox as CheckboxPrimitive } from "@tuiparts/react/checkbox";
+import { useTheme } from "./use-theme";
 
 export interface CheckboxProps
   extends Omit<CheckboxPrimitive.Root.Props, "children"> {
@@ -13,12 +15,14 @@ export interface CheckboxProps
 /** Consumer-owned recipe installed on top of packaged primitive behavior. */
 export function Checkbox({
   label,
-  mark = "✓",
+  mark,
   tone = "accent",
   disabled,
   ...props
 }: CheckboxProps) {
-  const markColor = tone === "success" ? "#10B981" : "#3B82F6";
+  const tokens = useTheme();
+  const markColor =
+    tone === "success" ? RGBA.fromIndex(2) : tokens.colors.primary;
 
   return (
     <CheckboxPrimitive.Root
@@ -32,13 +36,17 @@ export function Checkbox({
         <>
           <box width={1}>
             <CheckboxPrimitive.Indicator>
-              <text content={mark} fg={markColor} />
+              <text content={mark ?? tokens.glyphs.check} fg={markColor} />
             </CheckboxPrimitive.Indicator>
           </box>
           <text
             content={label}
             fg={
-              state.disabled ? "#737373" : state.focused ? "#FFFFFF" : "#E5E5E5"
+              state.disabled
+                ? tokens.colors.disabledForeground
+                : state.focused
+                  ? tokens.colors.focus
+                  : tokens.colors.foreground
             }
           />
         </>

--- a/registry/checkbox/smoke/core.test.ts
+++ b/registry/checkbox/smoke/core.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
+  type BoxRenderable,
+  parseColor,
+  type TextRenderable,
+} from "@opentui/core";
+import {
   createTestRenderer,
   type TestRendererSetup,
 } from "@opentui/core/testing";
 import { createCheckbox } from "./components/ui/checkbox";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -79,5 +85,25 @@ describe("installed Core Checkbox recipe", () => {
   it("renders a consumer-owned mark", async () => {
     await render({ defaultChecked: true, label: "Custom", mark: "*" });
     expect(firstLine()).toBe("* Custom");
+  });
+
+  it("restyles from the theme store on theme switch", async () => {
+    theme.register("smoke", {
+      tokens: { colors: { primary: "#123456" }, glyphs: { check: "x" } },
+    });
+    const checkbox = await render({ defaultChecked: true, label: "Theme" });
+    expect(firstLine()).toBe("✓ Theme");
+
+    theme.setActive("smoke");
+    await setup?.renderOnce();
+    expect(firstLine()).toBe("x Theme");
+    const markCell = checkbox.getChildren()[0] as BoxRenderable;
+    const indicator = markCell.getChildren()[0] as BoxRenderable;
+    const mark = indicator.getChildren()[0] as TextRenderable;
+    expect(mark.fg.equals(parseColor("#123456"))).toBe(true);
+
+    theme.setActive("terminal");
+    await setup?.renderOnce();
+    expect(firstLine()).toBe("✓ Theme");
   });
 });

--- a/registry/checkbox/smoke/react.test.tsx
+++ b/registry/checkbox/smoke/react.test.tsx
@@ -7,6 +7,7 @@ import { testRender } from "@opentui/react/test-utils";
 import type { CheckboxRootRenderable } from "@tuiparts/core/checkbox";
 import { act, useState } from "react";
 import { Checkbox } from "./components/ui/checkbox";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -77,4 +78,26 @@ test("installed React Checkbox recipe runtime smoke", async () => {
   expect(disabledChanges).toBe(0);
 
   expect(text(root("custom-mark"))).toEqual(["x", "Custom mark"]);
+});
+
+test("restyles rendered checkboxes on theme switch", async () => {
+  theme.register("smoke", {
+    tokens: { colors: { primary: "#123456" }, glyphs: { check: "x" } },
+  });
+  setup = await testRender(
+    <Checkbox id="themed" label="Theme" defaultChecked />,
+    { width: 30, height: 3 },
+  );
+  const themed = root("themed");
+  expect(text(themed)).toEqual(["✓", "Theme"]);
+
+  await act(async () => {
+    theme.setActive("smoke");
+  });
+  await setup.waitFor(() => text(themed).join(" ") === "x Theme");
+
+  expect(setup.renderer.root.findDescendantById("themed")).toBe(themed);
+  await act(async () => {
+    theme.setActive("terminal");
+  });
 });

--- a/registry/checkbox/smoke/solid.test.tsx
+++ b/registry/checkbox/smoke/solid.test.tsx
@@ -7,6 +7,7 @@ import { testRender } from "@opentui/solid";
 import type { CheckboxRootRenderable } from "@tuiparts/core/checkbox";
 import { createSignal } from "solid-js";
 import { Checkbox } from "./components/ui/checkbox";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -106,5 +107,25 @@ describe("installed Solid Checkbox recipe", () => {
       "custom-mark",
     ) as CheckboxRootRenderable;
     expect(text(root)).toEqual(["x", "Custom mark"]);
+  });
+
+  it("restyles rendered checkboxes on theme switch", async () => {
+    theme.register("smoke", {
+      tokens: { colors: { primary: "#123456" }, glyphs: { check: "x" } },
+    });
+    setup = await testRender(
+      () => <Checkbox id="themed" label="Theme" defaultChecked />,
+      { width: 30, height: 3 },
+    );
+    const root = setup.renderer.root.findDescendantById(
+      "themed",
+    ) as CheckboxRootRenderable;
+    expect(text(root)).toEqual(["✓", "Theme"]);
+
+    theme.setActive("smoke");
+    await setup.waitFor(() => text(root).join(" ") === "x Theme");
+
+    expect(setup.renderer.root.findDescendantById("themed")).toBe(root);
+    theme.setActive("terminal");
   });
 });

--- a/registry/checkbox/solid.tsx
+++ b/registry/checkbox/solid.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @opentui/solid */
 
-import { RGBA } from "@opentui/core";
 import { Checkbox as CheckboxPrimitive } from "@tuiparts/solid/checkbox";
 import { splitProps } from "solid-js";
 import { useTheme } from "./use-theme";
@@ -23,7 +22,9 @@ export function Checkbox(props: CheckboxProps) {
   ]);
   const tokens = useTheme();
   const markColor = () =>
-    recipe.tone === "success" ? RGBA.fromIndex(2) : tokens().colors.primary;
+    recipe.tone === "success"
+      ? tokens().colors.success
+      : tokens().colors.primary;
 
   return (
     <CheckboxPrimitive.Root

--- a/registry/checkbox/solid.tsx
+++ b/registry/checkbox/solid.tsx
@@ -1,7 +1,9 @@
 /** @jsxImportSource @opentui/solid */
 
+import { RGBA } from "@opentui/core";
 import { Checkbox as CheckboxPrimitive } from "@tuiparts/solid/checkbox";
 import { splitProps } from "solid-js";
+import { useTheme } from "./use-theme";
 
 export interface CheckboxProps
   extends Omit<CheckboxPrimitive.Root.Props, "children"> {
@@ -19,7 +21,9 @@ export function Checkbox(props: CheckboxProps) {
     "tone",
     "disabled",
   ]);
-  const markColor = () => (recipe.tone === "success" ? "#10B981" : "#3B82F6");
+  const tokens = useTheme();
+  const markColor = () =>
+    recipe.tone === "success" ? RGBA.fromIndex(2) : tokens().colors.primary;
 
   return (
     <CheckboxPrimitive.Root
@@ -33,13 +37,20 @@ export function Checkbox(props: CheckboxProps) {
         <>
           <box width={1}>
             <CheckboxPrimitive.Indicator>
-              <text content={recipe.mark ?? "✓"} fg={markColor()} />
+              <text
+                content={recipe.mark ?? tokens().glyphs.check}
+                fg={markColor()}
+              />
             </CheckboxPrimitive.Indicator>
           </box>
           <text
             content={recipe.label}
             fg={
-              state.disabled ? "#737373" : state.focused ? "#FFFFFF" : "#E5E5E5"
+              state.disabled
+                ? tokens().colors.disabledForeground
+                : state.focused
+                  ? tokens().colors.focus
+                  : tokens().colors.foreground
             }
           />
         </>

--- a/registry/dialog/core.ts
+++ b/registry/dialog/core.ts
@@ -14,6 +14,7 @@ import {
   DialogTitleRenderable,
   DialogTriggerRenderable,
 } from "@tuiparts/core/dialog";
+import { type Tokens, theme, tint } from "./theme";
 
 /** Visual defaults only; the Dialog primitive retains all layer behavior. */
 export interface DialogOptions extends DialogRootOptions {
@@ -28,17 +29,31 @@ export interface DialogRecipe {
   popup: DialogPopupRenderable;
 }
 
+/** Applies themed styling now and on every change until `renderable` is destroyed. */
+function bindThemeStyle(
+  renderable: { destroy(): void },
+  applyStyle: (tokens: Readonly<Tokens>) => void,
+): void {
+  applyStyle(theme.get());
+  const unsubscribeTheme = theme.subscribe(() => applyStyle(theme.get()));
+  const destroy = renderable.destroy.bind(renderable);
+  renderable.destroy = () => {
+    unsubscribeTheme();
+    destroy();
+  };
+}
+
 /** Assemble an editable, terminal-wide Dialog layer from packaged Core parts. */
 export function createDialog(
   ctx: RenderContext,
   { width = "80%", ...options }: DialogOptions = {},
 ): DialogRecipe {
+  const tokens = theme.get();
   const root = new DialogRootRenderable(ctx, options);
   const trigger = new DialogTriggerRenderable(ctx, {
     store: root.store,
-    backgroundColor: "#262626",
-    paddingLeft: 1,
-    paddingRight: 1,
+    paddingLeft: tokens.density.paddingX,
+    paddingRight: tokens.density.paddingX,
   });
   const portal = new DialogPortalRenderable(ctx, {
     store: root.store,
@@ -53,22 +68,30 @@ export function createDialog(
     position: "absolute",
     width: "100%",
     height: "100%",
-    backgroundColor: "#000000",
   });
   const popup = new DialogPopupRenderable(ctx, {
     store: root.store,
     width,
     maxWidth: 56,
     flexDirection: "column",
-    backgroundColor: "#171717",
     border: true,
-    borderColor: "#737373",
-    paddingLeft: 1,
-    paddingRight: 1,
+    paddingLeft: tokens.density.paddingX,
+    paddingRight: tokens.density.paddingX,
   });
   portal.add(backdrop);
   portal.add(popup);
   root.add(trigger);
+  bindThemeStyle(root, (tokens) => {
+    trigger.backgroundColor = tokens.colors.surface;
+    backdrop.backgroundColor = tint(
+      tokens.colors.background,
+      tokens.colors.foreground,
+      0.25,
+    );
+    popup.backgroundColor = tokens.colors.surface;
+    popup.borderColor = tokens.colors.border;
+    popup.borderStyle = tokens.borders.style;
+  });
   return { root, trigger, portal, backdrop, popup };
 }
 
@@ -80,7 +103,9 @@ export function addDialogTitle(
   const title = new DialogTitleRenderable(ctx, {
     store: dialog.root.store,
     content,
-    fg: "#FFFFFF",
+  });
+  bindThemeStyle(title, (tokens) => {
+    title.fg = tokens.colors.foreground;
   });
   dialog.popup.add(title);
   return title;
@@ -94,7 +119,9 @@ export function addDialogDescription(
   const description = new DialogDescriptionRenderable(ctx, {
     store: dialog.root.store,
     content,
-    fg: "#A3A3A3",
+  });
+  bindThemeStyle(description, (tokens) => {
+    description.fg = tokens.colors.mutedForeground;
   });
   dialog.popup.add(description);
   return description;
@@ -106,13 +133,18 @@ export function addDialogClose(
   dialog: DialogRecipe,
   label = "× Close",
 ): DialogCloseRenderable {
+  const tokens = theme.get();
   const close = new DialogCloseRenderable(ctx, {
     store: dialog.root.store,
-    backgroundColor: "#262626",
-    paddingLeft: 1,
-    paddingRight: 1,
+    paddingLeft: tokens.density.paddingX,
+    paddingRight: tokens.density.paddingX,
   });
-  close.add(new TextRenderable(ctx, { content: label, fg: "#E5E5E5" }));
+  const text = new TextRenderable(ctx, { content: label });
+  close.add(text);
+  bindThemeStyle(close, (tokens) => {
+    close.backgroundColor = tokens.colors.surface;
+    text.fg = tokens.colors.foreground;
+  });
   dialog.popup.add(close);
   return close;
 }

--- a/registry/dialog/react.tsx
+++ b/registry/dialog/react.tsx
@@ -1,6 +1,8 @@
 /** @jsxImportSource @opentui/react */
 
 import { Dialog as DialogPrimitive } from "@tuiparts/react/dialog";
+import { tint } from "./theme";
+import { useTheme } from "./use-theme";
 
 /** Props for the consumer-owned Dialog root. */
 export interface DialogProps extends DialogPrimitive.Root.Props {}
@@ -17,11 +19,12 @@ export function Dialog(props: DialogProps) {
 
 /** Editable trigger presentation that retains the primitive Trigger ref. */
 export function DialogTrigger(props: DialogPrimitive.Trigger.Props) {
+  const tokens = useTheme();
   return (
     <DialogPrimitive.Trigger
-      backgroundColor="#262626"
-      paddingLeft={1}
-      paddingRight={1}
+      backgroundColor={tokens.colors.surface}
+      paddingLeft={tokens.density.paddingX}
+      paddingRight={tokens.density.paddingX}
       {...props}
     />
   );
@@ -29,10 +32,11 @@ export function DialogTrigger(props: DialogPrimitive.Trigger.Props) {
 
 /** Responsive Portal, Backdrop, and Popup composition for Dialog content. */
 export function DialogContent({
-  backdropColor = "#000000",
+  backdropColor,
   children,
   ...props
 }: DialogContentProps) {
+  const tokens = useTheme();
   return (
     <DialogPrimitive.Portal
       position="absolute"
@@ -45,17 +49,21 @@ export function DialogContent({
         position="absolute"
         width="100%"
         height="100%"
-        backgroundColor={backdropColor}
+        backgroundColor={
+          backdropColor ??
+          tint(tokens.colors.background, tokens.colors.foreground, 0.25)
+        }
       />
       <DialogPrimitive.Popup
         width="80%"
         maxWidth={56}
         flexDirection="column"
-        backgroundColor="#171717"
+        backgroundColor={tokens.colors.surface}
         border
-        borderColor="#737373"
-        paddingLeft={1}
-        paddingRight={1}
+        borderColor={tokens.colors.border}
+        borderStyle={tokens.borders.style}
+        paddingLeft={tokens.density.paddingX}
+        paddingRight={tokens.density.paddingX}
         {...props}
       >
         {children}
@@ -66,21 +74,29 @@ export function DialogContent({
 
 /** Editable semantic Dialog title. */
 export function DialogTitle(props: DialogPrimitive.Title.Props) {
-  return <DialogPrimitive.Title fg="#FFFFFF" {...props} />;
+  const tokens = useTheme();
+  return <DialogPrimitive.Title fg={tokens.colors.foreground} {...props} />;
 }
 
 /** Editable semantic Dialog description. */
 export function DialogDescription(props: DialogPrimitive.Description.Props) {
-  return <DialogPrimitive.Description fg="#A3A3A3" {...props} />;
+  const tokens = useTheme();
+  return (
+    <DialogPrimitive.Description
+      fg={tokens.colors.mutedForeground}
+      {...props}
+    />
+  );
 }
 
 /** Editable Dialog dismissal or action control. */
 export function DialogClose(props: DialogPrimitive.Close.Props) {
+  const tokens = useTheme();
   return (
     <DialogPrimitive.Close
-      backgroundColor="#262626"
-      paddingLeft={1}
-      paddingRight={1}
+      backgroundColor={tokens.colors.surface}
+      paddingLeft={tokens.density.paddingX}
+      paddingRight={tokens.density.paddingX}
       {...props}
     />
   );

--- a/registry/dialog/smoke/core.test.ts
+++ b/registry/dialog/smoke/core.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, expect, test } from "bun:test";
+import { parseColor } from "@opentui/core";
 import {
   createTestRenderer,
   type TestRendererSetup,
@@ -9,6 +10,7 @@ import {
   addDialogTitle,
   createDialog,
 } from "./components/ui/dialog";
+import { theme, tint } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -36,4 +38,38 @@ test("installed Core Dialog recipe composes and delegates trigger, close, and ba
   expect(dialog.popup.visible).toBe(true);
   dialog.backdrop.processMouseEvent({ type: "up" } as never);
   expect(dialog.root.state.open).toBe(false);
+});
+
+test("restyles from the theme store on theme switch", async () => {
+  theme.register("smoke", {
+    tokens: {
+      colors: {
+        surface: "#123456",
+        background: "#654321",
+        foreground: "#FEDCBA",
+      },
+    },
+  });
+  setup = await createTestRenderer({ width: 60, height: 16 });
+  const dialog = createDialog(setup.renderer);
+  setup.renderer.root.add(dialog.root);
+  setup.renderer.root.add(dialog.portal);
+  await setup.renderOnce();
+
+  theme.setActive("smoke");
+  expect(dialog.popup.backgroundColor.equals(parseColor("#123456"))).toBe(true);
+  expect(dialog.trigger.backgroundColor.equals(parseColor("#123456"))).toBe(
+    true,
+  );
+  expect(
+    dialog.backdrop.backgroundColor.equals(tint("#654321", "#FEDCBA", 0.25)),
+  ).toBe(true);
+  expect(dialog.backdrop.backgroundColor.equals(parseColor("#654321"))).toBe(
+    false,
+  );
+
+  theme.setActive("terminal");
+  expect(dialog.popup.backgroundColor.equals(parseColor("#123456"))).toBe(
+    false,
+  );
 });

--- a/registry/dialog/smoke/react.test.tsx
+++ b/registry/dialog/smoke/react.test.tsx
@@ -1,7 +1,11 @@
 /** @jsxImportSource @opentui/react */
 
 import { afterEach, expect, test } from "bun:test";
-import type { BaseRenderable } from "@opentui/core";
+import {
+  type BaseRenderable,
+  type BoxRenderable,
+  parseColor,
+} from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import {
@@ -17,6 +21,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "./components/ui/dialog";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -70,6 +75,36 @@ test("installed React Dialog recipe delegates controlled intent once and retains
     controlledRoot.getChildren()[0] as DialogTriggerRenderable;
   await act(async () => controlledTrigger.press());
   expect(changes).toBe(1);
+});
+
+test("restyles rendered dialog parts on theme switch", async () => {
+  theme.register("smoke", { tokens: { colors: { surface: "#123456" } } });
+  setup = await testRender(
+    <Dialog defaultOpen>
+      <DialogTrigger>
+        <text content="Open" />
+      </DialogTrigger>
+      <DialogContent id="themed-popup">
+        <DialogTitle content="Theme" />
+      </DialogContent>
+    </Dialog>,
+    { width: 60, height: 16 },
+  );
+  const popup = setup.renderer.root.findDescendantById(
+    "themed-popup",
+  ) as BoxRenderable;
+
+  await act(async () => {
+    theme.setActive("smoke");
+  });
+  await setup.waitFor(() =>
+    popup.backgroundColor.equals(parseColor("#123456")),
+  );
+
+  expect(setup.renderer.root.findDescendantById("themed-popup")).toBe(popup);
+  await act(async () => {
+    theme.setActive("terminal");
+  });
 });
 
 function findClose(node: BaseRenderable): DialogCloseRenderable {

--- a/registry/dialog/smoke/solid.test.tsx
+++ b/registry/dialog/smoke/solid.test.tsx
@@ -1,7 +1,11 @@
 /** @jsxImportSource @opentui/solid */
 
 import { afterEach, expect, test } from "bun:test";
-import type { BaseRenderable } from "@opentui/core";
+import {
+  type BaseRenderable,
+  type BoxRenderable,
+  parseColor,
+} from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/solid";
 import {
@@ -17,6 +21,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "./components/ui/dialog";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -83,6 +88,34 @@ test("installed Solid Dialog recipe delegates controlled intent once and retains
   controlledTrigger.press();
   await setup.waitFor(() => controlledRoot?.state.open === true);
   expect(controlledChanges).toBe(1);
+});
+
+test("restyles rendered dialog parts on theme switch", async () => {
+  theme.register("smoke", { tokens: { colors: { surface: "#123456" } } });
+  setup = await testRender(
+    () => (
+      <Dialog defaultOpen>
+        <DialogTrigger>
+          <text content="Open" />
+        </DialogTrigger>
+        <DialogContent id="themed-popup">
+          <DialogTitle content="Theme" />
+        </DialogContent>
+      </Dialog>
+    ),
+    { width: 60, height: 16 },
+  );
+  const popup = setup.renderer.root.findDescendantById(
+    "themed-popup",
+  ) as BoxRenderable;
+
+  theme.setActive("smoke");
+  await setup.waitFor(() =>
+    popup.backgroundColor.equals(parseColor("#123456")),
+  );
+
+  expect(setup.renderer.root.findDescendantById("themed-popup")).toBe(popup);
+  theme.setActive("terminal");
 });
 
 function findClose(node: BaseRenderable): DialogCloseRenderable {

--- a/registry/dialog/solid.tsx
+++ b/registry/dialog/solid.tsx
@@ -2,6 +2,8 @@
 
 import { Dialog as DialogPrimitive } from "@tuiparts/solid/dialog";
 import { splitProps } from "solid-js";
+import { tint } from "./theme";
+import { useTheme } from "./use-theme";
 
 /** Props for the consumer-owned Dialog root. */
 export interface DialogProps extends DialogPrimitive.Root.Props {}
@@ -18,11 +20,12 @@ export function Dialog(props: DialogProps) {
 
 /** Editable trigger presentation that retains the primitive Trigger ref. */
 export function DialogTrigger(props: DialogPrimitive.Trigger.Props) {
+  const tokens = useTheme();
   return (
     <DialogPrimitive.Trigger
-      backgroundColor="#262626"
-      paddingLeft={1}
-      paddingRight={1}
+      backgroundColor={tokens().colors.surface}
+      paddingLeft={tokens().density.paddingX}
+      paddingRight={tokens().density.paddingX}
       {...props}
     />
   );
@@ -31,6 +34,7 @@ export function DialogTrigger(props: DialogPrimitive.Trigger.Props) {
 /** Responsive Portal, Backdrop, and Popup composition for Dialog content. */
 export function DialogContent(props: DialogContentProps) {
   const [recipe, popup] = splitProps(props, ["backdropColor", "children"]);
+  const tokens = useTheme();
   return (
     <DialogPrimitive.Portal
       position="absolute"
@@ -43,17 +47,21 @@ export function DialogContent(props: DialogContentProps) {
         position="absolute"
         width="100%"
         height="100%"
-        backgroundColor={recipe.backdropColor ?? "#000000"}
+        backgroundColor={
+          recipe.backdropColor ??
+          tint(tokens().colors.background, tokens().colors.foreground, 0.25)
+        }
       />
       <DialogPrimitive.Popup
         width="80%"
         maxWidth={56}
         flexDirection="column"
-        backgroundColor="#171717"
+        backgroundColor={tokens().colors.surface}
         border
-        borderColor="#737373"
-        paddingLeft={1}
-        paddingRight={1}
+        borderColor={tokens().colors.border}
+        borderStyle={tokens().borders.style}
+        paddingLeft={tokens().density.paddingX}
+        paddingRight={tokens().density.paddingX}
         {...popup}
       >
         {recipe.children}
@@ -64,21 +72,29 @@ export function DialogContent(props: DialogContentProps) {
 
 /** Editable semantic Dialog title. */
 export function DialogTitle(props: DialogPrimitive.Title.Props) {
-  return <DialogPrimitive.Title fg="#FFFFFF" {...props} />;
+  const tokens = useTheme();
+  return <DialogPrimitive.Title fg={tokens().colors.foreground} {...props} />;
 }
 
 /** Editable semantic Dialog description. */
 export function DialogDescription(props: DialogPrimitive.Description.Props) {
-  return <DialogPrimitive.Description fg="#A3A3A3" {...props} />;
+  const tokens = useTheme();
+  return (
+    <DialogPrimitive.Description
+      fg={tokens().colors.mutedForeground}
+      {...props}
+    />
+  );
 }
 
 /** Editable Dialog dismissal or action control. */
 export function DialogClose(props: DialogPrimitive.Close.Props) {
+  const tokens = useTheme();
   return (
     <DialogPrimitive.Close
-      backgroundColor="#262626"
-      paddingLeft={1}
-      paddingRight={1}
+      backgroundColor={tokens().colors.surface}
+      paddingLeft={tokens().density.paddingX}
+      paddingRight={tokens().density.paddingX}
       {...props}
     />
   );

--- a/registry/input/core.ts
+++ b/registry/input/core.ts
@@ -3,21 +3,48 @@ import {
   type InputOptions as BaseInputOptions,
   InputRenderable,
 } from "@tuiparts/core/input";
+import { type Tokens, theme, tint } from "./theme";
 
 export interface InputOptions extends BaseInputOptions {}
+
+class InputRecipeRenderable extends InputRenderable {
+  private readonly unsubscribeTheme: () => void;
+
+  constructor(ctx: RenderContext, options: InputOptions) {
+    super(ctx, {
+      backgroundColor: "transparent",
+      focusedBackgroundColor: "transparent",
+      ...options,
+    });
+
+    const applyStyle = (tokens: Readonly<Tokens>) => {
+      if (options.cursorColor === undefined)
+        this.cursorColor = tokens.colors.foreground;
+      if (options.focusedTextColor === undefined)
+        this.focusedTextColor = tint(
+          tokens.colors.foreground,
+          tokens.colors.focus,
+          0.35,
+        );
+      if (options.placeholderColor === undefined)
+        this.placeholderColor = tokens.colors.mutedForeground;
+      if (options.textColor === undefined)
+        this.textColor = tokens.colors.foreground;
+    };
+    applyStyle(theme.get());
+    this.unsubscribeTheme = theme.subscribe(() => applyStyle(theme.get()));
+  }
+
+  override destroy(): void {
+    this.unsubscribeTheme();
+    super.destroy();
+  }
+}
 
 /** Consumer-owned imperative Input recipe with editable visual defaults. */
 export function createInput(
   ctx: RenderContext,
   options: InputOptions = {},
 ): InputRenderable {
-  return new InputRenderable(ctx, {
-    backgroundColor: "transparent",
-    cursorColor: "#E5E5E5",
-    focusedBackgroundColor: "transparent",
-    focusedTextColor: "#FFFFFF",
-    placeholderColor: "#737373",
-    textColor: "#E5E5E5",
-    ...options,
-  });
+  return new InputRecipeRenderable(ctx, options);
 }

--- a/registry/input/react.tsx
+++ b/registry/input/react.tsx
@@ -1,19 +1,26 @@
 /** @jsxImportSource @opentui/react */
 
 import { Input as InputPrimitive } from "@tuiparts/react/input";
+import { tint } from "./theme";
+import { useTheme } from "./use-theme";
 
 export interface InputProps extends InputPrimitive.Props {}
 
 /** Consumer-owned React Input recipe with editable visual defaults. */
 export function Input(props: InputProps) {
+  const tokens = useTheme();
   return (
     <InputPrimitive
       backgroundColor="transparent"
-      cursorColor="#E5E5E5"
+      cursorColor={tokens.colors.foreground}
       focusedBackgroundColor="transparent"
-      focusedTextColor="#FFFFFF"
-      placeholderColor="#737373"
-      textColor="#E5E5E5"
+      focusedTextColor={tint(
+        tokens.colors.foreground,
+        tokens.colors.focus,
+        0.35,
+      )}
+      placeholderColor={tokens.colors.mutedForeground}
+      textColor={tokens.colors.foreground}
       {...props}
     />
   );

--- a/registry/input/smoke/core.test.ts
+++ b/registry/input/smoke/core.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { parseColor } from "@opentui/core";
 import {
   createTestRenderer,
   type TestRendererSetup,
 } from "@opentui/core/testing";
 import { createInput } from "./components/ui/input";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -30,5 +32,24 @@ describe("installed Core Input recipe", () => {
 
     expect(input.value).toBe("AB");
     expect(events).toEqual(["input:AB", "change:AB", "submit:AB"]);
+  });
+
+  it("restyles from the theme store on theme switch", async () => {
+    theme.register("smoke", {
+      tokens: {
+        colors: { foreground: "#123456", mutedForeground: "#654321" },
+      },
+    });
+    setup = await createTestRenderer({ width: 30, height: 5 });
+    const input = createInput(setup.renderer, { placeholder: "Theme" });
+    setup.renderer.root.add(input);
+    await setup.renderOnce();
+
+    theme.setActive("smoke");
+    expect(input.textColor.equals(parseColor("#123456"))).toBe(true);
+    expect(input.placeholderColor.equals(parseColor("#654321"))).toBe(true);
+
+    theme.setActive("terminal");
+    expect(input.textColor.equals(parseColor("#123456"))).toBe(false);
   });
 });

--- a/registry/input/smoke/react.test.tsx
+++ b/registry/input/smoke/react.test.tsx
@@ -1,11 +1,13 @@
 /** @jsxImportSource @opentui/react */
 
 import { afterEach, describe, expect, it } from "bun:test";
+import { parseColor } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import type { InputRenderable } from "@tuiparts/core/input";
 import { act, createRef } from "react";
 import { Input } from "./components/ui/input";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -34,5 +36,26 @@ describe("installed React Input recipe", () => {
 
     expect(ref.current?.value).toBe("AB");
     expect(events).toEqual(["input:AB", "change:AB", "submit:AB"]);
+  });
+
+  it("restyles the rendered input on theme switch", async () => {
+    theme.register("smoke", { tokens: { colors: { foreground: "#123456" } } });
+    setup = await testRender(<Input id="themed" placeholder="Theme" />, {
+      width: 30,
+      height: 5,
+    });
+    const input = setup.renderer.root.findDescendantById(
+      "themed",
+    ) as InputRenderable;
+
+    await act(async () => {
+      theme.setActive("smoke");
+    });
+    await setup.waitFor(() => input.textColor.equals(parseColor("#123456")));
+
+    expect(setup.renderer.root.findDescendantById("themed")).toBe(input);
+    await act(async () => {
+      theme.setActive("terminal");
+    });
   });
 });

--- a/registry/input/smoke/solid.test.tsx
+++ b/registry/input/smoke/solid.test.tsx
@@ -1,10 +1,12 @@
 /** @jsxImportSource @opentui/solid */
 
 import { afterEach, describe, expect, it } from "bun:test";
+import { parseColor } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/solid";
 import type { InputRenderable } from "@tuiparts/core/input";
 import { Input } from "./components/ui/input";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -37,5 +39,22 @@ describe("installed Solid Input recipe", () => {
 
     expect(input?.value).toBe("AB");
     expect(events).toEqual(["input:AB", "change:AB", "submit:AB"]);
+  });
+
+  it("restyles the rendered input on theme switch", async () => {
+    theme.register("smoke", { tokens: { colors: { foreground: "#123456" } } });
+    setup = await testRender(() => <Input id="themed" placeholder="Theme" />, {
+      width: 30,
+      height: 5,
+    });
+    const input = setup.renderer.root.findDescendantById(
+      "themed",
+    ) as InputRenderable;
+
+    theme.setActive("smoke");
+    await setup.waitFor(() => input.textColor.equals(parseColor("#123456")));
+
+    expect(setup.renderer.root.findDescendantById("themed")).toBe(input);
+    theme.setActive("terminal");
   });
 });

--- a/registry/input/solid.tsx
+++ b/registry/input/solid.tsx
@@ -1,19 +1,26 @@
 /** @jsxImportSource @opentui/solid */
 
 import { Input as InputPrimitive } from "@tuiparts/solid/input";
+import { tint } from "./theme";
+import { useTheme } from "./use-theme";
 
 export interface InputProps extends InputPrimitive.Props {}
 
 /** Consumer-owned Solid Input recipe with editable visual defaults. */
 export function Input(props: InputProps) {
+  const tokens = useTheme();
   return (
     <InputPrimitive
       backgroundColor="transparent"
-      cursorColor="#E5E5E5"
+      cursorColor={tokens().colors.foreground}
       focusedBackgroundColor="transparent"
-      focusedTextColor="#FFFFFF"
-      placeholderColor="#737373"
-      textColor="#E5E5E5"
+      focusedTextColor={tint(
+        tokens().colors.foreground,
+        tokens().colors.focus,
+        0.35,
+      )}
+      placeholderColor={tokens().colors.mutedForeground}
+      textColor={tokens().colors.foreground}
       {...props}
     />
   );

--- a/registry/radio-group/core.ts
+++ b/registry/radio-group/core.ts
@@ -13,6 +13,7 @@ import {
   type RadioGroupStore,
   type RadioGroupStoreOptions,
 } from "@tuiparts/core/radio-group";
+import { type Tokens, theme } from "./theme";
 
 export interface RadioGroupOptions extends RadioGroupStoreOptions {
   gap?: BoxOptions["gap"];
@@ -40,34 +41,61 @@ export function createRadioGroup(
   });
 }
 
+class RadioGroupItemRecipeRenderable extends RadioRootRenderable {
+  private readonly unsubscribeTheme: () => void;
+
+  constructor(
+    ctx: RenderContext,
+    store: RadioGroupStore,
+    options: RadioGroupItemOptions,
+  ) {
+    const tokens = theme.get();
+    super(ctx, {
+      store,
+      value: options.value,
+      disabled: options.disabled,
+      backgroundColor: "transparent",
+      flexDirection: "row",
+      gap: 1,
+    });
+    const markCell = new BoxRenderable(ctx, { width: 1 });
+    const indicator = new RadioIndicatorRenderable(ctx, { radio: this });
+    const mark = new TextRenderable(ctx, {
+      content: options.mark ?? tokens.glyphs.radio,
+      fg: tokens.colors.primary,
+    });
+    indicator.add(mark);
+    markCell.add(indicator);
+    this.add(markCell);
+    const label = new TextRenderable(ctx, {
+      content: options.label,
+      fg: options.disabled
+        ? tokens.colors.disabledForeground
+        : tokens.colors.foreground,
+    });
+    this.add(label);
+
+    const applyStyle = (tokens: Readonly<Tokens>) => {
+      mark.content = options.mark ?? tokens.glyphs.radio;
+      mark.fg = tokens.colors.primary;
+      label.fg = options.disabled
+        ? tokens.colors.disabledForeground
+        : tokens.colors.foreground;
+    };
+    applyStyle(tokens);
+    this.unsubscribeTheme = theme.subscribe(() => applyStyle(theme.get()));
+  }
+
+  override destroy(): void {
+    this.unsubscribeTheme();
+    super.destroy();
+  }
+}
+
 export function createRadioGroupItem(
   ctx: RenderContext,
   store: RadioGroupStore,
   options: RadioGroupItemOptions,
 ): RadioRootRenderable {
-  const item = new RadioRootRenderable(ctx, {
-    store,
-    value: options.value,
-    disabled: options.disabled,
-    backgroundColor: "transparent",
-    flexDirection: "row",
-    gap: 1,
-  });
-  const markCell = new BoxRenderable(ctx, { width: 1 });
-  const indicator = new RadioIndicatorRenderable(ctx, { radio: item });
-  indicator.add(
-    new TextRenderable(ctx, {
-      content: options.mark ?? "o",
-      fg: "#3B82F6",
-    }),
-  );
-  markCell.add(indicator);
-  item.add(markCell);
-  item.add(
-    new TextRenderable(ctx, {
-      content: options.label,
-      fg: options.disabled ? "#737373" : "#E5E5E5",
-    }),
-  );
-  return item;
+  return new RadioGroupItemRecipeRenderable(ctx, store, options);
 }

--- a/registry/radio-group/react.tsx
+++ b/registry/radio-group/react.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @opentui/react */
 
-import { RGBA } from "@opentui/core";
 import { Radio as RadioPrimitive } from "@tuiparts/react/radio";
 import { RadioGroup as RadioGroupPrimitive } from "@tuiparts/react/radio-group";
 import { useTheme } from "./use-theme";
@@ -31,14 +30,14 @@ export function RadioGroup({ children, ...props }: RadioGroupProps) {
 /** Consumer-owned Item layout, label, mark, and colors. */
 export function RadioGroupItem({
   label,
-  mark = "●",
+  mark,
   tone = "accent",
   disabled,
   ...props
 }: RadioGroupItemProps) {
   const tokens = useTheme();
   const markColor =
-    tone === "success" ? RGBA.fromIndex(2) : tokens.colors.primary;
+    tone === "success" ? tokens.colors.success : tokens.colors.primary;
 
   return (
     <RadioPrimitive.Root
@@ -53,7 +52,7 @@ export function RadioGroupItem({
         <>
           <box width={1}>
             <RadioPrimitive.Indicator>
-              <text content={mark} fg={markColor} />
+              <text content={mark ?? tokens.glyphs.radio} fg={markColor} />
             </RadioPrimitive.Indicator>
           </box>
           <text

--- a/registry/radio-group/react.tsx
+++ b/registry/radio-group/react.tsx
@@ -1,7 +1,9 @@
 /** @jsxImportSource @opentui/react */
 
+import { RGBA } from "@opentui/core";
 import { Radio as RadioPrimitive } from "@tuiparts/react/radio";
 import { RadioGroup as RadioGroupPrimitive } from "@tuiparts/react/radio-group";
+import { useTheme } from "./use-theme";
 
 export interface RadioGroupProps extends RadioGroupPrimitive.Props {}
 
@@ -34,7 +36,9 @@ export function RadioGroupItem({
   disabled,
   ...props
 }: RadioGroupItemProps) {
-  const markColor = tone === "success" ? "#10B981" : "#3B82F6";
+  const tokens = useTheme();
+  const markColor =
+    tone === "success" ? RGBA.fromIndex(2) : tokens.colors.primary;
 
   return (
     <RadioPrimitive.Root
@@ -55,7 +59,11 @@ export function RadioGroupItem({
           <text
             content={label}
             fg={
-              state.disabled ? "#737373" : state.focused ? "#FFFFFF" : "#E5E5E5"
+              state.disabled
+                ? tokens.colors.disabledForeground
+                : state.focused
+                  ? tokens.colors.focus
+                  : tokens.colors.foreground
             }
           />
         </>

--- a/registry/radio-group/smoke/core.test.ts
+++ b/registry/radio-group/smoke/core.test.ts
@@ -128,7 +128,7 @@ describe("installed Core RadioGroup recipe", () => {
     expect(gamma?.focused).toBe(true);
     await setup?.mockInput.pressKey("HOME");
     expect(alpha?.focused).toBe(true);
-    expect(frameLines()[0]).toBe("o Alpha");
+    expect(frameLines()[0]).toBe("● Alpha");
     expect(frameLines()[1]).toBe("  Beta");
   });
 
@@ -160,7 +160,7 @@ describe("installed Core RadioGroup recipe", () => {
     const { items } = await renderGroup({ defaultValue: "alpha" }, [
       { value: "alpha", label: "Alpha" },
     ]);
-    expect(frameLines()[0]).toBe("o Alpha");
+    expect(frameLines()[0]).toBe("● Alpha");
 
     theme.setActive("smoke");
     await setup?.renderOnce();
@@ -172,6 +172,6 @@ describe("installed Core RadioGroup recipe", () => {
 
     theme.setActive("terminal");
     await setup?.renderOnce();
-    expect(frameLines()[0]).toBe("o Alpha");
+    expect(frameLines()[0]).toBe("● Alpha");
   });
 });

--- a/registry/radio-group/smoke/core.test.ts
+++ b/registry/radio-group/smoke/core.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
+  type BoxRenderable,
+  parseColor,
+  type TextRenderable,
+} from "@opentui/core";
+import {
   createTestRenderer,
   type TestRendererSetup,
 } from "@opentui/core/testing";
@@ -9,6 +14,7 @@ import {
   type RadioGroupItemOptions,
   type RadioGroupOptions,
 } from "./components/ui/radio-group";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -145,5 +151,27 @@ describe("installed Core RadioGroup recipe", () => {
     expect(gamma?.focused).toBe(true);
     expect(frameLines()).not.toContain("  Beta");
     expect(frameLines()[1]).toBe("  Gamma");
+  });
+
+  it("restyles from the theme store on theme switch", async () => {
+    theme.register("smoke", {
+      tokens: { colors: { primary: "#123456" }, glyphs: { radio: "*" } },
+    });
+    const { items } = await renderGroup({ defaultValue: "alpha" }, [
+      { value: "alpha", label: "Alpha" },
+    ]);
+    expect(frameLines()[0]).toBe("o Alpha");
+
+    theme.setActive("smoke");
+    await setup?.renderOnce();
+    expect(frameLines()[0]).toBe("* Alpha");
+    const markCell = items[0]?.getChildren()[0] as BoxRenderable;
+    const indicator = markCell.getChildren()[0] as BoxRenderable;
+    const mark = indicator.getChildren()[0] as TextRenderable;
+    expect(mark.fg.equals(parseColor("#123456"))).toBe(true);
+
+    theme.setActive("terminal");
+    await setup?.renderOnce();
+    expect(frameLines()[0]).toBe("o Alpha");
   });
 });

--- a/registry/radio-group/smoke/react.test.tsx
+++ b/registry/radio-group/smoke/react.test.tsx
@@ -1,13 +1,19 @@
 /** @jsxImportSource @opentui/react */
 
 import { afterEach, describe, expect, it } from "bun:test";
-import { type BaseRenderable, TextRenderable } from "@opentui/core";
+import {
+  type BaseRenderable,
+  type BoxRenderable,
+  parseColor,
+  TextRenderable,
+} from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import type { RadioRootRenderable } from "@tuiparts/core/radio";
 import type { RadioGroupRenderable } from "@tuiparts/core/radio-group";
 import { act, createRef, useState } from "react";
 import { RadioGroup, RadioGroupItem } from "./components/ui/radio-group";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -156,5 +162,33 @@ describe("installed React RadioGroup recipe", () => {
     expect(item("controlled-beta").checked).toBe(true);
     expect(rootRef.current).toBe(retainedRoot);
     expect(itemRef.current).toBe(retainedItem);
+  });
+
+  it("restyles rendered items on theme switch", async () => {
+    theme.register("smoke", { tokens: { colors: { primary: "#123456" } } });
+    setup = await testRender(
+      <RadioGroup id="themed" defaultValue="alpha">
+        <RadioGroupItem id="themed-alpha" value="alpha" label="Alpha" />
+      </RadioGroup>,
+      { width: 30, height: 3 },
+    );
+    await act(async () => setup?.renderOnce());
+    const alpha = item("themed-alpha");
+    expect(text(alpha)).toEqual(["●", "Alpha"]);
+
+    await act(async () => {
+      theme.setActive("smoke");
+    });
+    await setup.waitFor(() => {
+      const markCell = item("themed-alpha").getChildren()[0] as BoxRenderable;
+      const indicator = markCell.getChildren()[0] as BoxRenderable;
+      const mark = indicator.getChildren()[0] as TextRenderable;
+      return mark.fg.equals(parseColor("#123456"));
+    });
+
+    expect(setup.renderer.root.findDescendantById("themed-alpha")).toBe(alpha);
+    await act(async () => {
+      theme.setActive("terminal");
+    });
   });
 });

--- a/registry/radio-group/smoke/solid.test.tsx
+++ b/registry/radio-group/smoke/solid.test.tsx
@@ -182,7 +182,7 @@ test("restyles rendered items on theme switch", async () => {
   );
   await setup.renderOnce();
   const alpha = item("themed-alpha");
-  expect(text(alpha)).toEqual(["o", "Alpha"]);
+  expect(text(alpha)).toEqual(["●", "Alpha"]);
 
   theme.setActive("smoke");
   await setup.waitFor(() => text(alpha).join(" ") === "* Alpha");

--- a/registry/radio-group/smoke/solid.test.tsx
+++ b/registry/radio-group/smoke/solid.test.tsx
@@ -8,6 +8,7 @@ import type { RadioRootRenderable } from "@tuiparts/core/radio";
 import type { RadioGroupRenderable } from "@tuiparts/core/radio-group";
 import { createSignal } from "solid-js";
 import { RadioGroup, RadioGroupItem } from "./components/ui/radio-group";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -165,4 +166,27 @@ test("installed Solid RadioGroup recipe runtime smoke", async () => {
     controlledRoot,
   );
   expect(item("controlled-b")).toBe(controlledBeta);
+});
+
+test("restyles rendered items on theme switch", async () => {
+  theme.register("smoke", {
+    tokens: { colors: { primary: "#123456" }, glyphs: { radio: "*" } },
+  });
+  setup = await testRender(
+    () => (
+      <RadioGroup id="themed" defaultValue="alpha">
+        <RadioGroupItem id="themed-alpha" value="alpha" label="Alpha" />
+      </RadioGroup>
+    ),
+    { width: 30, height: 3 },
+  );
+  await setup.renderOnce();
+  const alpha = item("themed-alpha");
+  expect(text(alpha)).toEqual(["o", "Alpha"]);
+
+  theme.setActive("smoke");
+  await setup.waitFor(() => text(alpha).join(" ") === "* Alpha");
+
+  expect(setup.renderer.root.findDescendantById("themed-alpha")).toBe(alpha);
+  theme.setActive("terminal");
 });

--- a/registry/radio-group/solid.tsx
+++ b/registry/radio-group/solid.tsx
@@ -1,8 +1,10 @@
 /** @jsxImportSource @opentui/solid */
 
+import { RGBA } from "@opentui/core";
 import { Radio as RadioPrimitive } from "@tuiparts/solid/radio";
 import { RadioGroup as RadioGroupPrimitive } from "@tuiparts/solid/radio-group";
 import { splitProps } from "solid-js";
+import { useTheme } from "./use-theme";
 
 export interface RadioGroupProps extends RadioGroupPrimitive.Props {}
 
@@ -33,7 +35,9 @@ export function RadioGroupItem(props: RadioGroupItemProps) {
     "tone",
     "disabled",
   ]);
-  const markColor = () => (recipe.tone === "success" ? "#10B981" : "#3B82F6");
+  const tokens = useTheme();
+  const markColor = () =>
+    recipe.tone === "success" ? RGBA.fromIndex(2) : tokens().colors.primary;
 
   return (
     <RadioPrimitive.Root
@@ -48,13 +52,20 @@ export function RadioGroupItem(props: RadioGroupItemProps) {
         <>
           <box width={1}>
             <RadioPrimitive.Indicator>
-              <text content={recipe.mark ?? "o"} fg={markColor()} />
+              <text
+                content={recipe.mark ?? tokens().glyphs.radio}
+                fg={markColor()}
+              />
             </RadioPrimitive.Indicator>
           </box>
           <text
             content={recipe.label}
             fg={
-              state.disabled ? "#737373" : state.focused ? "#FFFFFF" : "#E5E5E5"
+              state.disabled
+                ? tokens().colors.disabledForeground
+                : state.focused
+                  ? tokens().colors.focus
+                  : tokens().colors.foreground
             }
           />
         </>

--- a/registry/radio-group/solid.tsx
+++ b/registry/radio-group/solid.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @opentui/solid */
 
-import { RGBA } from "@opentui/core";
 import { Radio as RadioPrimitive } from "@tuiparts/solid/radio";
 import { RadioGroup as RadioGroupPrimitive } from "@tuiparts/solid/radio-group";
 import { splitProps } from "solid-js";
@@ -37,7 +36,9 @@ export function RadioGroupItem(props: RadioGroupItemProps) {
   ]);
   const tokens = useTheme();
   const markColor = () =>
-    recipe.tone === "success" ? RGBA.fromIndex(2) : tokens().colors.primary;
+    recipe.tone === "success"
+      ? tokens().colors.success
+      : tokens().colors.primary;
 
   return (
     <RadioPrimitive.Root

--- a/registry/switch/core.ts
+++ b/registry/switch/core.ts
@@ -7,6 +7,7 @@ import {
   SwitchRootRenderable,
   SwitchThumbRenderable,
 } from "@tuiparts/core/switch";
+import { type Tokens, theme } from "./theme";
 
 export interface SwitchOptions {
   checked?: boolean;
@@ -25,10 +26,16 @@ const symbolSets = {
 
 class SwitchRecipeRenderable extends SwitchRootRenderable {
   private readonly unsubscribeRecipe: () => void;
+  private readonly unsubscribeTheme: () => void;
 
   constructor(ctx: RenderContext, options: SwitchOptions) {
+    const tokens = theme.get();
     const trackWidth = options.density === "comfortable" ? 5 : 3;
-    const symbols = symbolSets[options.symbols ?? "round"];
+    const resolveSymbols = (tokens: Readonly<Tokens>) =>
+      options.symbols
+        ? symbolSets[options.symbols]
+        : { thumb: tokens.glyphs.thumb, track: tokens.glyphs.track };
+    const symbols = resolveSymbols(tokens);
     super(ctx, {
       backgroundColor: "transparent",
       checked: options.checked,
@@ -45,12 +52,11 @@ class SwitchRecipeRenderable extends SwitchRootRenderable {
       position: "relative",
       width: trackWidth,
     });
-    track.add(
-      new TextRenderable(ctx, {
-        content: symbols.track.repeat(trackWidth),
-        fg: "#525252",
-      }),
-    );
+    const trackText = new TextRenderable(ctx, {
+      content: symbols.track.repeat(trackWidth),
+      fg: tokens.colors.border,
+    });
+    track.add(trackText);
     const thumb = new SwitchThumbRenderable(ctx, {
       height: 1,
       left: this.getState().checked ? trackWidth - 1 : 0,
@@ -58,26 +64,40 @@ class SwitchRecipeRenderable extends SwitchRootRenderable {
       store: this.store,
       width: 1,
     });
-    thumb.add(
-      new TextRenderable(ctx, {
-        content: symbols.thumb,
-        fg: "#3B82F6",
-      }),
-    );
+    const thumbText = new TextRenderable(ctx, {
+      content: symbols.thumb,
+      fg: tokens.colors.primary,
+    });
+    thumb.add(thumbText);
     track.add(thumb);
     this.add(track);
-    this.add(
-      new TextRenderable(ctx, {
-        content: options.label,
-        fg: options.disabled ? "#737373" : "#E5E5E5",
-      }),
-    );
+    const label = new TextRenderable(ctx, {
+      content: options.label,
+      fg: options.disabled
+        ? tokens.colors.disabledForeground
+        : tokens.colors.foreground,
+    });
+    this.add(label);
+
+    const applyStyle = (tokens: Readonly<Tokens>) => {
+      const symbols = resolveSymbols(tokens);
+      trackText.content = symbols.track.repeat(trackWidth);
+      trackText.fg = tokens.colors.border;
+      thumbText.content = symbols.thumb;
+      thumbText.fg = tokens.colors.primary;
+      label.fg = options.disabled
+        ? tokens.colors.disabledForeground
+        : tokens.colors.foreground;
+    };
+    applyStyle(tokens);
+    this.unsubscribeTheme = theme.subscribe(() => applyStyle(theme.get()));
     this.unsubscribeRecipe = this.subscribe((state) => {
       thumb.left = state.checked ? trackWidth - 1 : 0;
     });
   }
 
   override destroy(): void {
+    this.unsubscribeTheme();
     this.unsubscribeRecipe();
     super.destroy();
   }

--- a/registry/switch/react.tsx
+++ b/registry/switch/react.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @opentui/react */
 
 import { Switch as SwitchPrimitive } from "@tuiparts/react/switch";
+import { useTheme } from "./use-theme";
 
 export interface SwitchProps
   extends Omit<SwitchPrimitive.Root.Props, "children"> {
@@ -18,12 +19,15 @@ const symbolSets = {
 export function Switch({
   density = "compact",
   label,
-  symbols = "round",
+  symbols,
   disabled,
   ...props
 }: SwitchProps) {
+  const tokens = useTheme();
   const trackWidth = density === "comfortable" ? 5 : 3;
-  const glyphs = symbolSets[symbols];
+  const glyphs = symbols
+    ? symbolSets[symbols]
+    : { thumb: tokens.glyphs.thumb, track: tokens.glyphs.track };
 
   return (
     <SwitchPrimitive.Root
@@ -41,20 +45,27 @@ export function Switch({
             position="relative"
             backgroundColor="transparent"
           >
-            <text content={glyphs.track.repeat(trackWidth)} fg="#525252" />
+            <text
+              content={glyphs.track.repeat(trackWidth)}
+              fg={tokens.colors.border}
+            />
             <SwitchPrimitive.Thumb
               width={1}
               height={1}
               position="absolute"
               left={state.checked ? trackWidth - 1 : 0}
             >
-              <text content={glyphs.thumb} fg="#3B82F6" />
+              <text content={glyphs.thumb} fg={tokens.colors.primary} />
             </SwitchPrimitive.Thumb>
           </box>
           <text
             content={label}
             fg={
-              state.disabled ? "#737373" : state.focused ? "#FFFFFF" : "#E5E5E5"
+              state.disabled
+                ? tokens.colors.disabledForeground
+                : state.focused
+                  ? tokens.colors.focus
+                  : tokens.colors.foreground
             }
           />
         </>

--- a/registry/switch/smoke/core.test.ts
+++ b/registry/switch/smoke/core.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import {
+  type BoxRenderable,
+  parseColor,
+  type TextRenderable,
+} from "@opentui/core";
+import {
   createTestRenderer,
   type TestRendererSetup,
 } from "@opentui/core/testing";
 import { createSwitch } from "./components/ui/switch";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -54,5 +60,31 @@ describe("installed Core Switch recipe", () => {
     expect(toggle.focused).toBe(false);
     expect(toggle.checked).toBe(false);
     expect(changes).toEqual([]);
+  });
+
+  it("restyles from the theme store on theme switch", async () => {
+    theme.register("smoke", {
+      tokens: {
+        colors: { primary: "#123456" },
+        glyphs: { thumb: "@", track: "=" },
+      },
+    });
+    setup = await createTestRenderer({ width: 30, height: 3 });
+    const toggle = createSwitch(setup.renderer, { label: "Theme" });
+    setup.renderer.root.add(toggle);
+    await setup.renderOnce();
+    expect(firstLine()).toBe("●── Theme");
+
+    theme.setActive("smoke");
+    await setup.renderOnce();
+    expect(firstLine()).toBe("@== Theme");
+    const track = toggle.getChildren()[0] as BoxRenderable;
+    const thumb = track.getChildren()[1] as BoxRenderable;
+    const thumbText = thumb.getChildren()[0] as TextRenderable;
+    expect(thumbText.fg.equals(parseColor("#123456"))).toBe(true);
+
+    theme.setActive("terminal");
+    await setup.renderOnce();
+    expect(firstLine()).toBe("●── Theme");
   });
 });

--- a/registry/switch/smoke/react.test.tsx
+++ b/registry/switch/smoke/react.test.tsx
@@ -1,11 +1,13 @@
 /** @jsxImportSource @opentui/react */
 
 import { afterEach, expect, test } from "bun:test";
+import { type BaseRenderable, TextRenderable } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import type { SwitchRootRenderable } from "@tuiparts/core/switch";
 import { act, useState } from "react";
 import { Switch } from "./components/ui/switch";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -71,4 +73,36 @@ test("installed React Switch recipe runtime smoke", async () => {
   expect(disabledChanges).toBe(0);
 
   expect(root("custom").checked).toBe(true);
+});
+
+test("restyles rendered switches on theme switch", async () => {
+  function text(node: BaseRenderable): string[] {
+    if (!node.visible) return [];
+    return [
+      ...(node instanceof TextRenderable ? [node.plainText] : []),
+      ...node.getChildren().flatMap(text),
+    ];
+  }
+  theme.register("smoke", {
+    tokens: {
+      colors: { primary: "#123456" },
+      glyphs: { thumb: "@", track: "=" },
+    },
+  });
+  setup = await testRender(<Switch id="themed" label="Theme" />, {
+    width: 30,
+    height: 3,
+  });
+  const themed = root("themed");
+  expect(text(themed)).toEqual(["───", "●", "Theme"]);
+
+  await act(async () => {
+    theme.setActive("smoke");
+  });
+  await setup.waitFor(() => text(themed).join(" ") === "=== @ Theme");
+
+  expect(setup.renderer.root.findDescendantById("themed")).toBe(themed);
+  await act(async () => {
+    theme.setActive("terminal");
+  });
 });

--- a/registry/switch/smoke/solid.test.tsx
+++ b/registry/switch/smoke/solid.test.tsx
@@ -1,11 +1,13 @@
 /** @jsxImportSource @opentui/solid */
 
 import { afterEach, describe, expect, it } from "bun:test";
+import { type BaseRenderable, TextRenderable } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/solid";
 import type { SwitchRootRenderable } from "@tuiparts/core/switch";
 import { createSignal } from "solid-js";
 import { Switch } from "./components/ui/switch";
+import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
 
@@ -69,5 +71,33 @@ describe("installed Solid Switch recipe", () => {
     expect(disabledChanges).toEqual([]);
 
     expect(root("custom").checked).toBe(true);
+  });
+
+  it("restyles rendered switches on theme switch", async () => {
+    function text(node: BaseRenderable): string[] {
+      if (!node.visible) return [];
+      return [
+        ...(node instanceof TextRenderable ? [node.plainText] : []),
+        ...node.getChildren().flatMap(text),
+      ];
+    }
+    theme.register("smoke", {
+      tokens: {
+        colors: { primary: "#123456" },
+        glyphs: { thumb: "@", track: "=" },
+      },
+    });
+    setup = await testRender(() => <Switch id="themed" label="Theme" />, {
+      width: 30,
+      height: 3,
+    });
+    const themed = root("themed");
+    expect(text(themed)).toEqual(["───", "●", "Theme"]);
+
+    theme.setActive("smoke");
+    await setup.waitFor(() => text(themed).join(" ") === "=== @ Theme");
+
+    expect(setup.renderer.root.findDescendantById("themed")).toBe(themed);
+    theme.setActive("terminal");
   });
 });

--- a/registry/switch/solid.tsx
+++ b/registry/switch/solid.tsx
@@ -2,6 +2,7 @@
 
 import { Switch as SwitchPrimitive } from "@tuiparts/solid/switch";
 import { splitProps } from "solid-js";
+import { useTheme } from "./use-theme";
 
 export interface SwitchProps
   extends Omit<SwitchPrimitive.Root.Props, "children"> {
@@ -23,8 +24,12 @@ export function Switch(props: SwitchProps) {
     "label",
     "symbols",
   ]);
+  const tokens = useTheme();
   const trackWidth = () => (recipe.density === "comfortable" ? 5 : 3);
-  const glyphs = () => symbolSets[recipe.symbols ?? "round"];
+  const glyphs = () =>
+    recipe.symbols
+      ? symbolSets[recipe.symbols]
+      : { thumb: tokens().glyphs.thumb, track: tokens().glyphs.track };
 
   return (
     <SwitchPrimitive.Root
@@ -42,20 +47,27 @@ export function Switch(props: SwitchProps) {
             position="relative"
             backgroundColor="transparent"
           >
-            <text content={glyphs().track.repeat(trackWidth())} fg="#525252" />
+            <text
+              content={glyphs().track.repeat(trackWidth())}
+              fg={tokens().colors.border}
+            />
             <SwitchPrimitive.Thumb
               width={1}
               height={1}
               position="absolute"
               left={state.checked ? trackWidth() - 1 : 0}
             >
-              <text content={glyphs().thumb} fg="#3B82F6" />
+              <text content={glyphs().thumb} fg={tokens().colors.primary} />
             </SwitchPrimitive.Thumb>
           </box>
           <text
             content={recipe.label}
             fg={
-              state.disabled ? "#737373" : state.focused ? "#FFFFFF" : "#E5E5E5"
+              state.disabled
+                ? tokens().colors.disabledForeground
+                : state.focused
+                  ? tokens().colors.focus
+                  : tokens().colors.foreground
             }
           />
         </>

--- a/registry/theme/README.md
+++ b/registry/theme/README.md
@@ -1,0 +1,23 @@
+# Theme Recipe
+
+These files are the consumer-owned theming layer every other recipe reads
+from: a semantic token contract, a small subscription store, and a default
+theme built from ANSI-indexed colors so apps inherit the terminal user's own
+palette.
+
+- `theme.ts` is the single shared source: it exports the `Tokens` contract,
+  `createThemeStore`, the `tint` blend helper, and the app-wide `theme` store.
+  It is installed for every framework as `components/ui/theme.ts`.
+- `react.tsx` is the installed React `use-theme` binding: a `useTheme()` hook
+  over the same store, installed alongside it as
+  `components/ui/use-theme.tsx`.
+- `solid.tsx` is the installed Solid `use-theme` binding: a reactive
+  `useTheme()` accessor over the same store, installed alongside it as
+  `components/ui/use-theme.tsx`.
+
+There is no packaged theme runtime. Customization is editing the installed
+files: change the default tokens, extend the `Tokens` interface with app-specific
+tokens, register preset themes from the catalog (`themes/<name>.ts`) in the
+`themes` map, or load user-supplied themes at runtime with `theme.register`.
+`theme.follow(renderer)` keeps `mode: "system"` in sync with the terminal's
+light/dark signal.

--- a/registry/theme/react.tsx
+++ b/registry/theme/react.tsx
@@ -1,0 +1,7 @@
+import { useSyncExternalStore } from "react";
+import { type Tokens, theme } from "./theme";
+
+/** Resolved theme snapshot; re-renders on theme and mode changes. */
+export function useTheme(): Readonly<Tokens> {
+  return useSyncExternalStore(theme.subscribe, theme.get);
+}

--- a/registry/theme/smoke/core.test.ts
+++ b/registry/theme/smoke/core.test.ts
@@ -30,6 +30,17 @@ describe("installed Core theme recipe", () => {
     expect(first.glyphs.check).toBe("✓");
   });
 
+  it("leaves the base tokens writable so the installed file stays editable", () => {
+    const base = structuredClone(terminal);
+    const store = createThemeStore({ base, themes: { terminal: {} } });
+
+    expect(Object.isFrozen(store.get())).toBe(true);
+    expect(Object.isFrozen(base)).toBe(false);
+    expect(Object.isFrozen(base.colors)).toBe(false);
+
+    expect(Object.isFrozen(terminal.colors)).toBe(false);
+  });
+
   it("merges the active definition over the base and notifies", () => {
     const store = createThemeStore({
       base: terminal,

--- a/registry/theme/smoke/core.test.ts
+++ b/registry/theme/smoke/core.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "bun:test";
+import { EventEmitter } from "node:events";
+import { RGBA, type ThemeMode } from "@opentui/core";
+import {
+  createThemeStore,
+  type ThemeDefinition,
+  terminal,
+  theme,
+  tint,
+} from "./components/ui/theme";
+import { ascii } from "./themes/ascii";
+import { cobaltDeep } from "./themes/cobalt-deep";
+
+const midnight: ThemeDefinition = {
+  tokens: { colors: { primary: "#FFB000" }, glyphs: { check: "x" } },
+};
+
+class FakeRenderer extends EventEmitter {
+  themeMode: ThemeMode | null = null;
+}
+
+describe("installed Core theme recipe", () => {
+  it("resolves a frozen, referentially stable snapshot", () => {
+    const store = createThemeStore({ base: terminal });
+    const first = store.get();
+
+    expect(store.get()).toBe(first);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Object.isFrozen(first.colors)).toBe(true);
+    expect(first.glyphs.check).toBe("✓");
+  });
+
+  it("merges the active definition over the base and notifies", () => {
+    const store = createThemeStore({
+      base: terminal,
+      themes: { terminal: {}, midnight },
+      active: "terminal",
+    });
+    let notified = 0;
+    store.subscribe(() => notified++);
+    const before = store.get();
+
+    expect(store.setActive("midnight")).toBe(true);
+    expect(notified).toBe(1);
+    const after = store.get();
+    expect(after).not.toBe(before);
+    expect(after.colors.primary).toBe("#FFB000");
+    expect(after.glyphs.check).toBe("x");
+    expect(after.colors.destructive).toBe(terminal.colors.destructive);
+    expect(after.density).toEqual(terminal.density);
+
+    expect(store.setActive("unknown")).toBe(false);
+    expect(notified).toBe(1);
+  });
+
+  it("keeps overrides across setActive", () => {
+    const store = createThemeStore({
+      base: terminal,
+      themes: { terminal: {}, midnight },
+      active: "terminal",
+    });
+
+    store.override({ colors: { focus: "#00FF00" } });
+    store.setActive("midnight");
+
+    expect(store.get().colors.focus).toBe("#00FF00");
+    expect(store.get().colors.primary).toBe("#FFB000");
+  });
+
+  it("registers themes at runtime", () => {
+    const store = createThemeStore({
+      base: terminal,
+      themes: { terminal: {} },
+      active: "terminal",
+    });
+
+    expect(store.setActive("runtime")).toBe(false);
+    store.register("runtime", { tokens: { colors: { primary: "#123456" } } });
+    expect(store.setActive("runtime")).toBe(true);
+    expect(store.get().colors.primary).toBe("#123456");
+  });
+
+  it("stops notifying after unsubscribe", () => {
+    const store = createThemeStore({
+      base: terminal,
+      themes: { terminal: {}, midnight },
+      active: "terminal",
+    });
+    let notified = 0;
+    const unsubscribe = store.subscribe(() => notified++);
+
+    unsubscribe();
+    store.setActive("midnight");
+
+    expect(notified).toBe(0);
+  });
+
+  it("follows renderer mode changes only while mode is system", () => {
+    const adaptive: ThemeDefinition = {
+      tokens: { colors: { background: "#101010" } },
+      light: { colors: { background: "#FAFAFA" } },
+    };
+    const store = createThemeStore({
+      base: terminal,
+      themes: { adaptive },
+      active: "adaptive",
+      mode: "system",
+    });
+    const renderer = new FakeRenderer();
+    renderer.themeMode = "light";
+
+    const unfollow = store.follow(renderer);
+    expect(store.get().colors.background).toBe("#FAFAFA");
+
+    renderer.emit("theme_mode", "dark");
+    expect(store.get().colors.background).toBe("#101010");
+
+    store.setMode("light");
+    renderer.emit("theme_mode", "dark");
+    expect(store.get().colors.background).toBe("#FAFAFA");
+
+    store.setMode("system");
+    expect(store.get().colors.background).toBe("#101010");
+
+    unfollow();
+    renderer.emit("theme_mode", "light");
+    expect(store.get().colors.background).toBe("#101010");
+  });
+
+  it("applies installed presets as partial overrides with base fallback", () => {
+    const store = createThemeStore({
+      base: terminal,
+      themes: { terminal: {}, "cobalt-deep": cobaltDeep, ascii },
+      active: "terminal",
+      mode: "dark",
+    });
+
+    store.setActive("cobalt-deep");
+    expect(store.get().colors.primary).toBe("#FFB000");
+    expect(store.get().colors.background).toBe("#0D1117");
+    expect(store.get().glyphs.check).toBe(terminal.glyphs.check);
+
+    store.setMode("light");
+    expect(store.get().colors.background).toBe("#F6F8FA");
+    expect(store.get().colors.primary).toBe("#B58500");
+
+    store.setActive("ascii");
+    expect(store.get().glyphs.check).toBe("x");
+    expect(store.get().glyphs.track).toBe("-");
+    expect(store.get().colors.primary).toBe(terminal.colors.primary);
+  });
+
+  it("blends colors toward an overlay with tint", () => {
+    const blended = tint(
+      RGBA.fromInts(0, 0, 0),
+      RGBA.fromInts(255, 255, 255),
+      0.5,
+    );
+
+    expect(blended.toInts().slice(0, 3)).toEqual([128, 128, 128]);
+    expect(tint("#000000", "#FFFFFF", 0).toInts().slice(0, 3)).toEqual([
+      0, 0, 0,
+    ]);
+  });
+
+  it("exposes the app-wide singleton resolved to the terminal default", () => {
+    expect(theme.get().glyphs.check).toBe("✓");
+    expect(theme.setActive("terminal")).toBe(true);
+  });
+});

--- a/registry/theme/smoke/react.test.tsx
+++ b/registry/theme/smoke/react.test.tsx
@@ -1,0 +1,48 @@
+/** @jsxImportSource @opentui/react */
+
+import { afterEach, expect, test } from "bun:test";
+import { parseColor, type TextRenderable } from "@opentui/core";
+import type { TestRendererSetup } from "@opentui/core/testing";
+import { testRender } from "@opentui/react/test-utils";
+import { act } from "react";
+import { theme } from "./components/ui/theme";
+import { useTheme } from "./components/ui/use-theme";
+import { ascii } from "./themes/ascii";
+import { cobaltDeep } from "./themes/cobalt-deep";
+
+let setup: TestRendererSetup | undefined;
+
+afterEach(async () => {
+  await act(async () => setup?.renderer.destroy());
+  setup = undefined;
+  theme.override(undefined);
+  theme.setActive("terminal");
+});
+
+function Mark() {
+  const tokens = useTheme();
+  return (
+    <text id="mark" content={tokens.glyphs.check} fg={tokens.colors.primary} />
+  );
+}
+
+test("installed React theme recipe restyles live components", async () => {
+  theme.register("ascii", ascii);
+  theme.register("cobalt-deep", cobaltDeep);
+  setup = await testRender(<Mark />, { width: 10, height: 3 });
+  const mark = setup.renderer.root.findDescendantById("mark") as TextRenderable;
+  expect(mark.plainText).toBe("✓");
+
+  await act(async () => {
+    theme.setActive("ascii");
+  });
+  await setup.waitFor(() => mark.plainText === "x");
+
+  await act(async () => {
+    theme.setMode("dark");
+    theme.setActive("cobalt-deep");
+  });
+  await setup.waitFor(() => mark.fg.equals(parseColor("#FFB000")));
+
+  expect(setup.renderer.root.findDescendantById("mark")).toBe(mark);
+});

--- a/registry/theme/smoke/solid.test.tsx
+++ b/registry/theme/smoke/solid.test.tsx
@@ -1,0 +1,40 @@
+/** @jsxImportSource @opentui/solid */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import type { TextRenderable } from "@opentui/core";
+import type { TestRendererSetup } from "@opentui/core/testing";
+import { testRender } from "@opentui/solid";
+import { theme } from "./components/ui/theme";
+import { useTheme } from "./components/ui/use-theme";
+import { ascii } from "./themes/ascii";
+
+let setup: TestRendererSetup | undefined;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = undefined;
+  theme.override(undefined);
+  theme.setActive("terminal");
+});
+
+describe("installed Solid theme recipe", () => {
+  it("restyles live components on theme switch", async () => {
+    theme.register("ascii", ascii);
+    setup = await testRender(
+      () => {
+        const tokens = useTheme();
+        return <text id="mark" content={tokens().glyphs.check} />;
+      },
+      { width: 10, height: 3 },
+    );
+    const mark = setup.renderer.root.findDescendantById(
+      "mark",
+    ) as TextRenderable;
+    expect(mark.plainText).toBe("✓");
+
+    theme.setActive("ascii");
+    await setup.waitFor(() => mark.plainText === "x");
+
+    expect(setup.renderer.root.findDescendantById("mark")).toBe(mark);
+  });
+});

--- a/registry/theme/solid.tsx
+++ b/registry/theme/solid.tsx
@@ -1,0 +1,9 @@
+import { type Accessor, createSignal, onCleanup } from "solid-js";
+import { type Tokens, theme } from "./theme";
+
+/** Reactive accessor over the resolved theme snapshot. */
+export function useTheme(): Accessor<Readonly<Tokens>> {
+  const [tokens, setTokens] = createSignal(theme.get());
+  onCleanup(theme.subscribe(() => setTokens(theme.get())));
+  return tokens;
+}

--- a/registry/theme/theme.ts
+++ b/registry/theme/theme.ts
@@ -102,12 +102,13 @@ function deepMerge<T>(base: T, layer: DeepPartial<T>): T {
   return merged as T;
 }
 
-function deepFreeze<T>(value: T): Readonly<T> {
-  if (isPlainObject(value)) {
-    for (const child of Object.values(value)) deepFreeze(child);
-    Object.freeze(value);
-  }
-  return value;
+/** Frozen deep copy; never freezes the caller's object, so `base` stays writable. */
+function deepFrozen<T>(value: T): Readonly<T> {
+  if (!isPlainObject(value)) return value;
+  const copy: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value))
+    copy[key] = deepFrozen(child);
+  return Object.freeze(copy) as Readonly<T>;
 }
 
 /**
@@ -133,7 +134,7 @@ export function createThemeStore(config: ThemeStoreConfig): ThemeStore {
       definition?.[resolvedMode()],
       overrides,
     ];
-    snapshot = deepFreeze(
+    snapshot = deepFrozen(
       layers.reduce<Tokens>(
         (tokens, layer) => (layer ? deepMerge(tokens, layer) : tokens),
         config.base,
@@ -245,7 +246,7 @@ export const terminal: Tokens = {
   },
   glyphs: {
     check: "✓",
-    radio: "o",
+    radio: "●",
     thumb: "●",
     track: "─",
   },

--- a/registry/theme/theme.ts
+++ b/registry/theme/theme.ts
@@ -1,0 +1,262 @@
+import {
+  type ColorInput,
+  parseColor,
+  RGBA,
+  type ThemeMode,
+} from "@opentui/core";
+
+/** Semantic token contract shared by every installed recipe. Extend freely. */
+export interface Tokens {
+  colors: {
+    background: ColorInput;
+    surface: ColorInput;
+    foreground: ColorInput;
+    mutedForeground: ColorInput;
+    border: ColorInput;
+    focus: ColorInput;
+    primary: ColorInput;
+    primaryForeground: ColorInput;
+    destructive: ColorInput;
+    destructiveForeground: ColorInput;
+    success: ColorInput;
+    successForeground: ColorInput;
+    warning: ColorInput;
+    warningForeground: ColorInput;
+    disabled: ColorInput;
+    disabledForeground: ColorInput;
+  };
+  glyphs: {
+    check: string;
+    radio: string;
+    thumb: string;
+    track: string;
+  };
+  borders: {
+    style: "single" | "rounded" | "double" | "heavy";
+  };
+  density: {
+    paddingX: number;
+    comfortablePaddingX: number;
+  };
+}
+
+export type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends RGBA
+    ? T[K]
+    : T[K] extends object
+      ? DeepPartial<T[K]>
+      : T[K];
+};
+
+/** A named theme: shared overrides plus optional per-mode overlays. */
+export interface ThemeDefinition {
+  tokens?: DeepPartial<Tokens>;
+  dark?: DeepPartial<Tokens>;
+  light?: DeepPartial<Tokens>;
+}
+
+export type ThemeModeSetting = ThemeMode | "system";
+
+/** Structural slice of CliRenderer consumed by `follow`. */
+export interface ThemeModeSource {
+  readonly themeMode: ThemeMode | null;
+  on(event: "theme_mode", listener: (mode: ThemeMode) => void): unknown;
+  off(event: "theme_mode", listener: (mode: ThemeMode) => void): unknown;
+}
+
+export interface ThemeStoreConfig {
+  base: Tokens;
+  themes?: Record<string, ThemeDefinition>;
+  active?: string;
+  mode?: ThemeModeSetting;
+}
+
+export interface ThemeStore {
+  get(): Readonly<Tokens>;
+  subscribe(listener: () => void): () => void;
+  setActive(name: string): boolean;
+  setMode(mode: ThemeModeSetting): void;
+  override(tokens: DeepPartial<Tokens> | undefined): void;
+  register(name: string, definition: ThemeDefinition): void;
+  follow(source: ThemeModeSource): () => void;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+function deepMerge<T>(base: T, layer: DeepPartial<T>): T {
+  const merged: Record<string, unknown> = { ...(base as object) };
+  for (const [key, value] of Object.entries(layer as object)) {
+    if (value === undefined) continue;
+    const current = merged[key];
+    merged[key] =
+      isPlainObject(current) && isPlainObject(value)
+        ? deepMerge(current, value)
+        : value;
+  }
+  return merged as T;
+}
+
+function deepFreeze<T>(value: T): Readonly<T> {
+  if (isPlainObject(value)) {
+    for (const child of Object.values(value)) deepFreeze(child);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+/**
+ * Resolves `base ⊕ active.tokens ⊕ active[mode] ⊕ override` eagerly into one
+ * frozen snapshot that stays referentially stable until the next change.
+ */
+export function createThemeStore(config: ThemeStoreConfig): ThemeStore {
+  const themes = new Map(Object.entries(config.themes ?? {}));
+  const listeners = new Set<() => void>();
+  let active = config.active ?? "";
+  let mode: ThemeModeSetting = config.mode ?? "system";
+  let detected: ThemeMode | undefined;
+  let overrides: DeepPartial<Tokens> | undefined;
+  let snapshot: Readonly<Tokens>;
+
+  const resolvedMode = (): ThemeMode =>
+    mode === "system" ? (detected ?? "dark") : mode;
+
+  const resolve = () => {
+    const definition = themes.get(active);
+    const layers = [
+      definition?.tokens,
+      definition?.[resolvedMode()],
+      overrides,
+    ];
+    snapshot = deepFreeze(
+      layers.reduce<Tokens>(
+        (tokens, layer) => (layer ? deepMerge(tokens, layer) : tokens),
+        config.base,
+      ),
+    );
+  };
+  resolve();
+
+  const notify = () => {
+    for (const listener of listeners) listener();
+  };
+
+  return {
+    get: () => snapshot,
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    setActive(name) {
+      if (!themes.has(name)) return false;
+      if (name !== active) {
+        active = name;
+        resolve();
+        notify();
+      }
+      return true;
+    },
+    setMode(next) {
+      if (next === mode) return;
+      const before = resolvedMode();
+      mode = next;
+      if (resolvedMode() !== before) {
+        resolve();
+        notify();
+      }
+    },
+    override(tokens) {
+      overrides = tokens;
+      resolve();
+      notify();
+    },
+    register(name, definition) {
+      themes.set(name, definition);
+      if (name === active) {
+        resolve();
+        notify();
+      }
+    },
+    follow(source) {
+      const apply = (next: ThemeMode) => {
+        if (next === detected) return;
+        const before = resolvedMode();
+        detected = next;
+        if (mode === "system" && resolvedMode() !== before) {
+          resolve();
+          notify();
+        }
+      };
+      if (source.themeMode) apply(source.themeMode);
+      const listener = (next: ThemeMode) => apply(next);
+      source.on("theme_mode", listener);
+      return () => {
+        source.off("theme_mode", listener);
+      };
+    },
+  };
+}
+
+/** Blend `overlay` into `base` by `alpha` (0–1); indexed and default-intent colors blend via their RGB snapshot. */
+export function tint(
+  base: ColorInput,
+  overlay: ColorInput,
+  alpha: number,
+): RGBA {
+  const from = parseColor(base);
+  const to = parseColor(overlay);
+  const channel = (a: number, b: number) =>
+    Math.round((a + (b - a) * alpha) * 255);
+  return RGBA.fromInts(
+    channel(from.r, to.r),
+    channel(from.g, to.g),
+    channel(from.b, to.b),
+    Math.round(from.a * 255),
+  );
+}
+
+/**
+ * Default theme built from ANSI-indexed colors, so recipes inherit whatever
+ * palette (and transparency) the terminal user configured.
+ */
+export const terminal: Tokens = {
+  colors: {
+    background: RGBA.defaultBackground(),
+    surface: RGBA.fromIndex(8), // bright black
+    foreground: RGBA.defaultForeground(),
+    mutedForeground: RGBA.fromIndex(7), // white
+    border: RGBA.fromIndex(8), // bright black
+    focus: RGBA.fromIndex(12), // bright blue
+    primary: RGBA.fromIndex(4), // blue
+    primaryForeground: RGBA.fromIndex(15), // bright white
+    destructive: RGBA.fromIndex(1), // red
+    destructiveForeground: RGBA.fromIndex(15), // bright white
+    success: RGBA.fromIndex(2), // green
+    successForeground: RGBA.fromIndex(15), // bright white
+    warning: RGBA.fromIndex(3), // yellow
+    warningForeground: RGBA.fromIndex(0), // black
+    disabled: RGBA.fromIndex(0), // black
+    disabledForeground: RGBA.fromIndex(8), // bright black
+  },
+  glyphs: {
+    check: "✓",
+    radio: "o",
+    thumb: "●",
+    track: "─",
+  },
+  borders: { style: "single" },
+  density: { paddingX: 1, comfortablePaddingX: 2 },
+};
+
+/** App-wide theme store; register presets here and switch with `setActive`. */
+export const theme = createThemeStore({
+  base: terminal,
+  themes: { terminal: {} },
+  active: "terminal",
+  mode: "system",
+});

--- a/registry/theme/themes/ascii.ts
+++ b/registry/theme/themes/ascii.ts
@@ -1,0 +1,13 @@
+import type { ThemeDefinition } from "../components/ui/theme";
+
+/** ASCII-only glyphs for fonts and terminals without Unicode coverage. */
+export const ascii: ThemeDefinition = {
+  tokens: {
+    glyphs: {
+      check: "x",
+      radio: "*",
+      thumb: "*",
+      track: "-",
+    },
+  },
+};

--- a/registry/theme/themes/catppuccin.ts
+++ b/registry/theme/themes/catppuccin.ts
@@ -1,0 +1,45 @@
+import type { ThemeDefinition } from "../components/ui/theme";
+
+/** Catppuccin (Mocha dark, Latte light); ported from the opencode TUI theme. */
+export const catppuccin: ThemeDefinition = {
+  tokens: {
+    colors: {
+      background: "#1E1E2E",
+      surface: "#313244",
+      foreground: "#CDD6F4",
+      mutedForeground: "#9399B2",
+      border: "#45475A",
+      focus: "#F5C2E7",
+      primary: "#89B4FA",
+      primaryForeground: "#1E1E2E",
+      destructive: "#F38BA8",
+      destructiveForeground: "#1E1E2E",
+      success: "#A6E3A1",
+      successForeground: "#1E1E2E",
+      warning: "#F9E2AF",
+      warningForeground: "#1E1E2E",
+      disabled: "#181825",
+      disabledForeground: "#585B70",
+    },
+  },
+  light: {
+    colors: {
+      background: "#EFF1F5",
+      surface: "#CCD0DA",
+      foreground: "#4C4F69",
+      mutedForeground: "#7C7F93",
+      border: "#BCC0CC",
+      focus: "#EA76CB",
+      primary: "#1E66F5",
+      primaryForeground: "#FFFFFF",
+      destructive: "#D20F39",
+      destructiveForeground: "#FFFFFF",
+      success: "#40A02B",
+      successForeground: "#FFFFFF",
+      warning: "#DF8E1D",
+      warningForeground: "#FFFFFF",
+      disabled: "#E6E9EF",
+      disabledForeground: "#ACB0BE",
+    },
+  },
+};

--- a/registry/theme/themes/cobalt-deep.ts
+++ b/registry/theme/themes/cobalt-deep.ts
@@ -1,0 +1,42 @@
+import type { ThemeDefinition } from "../components/ui/theme";
+
+/** Truecolor tuiparts.sh brand palette; trades terminal-native color for exact fidelity. */
+export const cobaltDeep: ThemeDefinition = {
+  tokens: {
+    colors: {
+      background: "#0D1117",
+      surface: "#161B22",
+      foreground: "#E8E4D9",
+      mutedForeground: "#A8A296",
+      border: "#30363D",
+      focus: "#FFC94D",
+      primary: "#FFB000",
+      primaryForeground: "#0D1117",
+      destructive: "#E5484D",
+      destructiveForeground: "#FBF8F0",
+      success: "#3FB950",
+      successForeground: "#0D1117",
+      warning: "#D29922",
+      warningForeground: "#0D1117",
+      disabled: "#161B22",
+      disabledForeground: "#6C675D",
+    },
+  },
+  light: {
+    colors: {
+      background: "#F6F8FA",
+      surface: "#EAEEF2",
+      foreground: "#1F2328",
+      mutedForeground: "#57606A",
+      border: "#D0D7DE",
+      primaryForeground: "#FFFFFF",
+      primary: "#B58500",
+      success: "#1A7F37",
+      successForeground: "#FFFFFF",
+      warning: "#9A6700",
+      warningForeground: "#FFFFFF",
+      disabled: "#EAEEF2",
+      disabledForeground: "#8C959F",
+    },
+  },
+};

--- a/registry/theme/themes/gruvbox.ts
+++ b/registry/theme/themes/gruvbox.ts
@@ -1,0 +1,45 @@
+import type { ThemeDefinition } from "../components/ui/theme";
+
+/** Gruvbox (dark and light hard-contrast pair); ported from the opencode TUI theme. */
+export const gruvbox: ThemeDefinition = {
+  tokens: {
+    colors: {
+      background: "#282828",
+      surface: "#3C3836",
+      foreground: "#EBDBB2",
+      mutedForeground: "#928374",
+      border: "#665C54",
+      focus: "#8EC07C",
+      primary: "#83A598",
+      primaryForeground: "#282828",
+      destructive: "#FB4934",
+      destructiveForeground: "#282828",
+      success: "#B8BB26",
+      successForeground: "#282828",
+      warning: "#FE8019",
+      warningForeground: "#282828",
+      disabled: "#3C3836",
+      disabledForeground: "#7C6F64",
+    },
+  },
+  light: {
+    colors: {
+      background: "#FBF1C7",
+      surface: "#EBDBB2",
+      foreground: "#3C3836",
+      mutedForeground: "#7C6F64",
+      border: "#BDAE93",
+      focus: "#427B58",
+      primary: "#076678",
+      primaryForeground: "#FBF1C7",
+      destructive: "#9D0006",
+      destructiveForeground: "#FBF1C7",
+      success: "#79740E",
+      successForeground: "#FBF1C7",
+      warning: "#AF3A03",
+      warningForeground: "#FBF1C7",
+      disabled: "#EBDBB2",
+      disabledForeground: "#BDAE93",
+    },
+  },
+};

--- a/registry/theme/themes/rosepine.ts
+++ b/registry/theme/themes/rosepine.ts
@@ -1,0 +1,45 @@
+import type { ThemeDefinition } from "../components/ui/theme";
+
+/** Rosé Pine (main dark, Dawn light); ported from the opencode TUI theme. */
+export const rosePine: ThemeDefinition = {
+  tokens: {
+    colors: {
+      background: "#191724",
+      surface: "#26233A",
+      foreground: "#E0DEF4",
+      mutedForeground: "#6E6A86",
+      border: "#403D52",
+      focus: "#EBBCBA",
+      primary: "#9CCFD8",
+      primaryForeground: "#191724",
+      destructive: "#EB6F92",
+      destructiveForeground: "#191724",
+      success: "#31748F",
+      successForeground: "#E0DEF4",
+      warning: "#F6C177",
+      warningForeground: "#191724",
+      disabled: "#1F1D2E",
+      disabledForeground: "#524F67",
+    },
+  },
+  light: {
+    colors: {
+      background: "#FAF4ED",
+      surface: "#F2E9E1",
+      foreground: "#575279",
+      mutedForeground: "#9893A5",
+      border: "#DFDAD9",
+      focus: "#D7827E",
+      primary: "#31748F",
+      primaryForeground: "#FAF4ED",
+      destructive: "#B4637A",
+      destructiveForeground: "#FAF4ED",
+      success: "#286983",
+      successForeground: "#FAF4ED",
+      warning: "#EA9D34",
+      warningForeground: "#FAF4ED",
+      disabled: "#F2E9E1",
+      disabledForeground: "#CECACD",
+    },
+  },
+};

--- a/registry/theme/tsconfig.core.json
+++ b/registry/theme/tsconfig.core.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../examples/core/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../../examples/core",
+    "paths": {
+      "*": ["node_modules/*"]
+    }
+  },
+  "include": ["theme.ts"]
+}

--- a/registry/theme/tsconfig.react.json
+++ b/registry/theme/tsconfig.react.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../examples/react/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../../examples/react",
+    "paths": {
+      "react": ["node_modules/@types/react/index.d.ts"],
+      "*": ["node_modules/*"]
+    }
+  },
+  "include": ["react.tsx"]
+}

--- a/registry/theme/tsconfig.solid.json
+++ b/registry/theme/tsconfig.solid.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../examples/solid/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "../../examples/solid",
+    "paths": {
+      "*": ["node_modules/*"]
+    }
+  },
+  "include": ["solid.tsx"]
+}

--- a/registry/toggle-group/core.ts
+++ b/registry/toggle-group/core.ts
@@ -5,6 +5,7 @@ import {
   ToggleGroupRenderable,
   type ToggleGroupStore,
 } from "@tuiparts/core/toggle-group";
+import { type Tokens, theme } from "./theme";
 
 /** Options for the consumer-owned imperative ToggleGroup layout. */
 export type ToggleGroupOptions = Omit<PrimitiveToggleGroupOptions, "store">;
@@ -18,6 +19,7 @@ export interface ToggleGroupItemOptions {
 
 class ToggleGroupItemRecipeRenderable extends ToggleRenderable {
   private readonly unsubscribeRecipe: () => void;
+  private readonly unsubscribeTheme: () => void;
 
   constructor(
     ctx: RenderContext,
@@ -33,19 +35,29 @@ class ToggleGroupItemRecipeRenderable extends ToggleRenderable {
     });
     const label = new TextRenderable(ctx, { content: options.label });
     this.add(label);
-    const applyState = (state: ToggleState) => {
+    const applyStyle = (tokens: Readonly<Tokens>, state: ToggleState) => {
       this.backgroundColor = state.pressed
-        ? "#2563EB"
+        ? tokens.colors.primary
         : state.focused
-          ? "#404040"
+          ? tokens.colors.surface
           : "transparent";
-      label.fg = state.disabled ? "#737373" : "#F5F5F5";
+      label.fg = state.disabled
+        ? tokens.colors.disabledForeground
+        : state.pressed
+          ? tokens.colors.primaryForeground
+          : tokens.colors.foreground;
     };
-    applyState(this.getState());
-    this.unsubscribeRecipe = this.subscribe(applyState);
+    applyStyle(theme.get(), this.getState());
+    this.unsubscribeTheme = theme.subscribe(() =>
+      applyStyle(theme.get(), this.getState()),
+    );
+    this.unsubscribeRecipe = this.subscribe((state) =>
+      applyStyle(theme.get(), state),
+    );
   }
 
   override destroy(): void {
+    this.unsubscribeTheme();
     this.unsubscribeRecipe();
     super.destroy();
   }

--- a/registry/toggle-group/core.ts
+++ b/registry/toggle-group/core.ts
@@ -26,11 +26,12 @@ class ToggleGroupItemRecipeRenderable extends ToggleRenderable {
     store: ToggleGroupStore,
     options: ToggleGroupItemOptions,
   ) {
+    const tokens = theme.get();
     super(ctx, {
       disabled: options.disabled,
       group: store,
       height: 1,
-      paddingX: 1,
+      paddingX: tokens.density.paddingX,
       value: options.value,
     });
     const label = new TextRenderable(ctx, { content: options.label });

--- a/registry/toggle-group/react.tsx
+++ b/registry/toggle-group/react.tsx
@@ -41,7 +41,7 @@ export function ToggleGroupItem({ label, ...props }: ToggleGroupItemProps) {
                 : "transparent"
           }
           height={1}
-          paddingX={1}
+          paddingX={tokens.density.paddingX}
         >
           <text
             content={label}

--- a/registry/toggle-group/react.tsx
+++ b/registry/toggle-group/react.tsx
@@ -2,6 +2,7 @@
 
 import { Toggle as TogglePrimitive } from "@tuiparts/react/toggle";
 import { ToggleGroup as ToggleGroupPrimitive } from "@tuiparts/react/toggle-group";
+import { useTheme } from "./use-theme";
 
 /** Props for the consumer-owned React ToggleGroup layout. */
 export type ToggleGroupProps = ToggleGroupPrimitive.Props;
@@ -27,21 +28,31 @@ export function ToggleGroup({ orientation, ...props }: ToggleGroupProps) {
 
 /** Consumer-owned React ToggleGroup item presentation. */
 export function ToggleGroupItem({ label, ...props }: ToggleGroupItemProps) {
+  const tokens = useTheme();
   return (
     <TogglePrimitive backgroundColor="transparent" {...props}>
       {(state) => (
         <box
           backgroundColor={
             state.pressed
-              ? "#2563EB"
+              ? tokens.colors.primary
               : state.focused
-                ? "#404040"
+                ? tokens.colors.surface
                 : "transparent"
           }
           height={1}
           paddingX={1}
         >
-          <text content={label} fg={state.disabled ? "#737373" : "#F5F5F5"} />
+          <text
+            content={label}
+            fg={
+              state.disabled
+                ? tokens.colors.disabledForeground
+                : state.pressed
+                  ? tokens.colors.primaryForeground
+                  : tokens.colors.foreground
+            }
+          />
         </box>
       )}
     </TogglePrimitive>

--- a/registry/toggle-group/smoke/core.test.ts
+++ b/registry/toggle-group/smoke/core.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, expect, test } from "bun:test";
+import { parseColor } from "@opentui/core";
 import {
   createTestRenderer,
   type TestRendererSetup,
 } from "@opentui/core/testing";
+import { theme } from "./components/ui/theme";
 import {
   createToggleGroup,
   createToggleGroupItem,
@@ -27,4 +29,25 @@ test("installed Core ToggleGroup recipe runtime smoke", async () => {
   await setup.renderOnce();
   left.press();
   expect(group.value).toEqual(["left"]);
+});
+
+test("restyles from the theme store on theme switch", async () => {
+  theme.register("smoke", { tokens: { colors: { primary: "#123456" } } });
+  setup = await createTestRenderer({ width: 30, height: 3 });
+  const group = createToggleGroup(setup.renderer);
+  const left = createToggleGroupItem(setup.renderer, group.store, {
+    label: "Left",
+    value: "left",
+  });
+  group.add(left);
+  setup.renderer.root.add(group);
+  await setup.renderOnce();
+  left.press();
+  expect(group.value).toEqual(["left"]);
+
+  theme.setActive("smoke");
+  expect(left.backgroundColor.equals(parseColor("#123456"))).toBe(true);
+
+  theme.setActive("terminal");
+  expect(left.backgroundColor.equals(parseColor("#123456"))).toBe(false);
 });

--- a/registry/toggle-group/smoke/react.test.tsx
+++ b/registry/toggle-group/smoke/react.test.tsx
@@ -1,11 +1,13 @@
 /** @jsxImportSource @opentui/react */
 
 import { afterEach, expect, test } from "bun:test";
+import { type BoxRenderable, parseColor } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import { ToggleRenderable } from "@tuiparts/core/toggle";
 import { ToggleGroupRenderable } from "@tuiparts/core/toggle-group";
 import { act } from "react";
+import { theme } from "./components/ui/theme";
 import { ToggleGroup, ToggleGroupItem } from "./components/ui/toggle-group";
 
 let setup: TestRendererSetup | undefined;
@@ -34,4 +36,30 @@ test("installed React ToggleGroup recipe runtime smoke", async () => {
   });
   await act(async () => left.press());
   expect(group.value).toEqual(["left"]);
+});
+
+test("restyles rendered items on theme switch", async () => {
+  theme.register("smoke", { tokens: { colors: { primary: "#123456" } } });
+  setup = await testRender(
+    <ToggleGroup id="themed" defaultValue={["left"]}>
+      <ToggleGroupItem id="themed-left" label="Left" value="left" />
+    </ToggleGroup>,
+    { width: 30, height: 3 },
+  );
+  const left = setup.renderer.root.findDescendantById(
+    "themed-left",
+  ) as ToggleRenderable;
+  const surface = left.getChildren()[0] as BoxRenderable;
+
+  await act(async () => {
+    theme.setActive("smoke");
+  });
+  await setup.waitFor(() =>
+    surface.backgroundColor.equals(parseColor("#123456")),
+  );
+
+  expect(setup.renderer.root.findDescendantById("themed-left")).toBe(left);
+  await act(async () => {
+    theme.setActive("terminal");
+  });
 });

--- a/registry/toggle-group/smoke/solid.test.tsx
+++ b/registry/toggle-group/smoke/solid.test.tsx
@@ -1,10 +1,12 @@
 /** @jsxImportSource @opentui/solid */
 
 import { afterEach, expect, test } from "bun:test";
+import { type BoxRenderable, parseColor } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/solid";
 import { ToggleRenderable } from "@tuiparts/core/toggle";
 import type { ToggleGroupRenderable } from "@tuiparts/core/toggle-group";
+import { theme } from "./components/ui/theme";
 import { ToggleGroup, ToggleGroupItem } from "./components/ui/toggle-group";
 
 let setup: TestRendererSetup | undefined;
@@ -29,4 +31,28 @@ test("installed Solid ToggleGroup recipe runtime smoke", async () => {
     throw new Error("Expected ToggleRenderable left");
   left.press();
   expect(group?.value).toEqual(["left"]);
+});
+
+test("restyles rendered items on theme switch", async () => {
+  theme.register("smoke", { tokens: { colors: { primary: "#123456" } } });
+  setup = await testRender(
+    () => (
+      <ToggleGroup id="themed" defaultValue={["left"]}>
+        <ToggleGroupItem id="themed-left" label="Left" value="left" />
+      </ToggleGroup>
+    ),
+    { width: 30, height: 3 },
+  );
+  const left = setup.renderer.root.findDescendantById(
+    "themed-left",
+  ) as ToggleRenderable;
+  const surface = left.getChildren()[0] as BoxRenderable;
+
+  theme.setActive("smoke");
+  await setup.waitFor(() =>
+    surface.backgroundColor.equals(parseColor("#123456")),
+  );
+
+  expect(setup.renderer.root.findDescendantById("themed-left")).toBe(left);
+  theme.setActive("terminal");
 });

--- a/registry/toggle-group/solid.tsx
+++ b/registry/toggle-group/solid.tsx
@@ -3,6 +3,7 @@
 import { Toggle as TogglePrimitive } from "@tuiparts/solid/toggle";
 import { ToggleGroup as ToggleGroupPrimitive } from "@tuiparts/solid/toggle-group";
 import { splitProps } from "solid-js";
+import { useTheme } from "./use-theme";
 
 /** Props for the consumer-owned Solid ToggleGroup layout. */
 export type ToggleGroupProps = ToggleGroupPrimitive.Props;
@@ -28,15 +29,16 @@ export function ToggleGroup(props: ToggleGroupProps) {
 /** Consumer-owned Solid ToggleGroup item presentation. */
 export function ToggleGroupItem(props: ToggleGroupItemProps) {
   const [recipe, toggle] = splitProps(props, ["label"]);
+  const tokens = useTheme();
   return (
     <TogglePrimitive backgroundColor="transparent" {...toggle}>
       {(state: TogglePrimitive.State) => (
         <box
           backgroundColor={
             state.pressed
-              ? "#2563EB"
+              ? tokens().colors.primary
               : state.focused
-                ? "#404040"
+                ? tokens().colors.surface
                 : "transparent"
           }
           height={1}
@@ -44,7 +46,13 @@ export function ToggleGroupItem(props: ToggleGroupItemProps) {
         >
           <text
             content={recipe.label}
-            fg={state.disabled ? "#737373" : "#F5F5F5"}
+            fg={
+              state.disabled
+                ? tokens().colors.disabledForeground
+                : state.pressed
+                  ? tokens().colors.primaryForeground
+                  : tokens().colors.foreground
+            }
           />
         </box>
       )}

--- a/registry/toggle-group/solid.tsx
+++ b/registry/toggle-group/solid.tsx
@@ -42,7 +42,7 @@ export function ToggleGroupItem(props: ToggleGroupItemProps) {
                 : "transparent"
           }
           height={1}
-          paddingX={1}
+          paddingX={tokens().density.paddingX}
         >
           <text
             content={recipe.label}

--- a/registry/toggle/core.ts
+++ b/registry/toggle/core.ts
@@ -20,13 +20,14 @@ class ToggleRecipeRenderable extends ToggleRenderable {
   private readonly unsubscribeTheme: () => void;
 
   constructor(ctx: RenderContext, options: ToggleOptions) {
+    const tokens = theme.get();
     super(ctx, {
       defaultPressed: options.defaultPressed,
       disabled: options.disabled,
       onPressedChange: options.onPressedChange,
       pressed: options.pressed,
       height: 1,
-      paddingX: 1,
+      paddingX: tokens.density.paddingX,
     });
     const label = new TextRenderable(ctx, { content: options.label });
     this.add(label);

--- a/registry/toggle/core.ts
+++ b/registry/toggle/core.ts
@@ -4,6 +4,7 @@ import {
   ToggleRenderable,
   type ToggleState,
 } from "@tuiparts/core/toggle";
+import { type Tokens, theme } from "./theme";
 
 /** Options for the consumer-owned imperative Toggle recipe. */
 export interface ToggleOptions {
@@ -16,6 +17,7 @@ export interface ToggleOptions {
 
 class ToggleRecipeRenderable extends ToggleRenderable {
   private readonly unsubscribeRecipe: () => void;
+  private readonly unsubscribeTheme: () => void;
 
   constructor(ctx: RenderContext, options: ToggleOptions) {
     super(ctx, {
@@ -28,19 +30,29 @@ class ToggleRecipeRenderable extends ToggleRenderable {
     });
     const label = new TextRenderable(ctx, { content: options.label });
     this.add(label);
-    const applyState = (state: ToggleState) => {
+    const applyStyle = (tokens: Readonly<Tokens>, state: ToggleState) => {
       this.backgroundColor = state.pressed
-        ? "#2563EB"
+        ? tokens.colors.primary
         : state.focused
-          ? "#404040"
+          ? tokens.colors.surface
           : "transparent";
-      label.fg = state.disabled ? "#737373" : "#F5F5F5";
+      label.fg = state.disabled
+        ? tokens.colors.disabledForeground
+        : state.pressed
+          ? tokens.colors.primaryForeground
+          : tokens.colors.foreground;
     };
-    applyState(this.getState());
-    this.unsubscribeRecipe = this.subscribe(applyState);
+    applyStyle(theme.get(), this.getState());
+    this.unsubscribeTheme = theme.subscribe(() =>
+      applyStyle(theme.get(), this.getState()),
+    );
+    this.unsubscribeRecipe = this.subscribe((state) =>
+      applyStyle(theme.get(), state),
+    );
   }
 
   override destroy(): void {
+    this.unsubscribeTheme();
     this.unsubscribeRecipe();
     super.destroy();
   }

--- a/registry/toggle/react.tsx
+++ b/registry/toggle/react.tsx
@@ -23,7 +23,7 @@ export function Toggle({ label, ...props }: ToggleProps) {
                 : "transparent"
           }
           height={1}
-          paddingX={1}
+          paddingX={tokens.density.paddingX}
         >
           <text
             content={label}

--- a/registry/toggle/react.tsx
+++ b/registry/toggle/react.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @opentui/react */
 
 import { Toggle as TogglePrimitive } from "@tuiparts/react/toggle";
+import { useTheme } from "./use-theme";
 
 /** Props for the consumer-owned React Toggle recipe. */
 export interface ToggleProps extends Omit<TogglePrimitive.Props, "children"> {
@@ -9,21 +10,31 @@ export interface ToggleProps extends Omit<TogglePrimitive.Props, "children"> {
 
 /** Consumer-owned React Toggle recipe. */
 export function Toggle({ label, ...props }: ToggleProps) {
+  const tokens = useTheme();
   return (
     <TogglePrimitive backgroundColor="transparent" {...props}>
       {(state) => (
         <box
           backgroundColor={
             state.pressed
-              ? "#2563EB"
+              ? tokens.colors.primary
               : state.focused
-                ? "#404040"
+                ? tokens.colors.surface
                 : "transparent"
           }
           height={1}
           paddingX={1}
         >
-          <text content={label} fg={state.disabled ? "#737373" : "#F5F5F5"} />
+          <text
+            content={label}
+            fg={
+              state.disabled
+                ? tokens.colors.disabledForeground
+                : state.pressed
+                  ? tokens.colors.primaryForeground
+                  : tokens.colors.foreground
+            }
+          />
         </box>
       )}
     </TogglePrimitive>

--- a/registry/toggle/smoke/core.test.ts
+++ b/registry/toggle/smoke/core.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, expect, test } from "bun:test";
+import { parseColor } from "@opentui/core";
 import {
   createTestRenderer,
   type TestRendererSetup,
 } from "@opentui/core/testing";
+import { theme } from "./components/ui/theme";
 import { createToggle } from "./components/ui/toggle";
 
 let setup: TestRendererSetup | undefined;
@@ -20,4 +22,21 @@ test("installed Core Toggle recipe runtime smoke", async () => {
   toggle.press();
   expect(toggle.pressed).toBe(true);
   expect(setup.captureCharFrame().includes("Bold")).toBe(true);
+});
+
+test("restyles from the theme store on theme switch", async () => {
+  theme.register("smoke", { tokens: { colors: { primary: "#123456" } } });
+  setup = await createTestRenderer({ width: 20, height: 3 });
+  const toggle = createToggle(setup.renderer, {
+    defaultPressed: true,
+    label: "Theme",
+  });
+  setup.renderer.root.add(toggle);
+  await setup.renderOnce();
+
+  theme.setActive("smoke");
+  expect(toggle.backgroundColor.equals(parseColor("#123456"))).toBe(true);
+
+  theme.setActive("terminal");
+  expect(toggle.backgroundColor.equals(parseColor("#123456"))).toBe(false);
 });

--- a/registry/toggle/smoke/react.test.tsx
+++ b/registry/toggle/smoke/react.test.tsx
@@ -1,10 +1,12 @@
 /** @jsxImportSource @opentui/react */
 
 import { afterEach, expect, test } from "bun:test";
+import { type BoxRenderable, parseColor } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import { ToggleRenderable } from "@tuiparts/core/toggle";
 import { act } from "react";
+import { theme } from "./components/ui/theme";
 import { Toggle } from "./components/ui/toggle";
 
 let setup: TestRendererSetup | undefined;
@@ -24,4 +26,28 @@ test("installed React Toggle recipe runtime smoke", async () => {
     throw new Error("Expected ToggleRenderable toggle");
   await act(async () => toggle.press());
   expect(toggle.pressed).toBe(true);
+});
+
+test("restyles rendered toggles on theme switch", async () => {
+  theme.register("smoke", { tokens: { colors: { primary: "#123456" } } });
+  setup = await testRender(
+    <Toggle id="themed" defaultPressed label="Theme" />,
+    { width: 20, height: 3 },
+  );
+  const themed = setup.renderer.root.findDescendantById(
+    "themed",
+  ) as ToggleRenderable;
+  const surface = themed.getChildren()[0] as BoxRenderable;
+
+  await act(async () => {
+    theme.setActive("smoke");
+  });
+  await setup.waitFor(() =>
+    surface.backgroundColor.equals(parseColor("#123456")),
+  );
+
+  expect(setup.renderer.root.findDescendantById("themed")).toBe(themed);
+  await act(async () => {
+    theme.setActive("terminal");
+  });
 });

--- a/registry/toggle/smoke/solid.test.tsx
+++ b/registry/toggle/smoke/solid.test.tsx
@@ -1,9 +1,11 @@
 /** @jsxImportSource @opentui/solid */
 
 import { afterEach, expect, test } from "bun:test";
+import { type BoxRenderable, parseColor } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/solid";
 import { ToggleRenderable } from "@tuiparts/core/toggle";
+import { theme } from "./components/ui/theme";
 import { Toggle } from "./components/ui/toggle";
 
 let setup: TestRendererSetup | undefined;
@@ -23,4 +25,24 @@ test("installed Solid Toggle recipe runtime smoke", async () => {
     throw new Error("Expected ToggleRenderable toggle");
   toggle.press();
   expect(toggle.pressed).toBe(true);
+});
+
+test("restyles rendered toggles on theme switch", async () => {
+  theme.register("smoke", { tokens: { colors: { primary: "#123456" } } });
+  setup = await testRender(
+    () => <Toggle id="themed" defaultPressed label="Theme" />,
+    { width: 20, height: 3 },
+  );
+  const themed = setup.renderer.root.findDescendantById(
+    "themed",
+  ) as ToggleRenderable;
+  const surface = themed.getChildren()[0] as BoxRenderable;
+
+  theme.setActive("smoke");
+  await setup.waitFor(() =>
+    surface.backgroundColor.equals(parseColor("#123456")),
+  );
+
+  expect(setup.renderer.root.findDescendantById("themed")).toBe(themed);
+  theme.setActive("terminal");
 });

--- a/registry/toggle/solid.tsx
+++ b/registry/toggle/solid.tsx
@@ -25,7 +25,7 @@ export function Toggle(props: ToggleProps) {
                 : "transparent"
           }
           height={1}
-          paddingX={1}
+          paddingX={tokens().density.paddingX}
         >
           <text
             content={recipe.label}

--- a/registry/toggle/solid.tsx
+++ b/registry/toggle/solid.tsx
@@ -2,6 +2,7 @@
 
 import { Toggle as TogglePrimitive } from "@tuiparts/solid/toggle";
 import { splitProps } from "solid-js";
+import { useTheme } from "./use-theme";
 
 /** Props for the consumer-owned Solid Toggle recipe. */
 export interface ToggleProps extends Omit<TogglePrimitive.Props, "children"> {
@@ -11,15 +12,16 @@ export interface ToggleProps extends Omit<TogglePrimitive.Props, "children"> {
 /** Consumer-owned Solid Toggle recipe. */
 export function Toggle(props: ToggleProps) {
   const [recipe, toggle] = splitProps(props, ["label"]);
+  const tokens = useTheme();
   return (
     <TogglePrimitive backgroundColor="transparent" {...toggle}>
       {(state: TogglePrimitive.State) => (
         <box
           backgroundColor={
             state.pressed
-              ? "#2563EB"
+              ? tokens().colors.primary
               : state.focused
-                ? "#404040"
+                ? tokens().colors.surface
                 : "transparent"
           }
           height={1}
@@ -27,7 +29,13 @@ export function Toggle(props: ToggleProps) {
         >
           <text
             content={recipe.label}
-            fg={state.disabled ? "#737373" : "#F5F5F5"}
+            fg={
+              state.disabled
+                ? tokens().colors.disabledForeground
+                : state.pressed
+                  ? tokens().colors.primaryForeground
+                  : tokens().colors.foreground
+            }
           />
         </box>
       )}

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -67,6 +67,7 @@ const recipes = [
   "dialog",
   "toggle",
   "toggle-group",
+  "theme",
 ];
 const foundationCatalogRecipes = [
   "checkbox",
@@ -77,6 +78,35 @@ const foundationCatalogRecipes = [
   "input",
   "toggle",
   "toggle-group",
+  "theme",
+];
+const primitivelessRecipes = ["badge", "theme"];
+const themePresets = [
+  {
+    item: "theme-cobalt-deep",
+    source: "registry/theme/themes/cobalt-deep.ts",
+    target: "themes/cobalt-deep.ts",
+  },
+  {
+    item: "theme-ascii",
+    source: "registry/theme/themes/ascii.ts",
+    target: "themes/ascii.ts",
+  },
+  {
+    item: "theme-catppuccin",
+    source: "registry/theme/themes/catppuccin.ts",
+    target: "themes/catppuccin.ts",
+  },
+  {
+    item: "theme-gruvbox",
+    source: "registry/theme/themes/gruvbox.ts",
+    target: "themes/gruvbox.ts",
+  },
+  {
+    item: "theme-rosepine",
+    source: "registry/theme/themes/rosepine.ts",
+    target: "themes/rosepine.ts",
+  },
 ];
 const expectedCatalogDependencyNames = {
   core: {
@@ -104,14 +134,32 @@ const expectedCatalogDependencyNames = {
     recipe: ["@opentui/core", "@opentui/solid", "solid-js"],
   },
 };
+function consumerFiles(recipe, framework, extension) {
+  if (recipe !== "theme") {
+    return [
+      {
+        source: `registry/${recipe}/${framework}.${extension}`,
+        target: `components/ui/${recipe}.${extension}`,
+      },
+    ];
+  }
+  const themeSource = { source: "registry/theme/theme.ts", target: "components/ui/theme.ts" };
+  if (framework === "core") return [themeSource];
+  return [
+    themeSource,
+    {
+      source: `registry/theme/${framework}.${extension}`,
+      target: "components/ui/use-theme.tsx",
+    },
+  ];
+}
 const consumers = recipes.flatMap((recipe) =>
   Object.entries(frameworks).map(([framework, config]) => ({
     ...config,
     localPackages: config.localPackages,
     framework,
     recipe,
-    source: `registry/${recipe}/${framework}.${config.extension}`,
-    target: `components/ui/${recipe}.${config.extension}`,
+    files: consumerFiles(recipe, framework, config.extension),
     smoke: `registry/${recipe}/smoke/${framework}.test.${config.extension}`,
   })),
 );
@@ -241,6 +289,15 @@ function consumersAffectedBy(paths) {
       selected.add(`${recipeMatch[2]}/${recipeMatch[1]}`);
       continue;
     }
+    if (
+      path.startsWith("registry/theme/") &&
+      !path.startsWith("registry/theme/smoke/")
+    ) {
+      selected.add("core/theme");
+      selected.add("react/theme");
+      selected.add("solid/theme");
+      continue;
+    }
     if (path.startsWith("packages/core/")) {
       exhaustive = true;
       continue;
@@ -298,13 +355,31 @@ try {
     const item = registry.items.find((candidate) => candidate.name === itemName);
     assert(item, `Missing registry item ${itemName}`);
     assert(
-      item.files.length === 1 &&
-        item.files[0]?.path === consumer.source &&
-        item.files[0]?.target === consumer.target,
+      item.files.length === consumer.files.length &&
+        consumer.files.every(
+          (file, index) =>
+            item.files[index]?.path === file.source &&
+            item.files[index]?.target === file.target,
+        ),
       `${itemName} must map its recipe source to the expected consumer target`,
     );
-    assert(existsSync(join(root, consumer.source)), `Missing ${consumer.source}`);
+    for (const file of consumer.files) {
+      assert(existsSync(join(root, file.source)), `Missing ${file.source}`);
+    }
     assert(existsSync(join(root, consumer.smoke)), `Missing ${consumer.smoke}`);
+  }
+  for (const preset of themePresets) {
+    const item = registry.items.find(
+      (candidate) => candidate.name === preset.item,
+    );
+    assert(item, `Missing registry item ${preset.item}`);
+    assert(
+      item.files.length === 1 &&
+        item.files[0]?.path === preset.source &&
+        item.files[0]?.target === preset.target,
+      `${preset.item} must map its preset source to the expected consumer target`,
+    );
+    assert(existsSync(join(root, preset.source)), `Missing ${preset.source}`);
   }
   for (const item of registry.items) {
     if (item.meta?.framework === "react") {
@@ -348,7 +423,9 @@ try {
         item.meta?.updateStrategy === "shadcn-diff",
         `${itemName} must declare the shadcn diff update strategy`,
       );
-      const recipeKind = recipe === "badge" ? "recipe" : "primitive";
+      const recipeKind = primitivelessRecipes.includes(recipe)
+        ? "recipe"
+        : "primitive";
       const actualDependencies = item.dependencies.map(packageName).sort();
       const expectedDependencies = expectedCatalogDependencyNames[framework][
         recipeKind
@@ -480,6 +557,9 @@ try {
       const tarball = tarballs.get(name);
       return tarball ? `${name}@file:${tarball}` : dependency;
     });
+    installItem.registryDependencies = installItem.registryDependencies?.map(
+      (address) => address.replace("https://tuiparts.sh/r/", `${registryDir}/`),
+    );
     const installItemPath = join(
       workDir,
       `${consumer.framework}-${consumer.recipe}-install.json`,
@@ -505,7 +585,7 @@ try {
       .join("\n");
     writeFileSync(
       join(consumerDir, "pnpm-workspace.yaml"),
-      `packages:\n  - "."\n\noverrides:\n${overrides}\n`,
+      `packages:\n  - "."\n${overrides ? `\noverrides:\n${overrides}\n` : ""}`,
     );
     writeJson(join(consumerDir, "tsconfig.json"), {
       compilerOptions: {
@@ -521,7 +601,10 @@ try {
         types: ["bun", "node"],
         ...consumer.compilerOptions,
       },
-      include: [consumer.target, ...(consumer.smoke ? [consumer.smokeFile] : [])],
+      include: [
+        ...consumer.files.map((file) => file.target),
+        ...(consumer.smoke ? [consumer.smokeFile] : []),
+      ],
     });
     writeJson(join(consumerDir, "components.json"), {
       $schema: "https://ui.shadcn.com/schema.json",
@@ -559,13 +642,15 @@ try {
       "--yes",
     ]);
 
-    assert(
-      readFileSync(join(consumerDir, consumer.target), "utf8") ===
-        readFileSync(join(root, consumer.source), "utf8"),
-      `Installed ${itemName} recipe differs from its registry source`,
-    );
+    for (const file of consumer.files) {
+      assert(
+        readFileSync(join(consumerDir, file.target), "utf8") ===
+          readFileSync(join(root, file.source), "utf8"),
+        `Installed ${itemName} recipe differs from its registry source`,
+      );
+    }
     if (itemName === "react/checkbox") {
-      const targetPath = join(consumerDir, consumer.target);
+      const targetPath = join(consumerDir, consumer.files[0].target);
       const localMarker = `// consumer-owned edit for ${itemName}`;
       const upstreamMarker = `// upstream recipe change for ${itemName}`;
       writeFileSync(
@@ -624,8 +709,14 @@ try {
     const allowedChanges = new Set([
       "package.json",
       "pnpm-lock.yaml",
-      consumer.target,
+      ...consumer.files.map((file) => file.target),
     ]);
+    if (registryItem.registryDependencies?.length) {
+      allowedChanges.add("components/ui/theme.ts");
+      if (consumer.framework === "react" || consumer.framework === "solid") {
+        allowedChanges.add("components/ui/use-theme.tsx");
+      }
+    }
     for (const [path, content] of afterInstall) {
       if (allowedChanges.has(path)) continue;
       assert(
@@ -666,6 +757,35 @@ try {
         localLockfile.includes(`file:${tarballs.get(name)}`),
         `${itemName} lockfile did not resolve ${name} locally`,
       );
+    }
+
+    if (consumer.recipe === "theme") {
+      for (const preset of themePresets) {
+        const presetInstallPath = join(
+          workDir,
+          `${consumer.framework}-${preset.item}-install.json`,
+        );
+        writeJson(
+          presetInstallPath,
+          JSON.parse(
+            readFileSync(join(registryDir, `${preset.item}.json`), "utf8"),
+          ),
+        );
+        await capture("pnpm", [
+          "exec",
+          "shadcn",
+          "add",
+          presetInstallPath,
+          "--cwd",
+          consumerDir,
+          "--yes",
+        ]);
+        assert(
+          readFileSync(join(consumerDir, preset.target), "utf8") ===
+            readFileSync(join(root, preset.source), "utf8"),
+          `Installed ${preset.item} preset differs from its registry source`,
+        );
+      }
     }
 
     if (consumer.smoke) {

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -143,7 +143,10 @@ function consumerFiles(recipe, framework, extension) {
       },
     ];
   }
-  const themeSource = { source: "registry/theme/theme.ts", target: "components/ui/theme.ts" };
+  const themeSource = {
+    source: "registry/theme/theme.ts",
+    target: "components/ui/theme.ts",
+  };
   if (framework === "core") return [themeSource];
   return [
     themeSource,
@@ -233,6 +236,14 @@ function assert(condition, message) {
 
 function writeJson(path, value) {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+/** Points an item's registry dependencies at the locally built registry. */
+function localizeRegistryDependencies(item) {
+  item.registryDependencies = item.registryDependencies?.map((address) =>
+    address.replace("https://tuiparts.sh/r/", `${registryDir}/`),
+  );
+  return item;
 }
 
 function packageName(specifier) {
@@ -557,9 +568,7 @@ try {
       const tarball = tarballs.get(name);
       return tarball ? `${name}@file:${tarball}` : dependency;
     });
-    installItem.registryDependencies = installItem.registryDependencies?.map(
-      (address) => address.replace("https://tuiparts.sh/r/", `${registryDir}/`),
-    );
+    localizeRegistryDependencies(installItem);
     const installItemPath = join(
       workDir,
       `${consumer.framework}-${consumer.recipe}-install.json`,
@@ -712,10 +721,12 @@ try {
       ...consumer.files.map((file) => file.target),
     ]);
     if (registryItem.registryDependencies?.length) {
-      allowedChanges.add("components/ui/theme.ts");
-      if (consumer.framework === "react" || consumer.framework === "solid") {
-        allowedChanges.add("components/ui/use-theme.tsx");
-      }
+      const themeFiles = consumerFiles(
+        "theme",
+        consumer.framework,
+        consumer.extension,
+      );
+      for (const file of themeFiles) allowedChanges.add(file.target);
     }
     for (const [path, content] of afterInstall) {
       if (allowedChanges.has(path)) continue;
@@ -767,8 +778,10 @@ try {
         );
         writeJson(
           presetInstallPath,
-          JSON.parse(
-            readFileSync(join(registryDir, `${preset.item}.json`), "utf8"),
+          localizeRegistryDependencies(
+            JSON.parse(
+              readFileSync(join(registryDir, `${preset.item}.json`), "utf8"),
+            ),
           ),
         );
         await capture("pnpm", [


### PR DESCRIPTION
## Summary

Ships the registry-only theming system designed in ADR 0006: every recipe now reads its colors, glyphs, and density from a consumer-owned theme file instead of hard-coded literals.

### Theme recipe (multi-file registry item)

- `registry/theme/theme.ts` — the single shared source installed as `components/ui/theme.ts` by all three adapters: the `Tokens` contract (16 semantic colors incl. `success`/`warning` pairs, glyphs, borders, density), a small subscription store (`get`/`subscribe`/`setActive`/`setMode`/`override`/`register`/`follow`), the `tint` blend helper, and an ANSI-indexed `terminal` default that inherits the terminal user's palette and transparency.
- React/Solid items additionally install a tiny `components/ui/use-theme.tsx` binding.
- `"system"` mode follows the terminal's live light/dark signal via `theme.follow(renderer)` (OSC-based `theme_mode` events), falling back to dark.

### Recipes

All nine recipes (button, checkbox, switch, radio-group, toggle, toggle-group, input, badge, dialog) migrated to tokens across core/react/solid, declaring their adapter's `theme` item in `registryDependencies`. Interaction states outside the vocabulary derive via `tint`: button pressed flash, dialog backdrop scrim, input focus emphasis. Every smoke gains a live theme-switch test.

### Preset catalog

Framework-neutral `theme-<name>` items installing to `themes/<name>.ts`:

- `theme-cobalt-deep` — brand palette (dark + light)
- `theme-ascii` — glyph-only compatibility preset
- `theme-catppuccin` (Mocha/Latte), `theme-gruvbox` (dark/light), `theme-rosepine` (main/Dawn) — ported from the opencode TUI theme catalog

Presets are `DeepPartial` overrides merged over the consumer's base, so consumer token extensions never break a preset install.

### Validation

`validate-registry.mjs` extended: theme consumers for all three frameworks, preset install + byte-compare inside them, `registryDependencies` URL→local rewrite for isolated installs. Full 30-consumer matrix green.

### Docs

New `/docs/theming` page (token contract, store API, system-mode behavior, out-of-the-box themes, custom themes incl. extending/reshaping the contract); registry catalog table, quickstart, catalog index, badge/button pages refreshed; registry README and ADR 0006 added.
