### PR TITLE
feat(core): concentrate activation behavior in one internal Pressable base class

### DIFF
--- a/.changeset/pressable-base-class.md
+++ b/.changeset/pressable-base-class.md
@@ -1,0 +1,26 @@
+---
+"@tuiparts/core": minor
+---
+
+Concentrate activation behavior in one internal Pressable base class
+(ADR-0007). Checkbox, Switch, Button, Toggle, Radio, and Dialog Trigger/Close
+now share a single interaction contract instead of five drifted copies.
+
+Behavior changes:
+
+- Keyboard activation everywhere is an uncancelled, unmodified Space or Enter
+  press. Modifier chords (Ctrl/Meta/Shift/Option/Super/Hyper) and keys with
+  `defaultPrevented` no longer activate any Root. Previously Checkbox and
+  Switch ignored both guards, Button ignored modifiers, Radio ignored
+  cancellation, and Dialog Trigger/Close ignored everything.
+- Pointer activation everywhere requires an uncancelled primary-button press
+  that starts and ends on the node (Button's model). Previously every
+  non-Button Root activated on any primary release over the node, including
+  drags that started elsewhere.
+
+Breaking (pre-release):
+
+- `RadioGroupChangeDetails.source` renames `"programmatic"` to
+  `"imperative"`, unifying the press vocabulary across the catalog.
+- `PressDetails` is exported from the core root as the canonical gesture
+  type; `ButtonPressDetails` and `ToggleChangeDetails` remain as aliases.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ tuiparts/
 
 | Symbol | Type | Location | Role |
 |--------|------|----------|------|
+| `PressableRenderable` | Class | `packages/core/src/internal/pressable.ts` | Shared activation behavior (guards, pointer model, focus sync) for all press-activated Roots (ADR-0007) |
 | `CheckboxRootRenderable` | Class | `packages/core/src/checkbox/primitive.ts` | Checkbox state, activation, and Indicator owner |
 | `toast` | Object | `packages/toast/src/state.ts` | Global toast API (toast.success, toast.error, etc.) |
 | `ToasterRenderable` | Class | `packages/toast/src/renderables/toaster.ts` | Container that manages toast notifications |

--- a/FOUNDATION_PRIMITIVE_CONTRACT.md
+++ b/FOUNDATION_PRIMITIVE_CONTRACT.md
@@ -271,10 +271,20 @@ itself.
 
 - Disabled behavior gates focus and semantic activation at every input seam,
   including imperative actions where applicable.
-- Keyboard handlers consume only keys they handle. Modifier handling and key
-  maps are primitive-specific and documented.
+- Keyboard handlers consume only keys they handle. Press-activated primitives
+  share one activation guard: an uncancelled, unmodified Space or Enter press.
+  Cancelled keys and modifier chords are never consumed. Additional
+  primitive-specific keys, such as roving-focus navigation, are documented per
+  primitive and observe the same cancellation and modifier guards.
 - Pointer handlers honor prior `defaultPrevented` state and supported button
-  semantics before activating.
+  semantics before activating. Press-activated primitives share one pointer
+  model: activation requires an uncancelled primary-button press that starts
+  and ends on the node; releasing elsewhere, dragging off, or cancelling
+  either half of the gesture abandons it.
+- The shared activation guard, pointer model, disabled-driven focusability,
+  and focus mirroring live in one internal Pressable behavior module
+  (`core/src/internal/pressable.ts`); press-activated Roots do not
+  re-implement them (ADR-0007).
 - Actual focus belongs to OpenTUI Renderables. Stores may coordinate eligible
   targets, roving tab stops, restoration targets, and topmost ownership, but
   they do not invent a second focused node.

--- a/docs/adr/0007-pressable-base-class.md
+++ b/docs/adr/0007-pressable-base-class.md
@@ -1,0 +1,92 @@
+---
+status: accepted
+---
+
+# Concentrate activation behavior in one internal Pressable base class
+
+Every press-activated Root — Checkbox, Switch, Button, Toggle, Radio, and the
+Dialog Trigger and Close parts — subclasses the internal
+`PressableRenderable` (`core/src/internal/pressable.ts`). The base owns the
+gesture contract; subclasses own what one semantic press means.
+
+## Context
+
+Five core Roots independently re-implemented the same ~70–80 lines of
+activation plumbing: mouse-up activation, Space/Enter key handling,
+disabled-driven focusability and blur, focus mirroring into the Store, Store
+adoption, and teardown. The copies drifted. Four different keyboard guard
+sets shipped at once: Checkbox and Switch checked neither `defaultPrevented`
+nor modifiers (Ctrl+Space toggled a checkbox), Button skipped modifiers,
+Radio skipped `defaultPrevented`, and Dialog Trigger/Close checked nothing.
+Two pointer models coexisted: Button required a press to start and end on the
+node; everything else activated on any primary release over the node.
+
+The codebase already had the proven fix at an adjacent seam:
+`RovingCollectionStore` is an internal base class with protected hooks that
+both group Stores subclass.
+
+## Decision
+
+### One shared interaction contract
+
+- Keyboard activation is an uncancelled, unmodified Space or Enter press.
+  Cancelled keys and modifier chords are never consumed.
+- Pointer activation requires an uncancelled primary-button press that starts
+  and ends on the node. Releasing elsewhere, dragging off, or cancelling
+  either half abandons the gesture. This adopts Button's model everywhere.
+
+### One internal base class
+
+`PressableRenderable extends BoxRenderable` owns mouse handling (via
+`onMouseEvent`), the activation key map (via `handleKeyPress`), disabled
+focusability sync, focus mirroring, the public imperative `press()`, and
+source teardown. Subclasses supply:
+
+- `handlePress(details)` — required; the meaning of one semantic press.
+- `handleUnclaimedKey(key)` — optional; keys beyond the activation map, such
+  as roving-focus navigation (Toggle, Radio).
+- `pressableDisabled()` / `pressableFocusable()` — optional; state shapes
+  that diverge from a plain Store (Radio's collection item state, Toggle's
+  roving tab stop).
+- `onPointerPressedChanged(pressed)` — optional; visual pressed state
+  (Button).
+
+### A minimal Store interface, satisfied structurally
+
+The base consumes a `PressableStore` — `state.disabled`, `subscribe()`,
+optional `setFocused()` — attached by the subclass constructor through
+`attachPressable(store)` after its Store exists. Every foundation Store
+satisfies the interface structurally, so Roots attach their Store directly
+with no adapter object. Radio keeps its custom collection subscription and
+only overrides the hooks; Dialog Trigger/Close attach nothing and stay
+permanently enabled. A future Store with a diverging state shape can attach
+an inline adapter literal at the same seam.
+
+### One press-details vocabulary
+
+`PressDetails` (`{source: "imperative"}` | `{key, source: "keyboard"}` |
+`{button: 0, source: "pointer"}`) is the single gesture vocabulary, exported
+from the core root. `ButtonPressDetails` and `ToggleChangeDetails` are
+aliases of it. `RadioGroupChangeDetails.source` renamed `"programmatic"` to
+`"imperative"` to match; this pre-release break landed before the first
+published foundation version.
+
+### Testing
+
+The activation matrix — guards, pointer model, disabled sync, focus
+mirroring, source lifecycle — is proven once at the internal seam in
+`core/src/internal/pressable.test.ts` through a minimal fake subclass. Each
+Root's suite keeps one pointer and one keyboard wiring round-trip plus its
+genuinely unique behavior, and does not re-prove the matrix.
+
+## Consequences
+
+- Guard and pointer fixes land once and apply to every press-activated Root.
+- New press-activated primitives implement `handlePress` and adapt a source;
+  they do not copy plumbing.
+- The interaction rules in `FOUNDATION_PRIMITIVE_CONTRACT.md` now state the
+  shared guard and pointer model; per-primitive drift from them is a
+  conformance failure, not a documented idiosyncrasy.
+- Behavior changes shipped with this decision: modifier chords and cancelled
+  keys no longer activate any Root; pointer activation now requires the
+  press to start on the node; Dialog Trigger/Close honor both rules.

--- a/packages/core/src/button/button-primitive.test.ts
+++ b/packages/core/src/button/button-primitive.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { BoxRenderable, type KeyEvent, TextRenderable } from "@opentui/core";
+import { type KeyEvent, TextRenderable } from "@opentui/core";
 import {
   createTestRenderer,
   type TestRendererSetup,
@@ -78,52 +78,33 @@ describe("Button primitive", () => {
     expect(presses.every(Object.isFrozen)).toBe(true);
   });
 
-  it("tracks primary-pointer press state and activates only on an uncancelled release", async () => {
+  // The shared activation matrix (guards, pointer model, disabled sync) is
+  // proven once in internal/pressable.test.ts; these cover the pressed-state
+  // wiring that is unique to the Button Store.
+  it("mirrors primary-pointer press state and presses on release", async () => {
     setup = await createTestRenderer({ width: 30, height: 5 });
     const presses: ButtonPressDetails[] = [];
-    const active = new ButtonRenderable(setup.renderer, {
+    const root = new ButtonRenderable(setup.renderer, {
       height: 1,
       onPress: (details) => presses.push(details),
       width: 5,
     });
-    const cancelled = new ButtonRenderable(setup.renderer, {
-      height: 1,
-      onMouseUp: (event) => event.preventDefault(),
-      onPress: (details) => presses.push(details),
-      width: 5,
-    });
-    const row = new BoxRenderable(setup.renderer, {
-      flexDirection: "row",
-      height: 1,
-      width: 10,
-    });
-    row.add(active);
-    row.add(cancelled);
-    setup.renderer.root.add(row);
+    setup.renderer.root.add(root);
     await setup.renderOnce();
 
     await setup.mockMouse.pressDown(0, 0);
-    expect(active.getState().pressed).toBe(true);
+    expect(root.getState().pressed).toBe(true);
     await setup.mockMouse.release(0, 0);
-    expect(active.getState()).toEqual({
+    expect(root.getState()).toEqual({
       disabled: false,
       focused: true,
       pressed: false,
     });
     expect(presses).toEqual([{ button: 0, source: "pointer" }]);
     expect(Object.isFrozen(presses[0])).toBe(true);
-
-    await setup.mockMouse.pressDown(5, 0);
-    expect(cancelled.getState().pressed).toBe(true);
-    await setup.mockMouse.release(5, 0);
-    expect(cancelled.getState().pressed).toBe(false);
-    expect(presses).toHaveLength(1);
-
-    await setup.mockMouse.click(0, 0, 2);
-    expect(presses).toHaveLength(1);
   });
 
-  it("resets pressed state on disablement, blur, and teardown while disabled gates every activation seam", async () => {
+  it("resets pressed state on disablement, blur, and teardown", async () => {
     setup = await createTestRenderer({ width: 30, height: 5 });
     const presses: ButtonPressDetails[] = [];
     const root = new ButtonRenderable(setup.renderer, {
@@ -143,21 +124,14 @@ describe("Button primitive", () => {
     });
 
     root.disabled = true;
-    expect(root.focusable).toBe(false);
     expect(root.getState()).toEqual({
       disabled: true,
       focused: false,
       pressed: false,
     });
-    root.focus();
-    root.press();
-    expect(root.handleKeyPress({ name: "space" } as KeyEvent)).toBe(false);
-    await setup.mockMouse.click(0, 0);
-    expect(root.focused).toBe(false);
     expect(presses).toEqual([]);
 
     root.disabled = undefined;
-    expect(root.focusable).toBe(true);
     root.focus();
     await setup.mockMouse.pressDown(0, 0);
     root.blur();

--- a/packages/core/src/button/primitive.ts
+++ b/packages/core/src/button/primitive.ts
@@ -1,15 +1,7 @@
-import {
-  type BoxOptions,
-  BoxRenderable,
-  type KeyEvent,
-  type MouseEvent,
-  type RenderContext,
-} from "@opentui/core";
+import type { BoxOptions, RenderContext } from "@opentui/core";
+import { PressableRenderable, type PressDetails } from "../internal/pressable";
 
-export type ButtonPressDetails =
-  | Readonly<{ source: "imperative" }>
-  | Readonly<{ key: "enter" | "space"; source: "keyboard" }>
-  | Readonly<{ button: 0; source: "pointer" }>;
+export type ButtonPressDetails = PressDetails;
 
 export interface ButtonState {
   readonly disabled: boolean;
@@ -88,11 +80,8 @@ export interface ButtonOptions extends BoxOptions, ButtonStoreOptions {
   store?: ButtonStore;
 }
 
-export class ButtonRenderable extends BoxRenderable {
-  protected override _focusable = true;
-
+export class ButtonRenderable extends PressableRenderable {
   protected _store: ButtonStore;
-  private _unsubscribe: () => void;
 
   constructor(ctx: RenderContext, options: ButtonOptions = {}) {
     const { disabled, onPress, store, ...boxOptions } = options;
@@ -102,12 +91,15 @@ export class ButtonRenderable extends BoxRenderable {
       if (disabled !== undefined) store.setDisabled(disabled);
       if (onPress !== undefined) store.setOnPress(onPress);
     }
-    this._focusable = !this._store.state.disabled;
-    this._unsubscribe = this._store.subscribe((state) => {
-      if (state.disabled && this._focused) this.blur();
-      this._focusable = !state.disabled;
-      this.requestRender();
-    });
+    this.attachPressable(this._store);
+  }
+
+  protected handlePress(details: PressDetails): void {
+    this._store.requestPress(details);
+  }
+
+  protected override onPointerPressedChanged(pressed: boolean): void {
+    this._store.setPressed(pressed);
   }
 
   getState(): ButtonState {
@@ -126,72 +118,6 @@ export class ButtonRenderable extends BoxRenderable {
       throw new Error("Button store cannot be replaced");
   }
 
-  protected override onMouseEvent(event: MouseEvent): void {
-    super.onMouseEvent(event);
-    if (this._store.state.disabled) {
-      event.preventDefault();
-      if (this._focused) super.blur();
-      return;
-    }
-    if (event.type === "down") {
-      if (event.button !== 0) return;
-      if (event.defaultPrevented) {
-        this._store.setPressed(false);
-        return;
-      }
-      this._store.setPressed(true);
-      return;
-    }
-    if (event.type === "up" && event.button === 0) {
-      const shouldPress =
-        this._store.state.pressed &&
-        !event.defaultPrevented &&
-        !this._store.state.disabled;
-      this._store.setPressed(false);
-      if (!shouldPress) return;
-      this.focus();
-      this._store.requestPress(Object.freeze({ button: 0, source: "pointer" }));
-      return;
-    }
-    if (event.type === "out" || event.type === "drag-end") {
-      this._store.setPressed(false);
-    }
-  }
-
-  press(): void {
-    if (this._isDestroyed) return;
-    this._store.requestPress(Object.freeze({ source: "imperative" }));
-  }
-
-  override handleKeyPress(key: KeyEvent): boolean {
-    if (this._isDestroyed || key.defaultPrevented || this._store.state.disabled)
-      return false;
-    if (key.name === "space") {
-      this._store.requestPress(
-        Object.freeze({ key: "space", source: "keyboard" }),
-      );
-      return true;
-    }
-    if (key.name === "return" || key.name === "enter") {
-      this._store.requestPress(
-        Object.freeze({ key: "enter", source: "keyboard" }),
-      );
-      return true;
-    }
-    return false;
-  }
-
-  override focus(): void {
-    if (this._store.state.disabled) return;
-    super.focus();
-    this._store.setFocused(this._focused);
-  }
-
-  override blur(): void {
-    super.blur();
-    this._store.setFocused(false);
-  }
-
   get disabled(): boolean {
     return this._store.state.disabled;
   }
@@ -202,12 +128,5 @@ export class ButtonRenderable extends BoxRenderable {
 
   set onPress(callback: ((details: ButtonPressDetails) => void) | undefined) {
     this._store.setOnPress(callback);
-  }
-
-  override destroy(): void {
-    this._store.setFocused(false);
-    this._store.setPressed(false);
-    this._unsubscribe();
-    super.destroy();
   }
 }

--- a/packages/core/src/checkbox/checkbox-primitive.test.ts
+++ b/packages/core/src/checkbox/checkbox-primitive.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { BoxRenderable, type KeyEvent } from "@opentui/core";
+import type { KeyEvent } from "@opentui/core";
 import {
   createTestRenderer,
   type TestRendererSetup,
@@ -101,39 +101,23 @@ describe("Checkbox primitive", () => {
     expect(root.checked).toBe(true);
   });
 
-  it("activates only uncancelled primary-button releases", async () => {
+  // The shared activation matrix (guards, pointer model, disabled sync) is
+  // proven once in internal/pressable.test.ts; this is the wiring round-trip.
+  it("toggles from a primary-button click", async () => {
     setup = await createTestRenderer({ width: 30, height: 5 });
     const changes: boolean[] = [];
-    const secondary = new CheckboxRootRenderable(setup.renderer, {
+    const root = new CheckboxRootRenderable(setup.renderer, {
       width: 5,
       height: 1,
       onCheckedChange: (checked) => changes.push(checked),
     });
-    const cancelled = new CheckboxRootRenderable(setup.renderer, {
-      width: 5,
-      height: 1,
-      onMouseUp: (event) => event.preventDefault(),
-      onCheckedChange: (checked) => changes.push(checked),
-    });
-    const row = new BoxRenderable(setup.renderer, {
-      width: 10,
-      height: 1,
-      flexDirection: "row",
-    });
-    row.add(secondary);
-    row.add(cancelled);
-    setup.renderer.root.add(row);
+    setup.renderer.root.add(root);
     await setup.renderOnce();
 
-    await setup.mockMouse.click(0, 0, 2);
-    expect(secondary.checked).toBe(false);
-
-    await setup.mockMouse.click(5, 0);
-    expect(cancelled.checked).toBe(false);
-
     await setup.mockMouse.click(0, 0);
-    expect(secondary.checked).toBe(true);
-    expect(secondary.focused).toBe(true);
+
+    expect(root.checked).toBe(true);
+    expect(root.focused).toBe(true);
     expect(changes).toEqual([true]);
   });
 

--- a/packages/core/src/checkbox/primitive.ts
+++ b/packages/core/src/checkbox/primitive.ts
@@ -1,10 +1,10 @@
 import {
   type BoxOptions,
   BoxRenderable,
-  type KeyEvent,
   type RenderContext,
 } from "@opentui/core";
 import { CheckedStore } from "../internal/checked-store";
+import { PressableRenderable } from "../internal/pressable";
 
 export interface CheckboxState {
   readonly checked: boolean;
@@ -65,11 +65,8 @@ export interface CheckboxRootOptions extends BoxOptions, CheckboxStoreOptions {
   store?: CheckboxStore;
 }
 
-export class CheckboxRootRenderable extends BoxRenderable {
-  protected override _focusable = true;
-
+export class CheckboxRootRenderable extends PressableRenderable {
   protected _store: CheckboxStore;
-  private _unsubscribe: () => void;
 
   constructor(ctx: RenderContext, options: CheckboxRootOptions = {}) {
     const {
@@ -80,20 +77,7 @@ export class CheckboxRootRenderable extends BoxRenderable {
       store,
       ...boxOptions
     } = options;
-    super(ctx, {
-      ...boxOptions,
-      onMouseUp: (event) => {
-        boxOptions.onMouseUp?.call(this, event);
-        if (
-          event.defaultPrevented ||
-          event.button !== 0 ||
-          this._store.state.disabled
-        )
-          return;
-        this.press();
-        this.focus();
-      },
-    });
+    super(ctx, boxOptions);
     this._store =
       store ??
       new CheckboxStore({
@@ -108,12 +92,11 @@ export class CheckboxRootRenderable extends BoxRenderable {
       if (onCheckedChange !== undefined)
         store.setOnCheckedChange(onCheckedChange);
     }
-    this._focusable = !this._store.state.disabled;
-    this._unsubscribe = this._store.subscribe((state) => {
-      if (state.disabled && this._focused) this.blur();
-      this._focusable = !state.disabled;
-      this.requestRender();
-    });
+    this.attachPressable(this._store);
+  }
+
+  protected handlePress(): void {
+    this._store.requestToggle();
   }
 
   getState(): CheckboxState {
@@ -131,31 +114,6 @@ export class CheckboxRootRenderable extends BoxRenderable {
   set store(store: CheckboxStore) {
     if (store !== this._store)
       throw new Error("Checkbox.Root store cannot be replaced");
-  }
-
-  press(): void {
-    if (this._isDestroyed) return;
-    this._store.requestToggle();
-  }
-
-  override handleKeyPress(key: KeyEvent): boolean {
-    if (this._isDestroyed || this._store.state.disabled) return false;
-    if (key.name === "space" || key.name === "return" || key.name === "enter") {
-      this.press();
-      return true;
-    }
-    return false;
-  }
-
-  override focus(): void {
-    if (this._store.state.disabled) return;
-    super.focus();
-    this._store.setFocused(this._focused);
-  }
-
-  override blur(): void {
-    super.blur();
-    this._store.setFocused(false);
   }
 
   get checked(): boolean {
@@ -176,11 +134,6 @@ export class CheckboxRootRenderable extends BoxRenderable {
 
   set onCheckedChange(callback: ((checked: boolean) => void) | undefined) {
     this._store.setOnCheckedChange(callback);
-  }
-
-  override destroy(): void {
-    this._unsubscribe();
-    super.destroy();
   }
 }
 

--- a/packages/core/src/dialog/index.ts
+++ b/packages/core/src/dialog/index.ts
@@ -7,6 +7,7 @@ import {
   type TextOptions,
   TextRenderable,
 } from "@opentui/core";
+import { PressableRenderable } from "../internal/pressable";
 
 export type DialogOpenChangeReason =
   | "trigger"
@@ -381,24 +382,22 @@ interface DialogPartOptions {
 
 export interface DialogTriggerOptions extends BoxOptions, DialogPartOptions {}
 
-export class DialogTriggerRenderable extends BoxRenderable {
+export class DialogTriggerRenderable extends PressableRenderable {
   constructor(ctx: RenderContext, options: DialogTriggerOptions) {
     const { store, ...boxOptions } = options;
-    super(ctx, {
-      ...boxOptions,
-      focusable: boxOptions.focusable ?? true,
-      onMouseUp: (event) => {
-        boxOptions.onMouseUp?.call(this, event);
-        this.open();
-      },
-    });
+    super(ctx, boxOptions);
     this.store = store;
   }
 
   readonly store: DialogStore;
 
-  press(): boolean {
+  override press(): boolean {
     return this.open();
+  }
+
+  /** Requests dialog opening for one semantic press. */
+  protected handlePress(): void {
+    this.open();
   }
 
   private open(): boolean {
@@ -407,14 +406,6 @@ export class DialogTriggerRenderable extends BoxRenderable {
     // A canceled or controlled intent has not moved focus into a popup.
     if (!this.store.state.open) this.focus();
     return changed;
-  }
-
-  override handleKeyPress(key: KeyEvent): boolean {
-    if (key.name !== "space" && key.name !== "return" && key.name !== "enter") {
-      return false;
-    }
-    this.press();
-    return true;
   }
 }
 
@@ -580,20 +571,13 @@ export interface DialogCloseOptions extends BoxOptions, DialogPartOptions {
   reason?: "close" | "action";
 }
 
-export class DialogCloseRenderable extends BoxRenderable {
+export class DialogCloseRenderable extends PressableRenderable {
   readonly store: DialogStore;
   private closeReason: "close" | "action";
 
   constructor(ctx: RenderContext, options: DialogCloseOptions) {
     const { store, reason = "close", ...boxOptions } = options;
-    super(ctx, {
-      ...boxOptions,
-      focusable: boxOptions.focusable ?? true,
-      onMouseUp: (event) => {
-        boxOptions.onMouseUp?.call(this, event);
-        store.requestOpen(false, this.closeReason, true);
-      },
-    });
+    super(ctx, boxOptions);
     this.store = store;
     this.closeReason = reason;
   }
@@ -606,15 +590,13 @@ export class DialogCloseRenderable extends BoxRenderable {
     this.closeReason = reason;
   }
 
-  press(): boolean {
+  override press(): boolean {
     return this.store.requestOpen(false, this.closeReason, true);
   }
 
-  override handleKeyPress(key: KeyEvent): boolean {
-    if (key.name !== "space" && key.name !== "return" && key.name !== "enter")
-      return false;
+  /** Requests dialog dismissal for one semantic press. */
+  protected handlePress(): void {
     this.press();
-    return true;
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,6 +38,7 @@ export {
   type InputOptions,
   InputRenderable,
 } from "./input";
+export type { PressDetails } from "./internal/pressable";
 export {
   type RadioIndicatorOptions,
   RadioIndicatorRenderable,

--- a/packages/core/src/internal/pressable.test.ts
+++ b/packages/core/src/internal/pressable.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { KeyEvent } from "@opentui/core";
+import {
+  createTestRenderer,
+  type TestRendererSetup,
+} from "@opentui/core/testing";
+import {
+  PressableRenderable,
+  type PressableStore,
+  type PressDetails,
+} from "./pressable";
+
+let setup: TestRendererSetup | undefined;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = undefined;
+});
+
+class FakeStore implements PressableStore {
+  focusedCalls: boolean[] = [];
+  private disabled = false;
+  private readonly listeners = new Set<() => void>();
+
+  get state(): { readonly disabled: boolean } {
+    return { disabled: this.disabled };
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  setFocused(focused: boolean): void {
+    this.focusedCalls.push(focused);
+  }
+
+  setDisabled(disabled: boolean): void {
+    this.disabled = disabled;
+    for (const listener of [...this.listeners]) listener();
+  }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+}
+
+class FakePressable extends PressableRenderable {
+  readonly presses: PressDetails[] = [];
+  readonly unclaimedKeys: string[] = [];
+  readonly pointerChanges: boolean[] = [];
+
+  protected handlePress(details: PressDetails): void {
+    this.presses.push(details);
+  }
+
+  protected override handleUnclaimedKey(key: KeyEvent): boolean {
+    if (key.name === "left") {
+      this.unclaimedKeys.push(key.name);
+      return true;
+    }
+    return false;
+  }
+
+  protected override onPointerPressedChanged(pressed: boolean): void {
+    this.pointerChanges.push(pressed);
+  }
+
+  adopt(store: PressableStore): void {
+    this.attachPressable(store);
+  }
+}
+
+async function createPressable(store?: PressableStore): Promise<{
+  setup: TestRendererSetup;
+  pressable: FakePressable;
+}> {
+  const rendererSetup = await createTestRenderer({ width: 20, height: 5 });
+  setup = rendererSetup;
+  const pressable = new FakePressable(rendererSetup.renderer, {
+    width: 10,
+    height: 1,
+  });
+  if (store) pressable.adopt(store);
+  rendererSetup.renderer.root.add(pressable);
+  await rendererSetup.renderOnce();
+  return { setup: rendererSetup, pressable };
+}
+
+function keyEvent(name: string, extra: Partial<KeyEvent> = {}): KeyEvent {
+  return { name, ...extra } as KeyEvent;
+}
+
+describe("PressableRenderable", () => {
+  it("presses once for each activation seam with matching details", async () => {
+    const { setup, pressable } = await createPressable(new FakeStore());
+
+    pressable.press();
+    expect(pressable.handleKeyPress(keyEvent("space"))).toBe(true);
+    expect(pressable.handleKeyPress(keyEvent("return"))).toBe(true);
+    expect(pressable.handleKeyPress(keyEvent("enter"))).toBe(true);
+    await setup.mockMouse.click(0, 0);
+
+    expect(pressable.presses).toEqual([
+      { source: "imperative" },
+      { key: "space", source: "keyboard" },
+      { key: "enter", source: "keyboard" },
+      { key: "enter", source: "keyboard" },
+      { button: 0, source: "pointer" },
+    ]);
+    for (const details of pressable.presses)
+      expect(Object.isFrozen(details)).toBe(true);
+    expect(pressable.focused).toBe(true);
+  });
+
+  it("ignores cancelled and modified activation keys", async () => {
+    const { pressable } = await createPressable(new FakeStore());
+
+    expect(
+      pressable.handleKeyPress(keyEvent("space", { defaultPrevented: true })),
+    ).toBe(false);
+    for (const modifier of [
+      "ctrl",
+      "meta",
+      "shift",
+      "option",
+      "super",
+      "hyper",
+    ] as const) {
+      expect(
+        pressable.handleKeyPress(keyEvent("space", { [modifier]: true })),
+      ).toBe(false);
+      expect(
+        pressable.handleKeyPress(keyEvent("enter", { [modifier]: true })),
+      ).toBe(false);
+    }
+
+    expect(pressable.presses).toEqual([]);
+  });
+
+  it("offers only unhandled unmodified keys to the subclass", async () => {
+    const { pressable } = await createPressable(new FakeStore());
+
+    expect(pressable.handleKeyPress(keyEvent("left"))).toBe(true);
+    expect(pressable.handleKeyPress(keyEvent("right"))).toBe(false);
+    expect(pressable.handleKeyPress(keyEvent("left", { ctrl: true }))).toBe(
+      false,
+    );
+
+    expect(pressable.unclaimedKeys).toEqual(["left"]);
+  });
+
+  it("activates a pointer press only when it starts and ends on the node", async () => {
+    const { setup, pressable } = await createPressable(new FakeStore());
+
+    await setup.mockMouse.release(0, 0);
+    expect(pressable.presses).toEqual([]);
+
+    await setup.mockMouse.click(0, 0, 2);
+    expect(pressable.presses).toEqual([]);
+
+    await setup.mockMouse.pressDown(0, 0);
+    expect(pressable.pointerChanges).toEqual([true]);
+    await setup.mockMouse.release(0, 0);
+    expect(pressable.pointerChanges).toEqual([true, false]);
+    expect(pressable.presses).toEqual([{ button: 0, source: "pointer" }]);
+
+    // A press that starts on the node but releases elsewhere never lands.
+    await setup.mockMouse.pressDown(0, 0);
+    await setup.mockMouse.release(15, 3);
+    expect(pressable.presses).toEqual([{ button: 0, source: "pointer" }]);
+  });
+
+  it("honors consumer cancellation of the pointer release", async () => {
+    const store = new FakeStore();
+    const rendererSetup = await createTestRenderer({ width: 20, height: 5 });
+    setup = rendererSetup;
+    const pressable = new FakePressable(rendererSetup.renderer, {
+      width: 10,
+      height: 1,
+      onMouseUp: (event) => event.preventDefault(),
+    });
+    pressable.adopt(store);
+    rendererSetup.renderer.root.add(pressable);
+    await rendererSetup.renderOnce();
+
+    await rendererSetup.mockMouse.click(0, 0);
+
+    expect(pressable.presses).toEqual([]);
+  });
+
+  it("gates every activation seam while disabled and blurs on disablement", async () => {
+    const store = new FakeStore();
+    const { setup, pressable } = await createPressable(store);
+
+    pressable.focus();
+    expect(pressable.focused).toBe(true);
+
+    store.setDisabled(true);
+    expect(pressable.focused).toBe(false);
+    expect(pressable.focusable).toBe(false);
+
+    pressable.focus();
+    expect(pressable.handleKeyPress(keyEvent("space"))).toBe(false);
+    await setup.mockMouse.click(0, 0);
+    expect(pressable.focused).toBe(false);
+    expect(pressable.presses).toEqual([]);
+
+    store.setDisabled(false);
+    expect(pressable.focusable).toBe(true);
+    expect(pressable.handleKeyPress(keyEvent("space"))).toBe(true);
+    expect(pressable.presses).toEqual([{ key: "space", source: "keyboard" }]);
+  });
+
+  it("gates the imperative press through the subclass, not the base", async () => {
+    const store = new FakeStore();
+    const { pressable } = await createPressable(store);
+    store.setDisabled(true);
+
+    pressable.press();
+
+    // The base forwards; disabled imperative gating belongs to the Store.
+    expect(pressable.presses).toEqual([{ source: "imperative" }]);
+  });
+
+  it("mirrors focus and blur into the store", async () => {
+    const store = new FakeStore();
+    const { pressable } = await createPressable(store);
+
+    pressable.focus();
+    pressable.blur();
+
+    expect(store.focusedCalls).toEqual([true, false]);
+  });
+
+  it("stays permanently enabled without an attached store", async () => {
+    const { pressable } = await createPressable();
+
+    expect(pressable.focusable).toBe(true);
+    expect(pressable.handleKeyPress(keyEvent("space"))).toBe(true);
+    expect(pressable.presses).toEqual([{ key: "space", source: "keyboard" }]);
+  });
+
+  it("rejects a second store", async () => {
+    const { pressable } = await createPressable(new FakeStore());
+
+    expect(() => pressable.adopt(new FakeStore())).toThrow(
+      "Pressable store is already attached",
+    );
+  });
+
+  it("releases the store and goes inert on destroy", async () => {
+    const store = new FakeStore();
+    const { pressable } = await createPressable(store);
+    expect(store.listenerCount).toBe(1);
+
+    pressable.destroy();
+
+    expect(store.listenerCount).toBe(0);
+    expect(store.focusedCalls).toEqual([false]);
+    pressable.press();
+    expect(pressable.handleKeyPress(keyEvent("space"))).toBe(false);
+    expect(pressable.presses).toEqual([]);
+  });
+});

--- a/packages/core/src/internal/pressable.ts
+++ b/packages/core/src/internal/pressable.ts
@@ -1,0 +1,182 @@
+import {
+  type BoxOptions,
+  BoxRenderable,
+  type KeyEvent,
+  type MouseEvent,
+  type RenderContext,
+} from "@opentui/core";
+
+/** Gesture that produced one semantic press. */
+export type PressDetails =
+  | Readonly<{ source: "imperative" }>
+  | Readonly<{ key: "enter" | "space"; source: "keyboard" }>
+  | Readonly<{ button: 0; source: "pointer" }>;
+
+/**
+ * Minimal Store shape a Pressable consults. Every foundation Store satisfies
+ * it structurally, so Roots attach their Store directly; parts without
+ * disabled or focused state simply never attach one and stay permanently
+ * enabled. A diverging state shape can attach an inline adapter object.
+ */
+export interface PressableStore {
+  /** Current state snapshot; only `disabled` is consulted. */
+  readonly state: { readonly disabled: boolean };
+  /** Change notifications driving disabled-blur and focusability sync. */
+  subscribe(listener: () => void): () => void;
+  /** Mirrors actual Renderable focus into the Store, when tracked. */
+  setFocused?(focused: boolean): void;
+}
+
+const FROZEN_IMPERATIVE_PRESS: PressDetails = Object.freeze({
+  source: "imperative",
+});
+const FROZEN_POINTER_PRESS: PressDetails = Object.freeze({
+  button: 0,
+  source: "pointer",
+});
+const FROZEN_SPACE_PRESS: PressDetails = Object.freeze({
+  key: "space",
+  source: "keyboard",
+});
+const FROZEN_ENTER_PRESS: PressDetails = Object.freeze({
+  key: "enter",
+  source: "keyboard",
+});
+
+/**
+ * Focusable Root behavior shared by every press-activated primitive.
+ *
+ * The base owns the interaction contract: the shared activation-key map
+ * (uncancelled, unmodified space/enter), the pointer press model (a press
+ * starts and ends on the node with the primary button, honoring
+ * `defaultPrevented`), disabled-driven focusability and blur, focus mirroring
+ * into the Store, and Store teardown. Subclasses define what one semantic
+ * press means through {@link handlePress} and may claim additional keys
+ * through {@link handleUnclaimedKey}.
+ */
+export abstract class PressableRenderable extends BoxRenderable {
+  private _pressableStore?: PressableStore;
+  private _unsubscribePressable?: () => void;
+  private _pointerPressed = false;
+
+  constructor(ctx: RenderContext, options: BoxOptions = {}) {
+    super(ctx, { ...options, focusable: options.focusable ?? true });
+  }
+
+  /** Applies the subclass meaning of one semantic press. */
+  protected abstract handlePress(details: PressDetails): void;
+
+  /** Claims keys outside the shared activation map, such as group navigation. */
+  protected handleUnclaimedKey(_key: KeyEvent): boolean {
+    return false;
+  }
+
+  /** Observes pointer-pressed visual state, for Stores that track it. */
+  protected onPointerPressedChanged(_pressed: boolean): void {}
+
+  /** Disabled state consulted by every input seam. */
+  protected pressableDisabled(): boolean {
+    return this._pressableStore?.state.disabled ?? false;
+  }
+
+  /** Focusability derived from the current Store state. */
+  protected pressableFocusable(): boolean {
+    return !this.pressableDisabled();
+  }
+
+  /** Adopts the one state Store once the subclass constructs it. */
+  protected attachPressable(store: PressableStore): void {
+    if (this._pressableStore)
+      throw new Error("Pressable store is already attached");
+    this._pressableStore = store;
+    this._focusable = this.pressableFocusable();
+    this._unsubscribePressable = store.subscribe(() => {
+      if (this.pressableDisabled() && this._focused) this.blur();
+      this._focusable = this.pressableFocusable();
+      this.requestRender();
+    });
+  }
+
+  /** Stops observing the Store; safe to call ahead of subclass teardown. */
+  protected detachPressable(): void {
+    this._unsubscribePressable?.();
+    this._unsubscribePressable = undefined;
+  }
+
+  /** Requests one semantic imperative press. */
+  press(): void {
+    if (this._isDestroyed) return;
+    this.handlePress(FROZEN_IMPERATIVE_PRESS);
+  }
+
+  protected override onMouseEvent(event: MouseEvent): void {
+    super.onMouseEvent(event);
+    if (this.pressableDisabled()) {
+      event.preventDefault();
+      if (this._focused) super.blur();
+      return;
+    }
+    if (event.type === "down") {
+      if (event.button !== 0) return;
+      this.setPointerPressed(!event.defaultPrevented);
+      return;
+    }
+    if (event.type === "up" && event.button === 0) {
+      const shouldPress = this._pointerPressed && !event.defaultPrevented;
+      this.setPointerPressed(false);
+      if (!shouldPress) return;
+      this.focus();
+      this.handlePress(FROZEN_POINTER_PRESS);
+      return;
+    }
+    if (event.type === "out" || event.type === "drag-end") {
+      this.setPointerPressed(false);
+    }
+  }
+
+  override handleKeyPress(key: KeyEvent): boolean {
+    if (this._isDestroyed || key.defaultPrevented || this.pressableDisabled())
+      return false;
+    if (
+      key.ctrl ||
+      key.meta ||
+      key.shift ||
+      key.option ||
+      key.super ||
+      key.hyper
+    )
+      return false;
+    if (key.name === "space") {
+      this.handlePress(FROZEN_SPACE_PRESS);
+      return true;
+    }
+    if (key.name === "return" || key.name === "enter") {
+      this.handlePress(FROZEN_ENTER_PRESS);
+      return true;
+    }
+    return this.handleUnclaimedKey(key);
+  }
+
+  override focus(): void {
+    if (this.pressableDisabled()) return;
+    super.focus();
+    this._pressableStore?.setFocused?.(this._focused);
+  }
+
+  override blur(): void {
+    super.blur();
+    this.setPointerPressed(false);
+    this._pressableStore?.setFocused?.(false);
+  }
+
+  override destroy(): void {
+    this.detachPressable();
+    super.destroy();
+  }
+
+  private setPointerPressed(pressed: boolean): void {
+    if (this._pointerPressed === pressed) return;
+    this._pointerPressed = pressed;
+    this.onPointerPressedChanged(pressed);
+  }
+}

--- a/packages/core/src/internal/toggle-change-details.ts
+++ b/packages/core/src/internal/toggle-change-details.ts
@@ -1,5 +1,0 @@
-/** Details describing how a Toggle requested a pressed-state change. */
-export type ToggleChangeDetails =
-  | Readonly<{ source: "imperative" }>
-  | Readonly<{ key: "enter" | "space"; source: "keyboard" }>
-  | Readonly<{ button: 0; source: "pointer" }>;

--- a/packages/core/src/radio/primitive.ts
+++ b/packages/core/src/radio/primitive.ts
@@ -5,6 +5,7 @@ import {
   type KeyEvent,
   type RenderContext,
 } from "@opentui/core";
+import { PressableRenderable, type PressDetails } from "../internal/pressable";
 import {
   type CollectionEntry,
   type CollectionFocusDirection,
@@ -22,7 +23,7 @@ export type RadioGroupItemKey = CollectionItemKey;
 
 export interface RadioGroupChangeDetails {
   readonly reason: "activation" | "navigation";
-  readonly source: "keyboard" | "pointer" | "programmatic";
+  readonly source: "imperative" | "keyboard" | "pointer";
 }
 
 export type RadioGroupFocusDirection = CollectionFocusDirection;
@@ -63,9 +64,9 @@ export type RadioGroupItemRegistration = CollectionItemRegistration;
 
 export type RadioGroupNavigationTarget = CollectionNavigationTarget;
 
-const PROGRAMMATIC_ACTIVATION_DETAILS: RadioGroupChangeDetails = Object.freeze({
+const IMPERATIVE_ACTIVATION_DETAILS: RadioGroupChangeDetails = Object.freeze({
   reason: "activation",
-  source: "programmatic",
+  source: "imperative",
 });
 
 export class RadioGroupStore extends RovingCollectionStore<
@@ -89,7 +90,7 @@ export class RadioGroupStore extends RovingCollectionStore<
 
   requestSelection(
     key: RadioGroupItemKey,
-    details: RadioGroupChangeDetails = PROGRAMMATIC_ACTIVATION_DETAILS,
+    details: RadioGroupChangeDetails = IMPERATIVE_ACTIVATION_DETAILS,
   ): void {
     this.runMutation(() => this.requestSelectionNow(key, details));
   }
@@ -253,9 +254,7 @@ export interface RadioRootOptions extends BoxOptions {
 
 type RadioGroupItemListener = (state: RadioState) => void;
 
-export class RadioRootRenderable extends BoxRenderable {
-  protected override _focusable = true;
-
+export class RadioRootRenderable extends PressableRenderable {
   private readonly _store: RadioGroupStore;
   private readonly _registration: RadioGroupItemRegistration;
   private _collectionState: RadioGroupCollectionItemState;
@@ -265,20 +264,7 @@ export class RadioRootRenderable extends BoxRenderable {
 
   constructor(ctx: RenderContext, options: RadioRootOptions) {
     const { store, value, disabled, ...boxOptions } = options;
-    super(ctx, {
-      ...boxOptions,
-      onMouseUp: (event) => {
-        boxOptions.onMouseUp?.call(this, event);
-        if (
-          event.defaultPrevented ||
-          event.button !== 0 ||
-          this._state.disabled
-        )
-          return;
-        this.focus();
-        this.press("pointer");
-      },
-    });
+    super(ctx, boxOptions);
     this._store = store;
     this._registration = store.registerItem(value, {
       disabled,
@@ -328,22 +314,25 @@ export class RadioRootRenderable extends BoxRenderable {
     return () => this._listeners.delete(listener);
   }
 
-  press(source: RadioGroupChangeDetails["source"] = "programmatic"): void {
+  override press(
+    source: RadioGroupChangeDetails["source"] = "imperative",
+  ): void {
     if (this._state.disabled || !this.refreshCollection()) return;
     this._store.requestSelection(this.key, { reason: "activation", source });
   }
 
-  override handleKeyPress(key: KeyEvent): boolean {
-    if (this._state.disabled) return false;
-    if (
-      key.ctrl ||
-      key.meta ||
-      key.shift ||
-      key.option ||
-      key.super ||
-      key.hyper
-    )
-      return false;
+  /** Selects this Radio for one semantic press. */
+  protected handlePress(details: PressDetails): void {
+    this.press(details.source);
+  }
+
+  /** Radio disablement lives on its collection item state, not an attached Store. */
+  protected override pressableDisabled(): boolean {
+    return this._state.disabled;
+  }
+
+  /** Handles roving-focus navigation keys outside the activation map. */
+  protected override handleUnclaimedKey(key: KeyEvent): boolean {
     if (key.name === "left" || key.name === "up") {
       return this.moveFocus("previous");
     }
@@ -352,10 +341,6 @@ export class RadioRootRenderable extends BoxRenderable {
     }
     if (key.name === "home") return this.moveFocus("first");
     if (key.name === "end") return this.moveFocus("last");
-    if (key.name === "space" || key.name === "return" || key.name === "enter") {
-      this.press("keyboard");
-      return true;
-    }
     return false;
   }
 

--- a/packages/core/src/radio/radio-group-parts.test.ts
+++ b/packages/core/src/radio/radio-group-parts.test.ts
@@ -5,6 +5,7 @@ import {
   type TestRendererSetup,
 } from "@opentui/core/testing";
 import {
+  type RadioGroupChangeDetails,
   RadioGroupRenderable,
   RadioGroupStore,
   RadioIndicatorRenderable,
@@ -160,37 +161,30 @@ describe("RadioGroup Core parts", () => {
     expect(root.store.getItemState(key)).toBeUndefined();
   });
 
-  it("activates only uncancelled primary-button releases", async () => {
+  // The shared activation matrix (guards, pointer model, disabled sync) is
+  // proven once in internal/pressable.test.ts; this is the wiring round-trip.
+  it("selects from a primary-button click with pointer-sourced details", async () => {
     setup = await createTestRenderer({ width: 30, height: 5 });
+    const details: RadioGroupChangeDetails[] = [];
     const root = new RadioGroupRenderable(setup.renderer, {
       flexDirection: "row",
+      onValueChange: (_value, changeDetails) => details.push(changeDetails),
     });
-    const secondary = new RadioRootRenderable(setup.renderer, {
+    const item = new RadioRootRenderable(setup.renderer, {
       store: root.store,
-      value: "secondary",
+      value: "alpha",
       width: 5,
       height: 1,
     });
-    const cancelled = new RadioRootRenderable(setup.renderer, {
-      store: root.store,
-      value: "cancelled",
-      width: 5,
-      height: 1,
-      onMouseUp: (event) => event.preventDefault(),
-    });
-    root.add(secondary);
-    root.add(cancelled);
+    root.add(item);
     setup.renderer.root.add(root);
     await setup.renderOnce();
 
-    await setup.mockMouse.click(0, 0, 2);
-    expect(root.value).toBeNull();
-
-    await setup.mockMouse.click(5, 0);
-    expect(root.value).toBeNull();
-
     await setup.mockMouse.click(0, 0);
-    expect(root.value).toBe("secondary");
+
+    expect(root.value).toBe("alpha");
+    expect(item.focused).toBe(true);
+    expect(details).toEqual([{ reason: "activation", source: "pointer" }]);
   });
 
   it("moves roving focus, skips disabled Items, wraps, and handles Home/End", async () => {

--- a/packages/core/src/switch/primitive.ts
+++ b/packages/core/src/switch/primitive.ts
@@ -1,10 +1,10 @@
 import {
   type BoxOptions,
   BoxRenderable,
-  type KeyEvent,
   type RenderContext,
 } from "@opentui/core";
 import { CheckedStore } from "../internal/checked-store";
+import { PressableRenderable } from "../internal/pressable";
 
 export interface SwitchState {
   readonly checked: boolean;
@@ -58,11 +58,8 @@ export interface SwitchRootOptions extends BoxOptions, SwitchStoreOptions {
   store?: SwitchStore;
 }
 
-export class SwitchRootRenderable extends BoxRenderable {
-  protected override _focusable = true;
-
+export class SwitchRootRenderable extends PressableRenderable {
   protected _store: SwitchStore;
-  private _unsubscribe: () => void;
 
   constructor(ctx: RenderContext, options: SwitchRootOptions = {}) {
     const {
@@ -73,20 +70,7 @@ export class SwitchRootRenderable extends BoxRenderable {
       store,
       ...boxOptions
     } = options;
-    super(ctx, {
-      ...boxOptions,
-      onMouseUp: (event) => {
-        boxOptions.onMouseUp?.call(this, event);
-        if (
-          event.defaultPrevented ||
-          event.button !== 0 ||
-          this._store.state.disabled
-        )
-          return;
-        this.press();
-        this.focus();
-      },
-    });
+    super(ctx, boxOptions);
     this._store =
       store ??
       new SwitchStore({
@@ -101,12 +85,11 @@ export class SwitchRootRenderable extends BoxRenderable {
       if (onCheckedChange !== undefined)
         store.setOnCheckedChange(onCheckedChange);
     }
-    this._focusable = !this._store.state.disabled;
-    this._unsubscribe = this._store.subscribe((state) => {
-      if (state.disabled && this._focused) this.blur();
-      this._focusable = !state.disabled;
-      this.requestRender();
-    });
+    this.attachPressable(this._store);
+  }
+
+  protected handlePress(): void {
+    this._store.requestToggle();
   }
 
   getState(): SwitchState {
@@ -123,31 +106,6 @@ export class SwitchRootRenderable extends BoxRenderable {
   set store(store: SwitchStore) {
     if (store !== this._store)
       throw new Error("Switch.Root store cannot be replaced");
-  }
-
-  press(): void {
-    if (this._isDestroyed) return;
-    this._store.requestToggle();
-  }
-
-  override handleKeyPress(key: KeyEvent): boolean {
-    if (this._isDestroyed || this._store.state.disabled) return false;
-    if (key.name === "space" || key.name === "return" || key.name === "enter") {
-      this.press();
-      return true;
-    }
-    return false;
-  }
-
-  override focus(): void {
-    if (this._store.state.disabled) return;
-    super.focus();
-    this._store.setFocused(this._focused);
-  }
-
-  override blur(): void {
-    super.blur();
-    this._store.setFocused(false);
   }
 
   get checked(): boolean {
@@ -168,11 +126,6 @@ export class SwitchRootRenderable extends BoxRenderable {
 
   set onCheckedChange(callback: ((checked: boolean) => void) | undefined) {
     this._store.setOnCheckedChange(callback);
-  }
-
-  override destroy(): void {
-    this._unsubscribe();
-    super.destroy();
   }
 }
 

--- a/packages/core/src/switch/switch-primitive.test.ts
+++ b/packages/core/src/switch/switch-primitive.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { BoxRenderable, type KeyEvent } from "@opentui/core";
+import type { KeyEvent } from "@opentui/core";
 import {
   createTestRenderer,
   type TestRendererSetup,
@@ -111,39 +111,23 @@ describe("Switch primitive", () => {
     expect(changes).toEqual([true, false, true]);
   });
 
-  it("activates only uncancelled primary-button releases", async () => {
+  // The shared activation matrix (guards, pointer model, disabled sync) is
+  // proven once in internal/pressable.test.ts; this is the wiring round-trip.
+  it("toggles from a primary-button click", async () => {
     setup = await createTestRenderer({ width: 30, height: 5 });
     const changes: boolean[] = [];
-    const secondary = new SwitchRootRenderable(setup.renderer, {
+    const root = new SwitchRootRenderable(setup.renderer, {
       width: 5,
       height: 1,
       onCheckedChange: (checked) => changes.push(checked),
     });
-    const cancelled = new SwitchRootRenderable(setup.renderer, {
-      width: 5,
-      height: 1,
-      onMouseUp: (event) => event.preventDefault(),
-      onCheckedChange: (checked) => changes.push(checked),
-    });
-    const row = new BoxRenderable(setup.renderer, {
-      width: 10,
-      height: 1,
-      flexDirection: "row",
-    });
-    row.add(secondary);
-    row.add(cancelled);
-    setup.renderer.root.add(row);
+    setup.renderer.root.add(root);
     await setup.renderOnce();
 
-    await setup.mockMouse.click(0, 0, 2);
-    expect(secondary.checked).toBe(false);
-
-    await setup.mockMouse.click(5, 0);
-    expect(cancelled.checked).toBe(false);
-
     await setup.mockMouse.click(0, 0);
-    expect(secondary.checked).toBe(true);
-    expect(secondary.focused).toBe(true);
+
+    expect(root.checked).toBe(true);
+    expect(root.focused).toBe(true);
     expect(changes).toEqual([true]);
   });
 

--- a/packages/core/src/toggle-group/index.ts
+++ b/packages/core/src/toggle-group/index.ts
@@ -1,4 +1,4 @@
-export type { ToggleChangeDetails as ToggleGroupChangeDetails } from "../internal/toggle-change-details";
+export type { PressDetails as ToggleGroupChangeDetails } from "../internal/pressable";
 export {
   type ToggleGroupFocusDirection,
   type ToggleGroupItemKey,

--- a/packages/core/src/toggle-group/primitive.ts
+++ b/packages/core/src/toggle-group/primitive.ts
@@ -1,4 +1,5 @@
 import type { BaseRenderable, BoxOptions, RenderContext } from "@opentui/core";
+import type { PressDetails } from "../internal/pressable";
 import {
   type CollectionFocusDirection,
   type CollectionItemInput,
@@ -9,7 +10,6 @@ import {
   RovingCollectionRenderable,
   RovingCollectionStore,
 } from "../internal/roving-collection";
-import type { ToggleChangeDetails } from "../internal/toggle-change-details";
 import { ToggleRenderable } from "../toggle/primitive";
 
 /** Stable identity for a Toggle registered with a ToggleGroup. */
@@ -41,7 +41,7 @@ export interface ToggleGroupItemState {
 /** Callback invoked when a ToggleGroup requests a new value. */
 export type ToggleGroupValueChangeHandler = (
   value: readonly string[],
-  details: ToggleChangeDetails,
+  details: PressDetails,
 ) => void;
 
 /** Options used to construct a ToggleGroup Store. */
@@ -115,7 +115,7 @@ export class ToggleGroupStore extends RovingCollectionStore<
   requestToggle(
     key: ToggleGroupItemKey,
     pressed: boolean,
-    details: ToggleChangeDetails,
+    details: PressDetails,
     onAccepted?: () => void,
   ): void {
     this.runMutation(() => {

--- a/packages/core/src/toggle/primitive.ts
+++ b/packages/core/src/toggle/primitive.ts
@@ -1,10 +1,5 @@
-import {
-  type BoxOptions,
-  BoxRenderable,
-  type KeyEvent,
-  type RenderContext,
-} from "@opentui/core";
-import type { ToggleChangeDetails } from "../internal/toggle-change-details";
+import type { BoxOptions, KeyEvent, RenderContext } from "@opentui/core";
+import { PressableRenderable, type PressDetails } from "../internal/pressable";
 import {
   type ToggleGroupFocusDirection,
   type ToggleGroupItemKey,
@@ -13,6 +8,9 @@ import {
   ToggleGroupRenderable,
   type ToggleGroupStore,
 } from "../toggle-group/primitive";
+
+/** Gesture details for one semantic Toggle press. */
+export type ToggleChangeDetails = PressDetails;
 
 /** Readonly observable Toggle state. */
 export interface ToggleState {
@@ -265,12 +263,9 @@ export interface ToggleOptions extends BoxOptions, ToggleStoreOptions {
 }
 
 /** Focusable two-state Toggle Renderable. */
-export class ToggleRenderable extends BoxRenderable {
-  protected override _focusable = true;
-
+export class ToggleRenderable extends PressableRenderable {
   private readonly toggleStore: ToggleStore;
   private readonly detach: () => void;
-  private readonly unsubscribe: () => void;
 
   /** Creates a Toggle Renderable. */
   constructor(ctx: RenderContext, options: ToggleOptions = {}) {
@@ -284,20 +279,7 @@ export class ToggleRenderable extends BoxRenderable {
       value,
       ...boxOptions
     } = options;
-    super(ctx, {
-      ...boxOptions,
-      onMouseUp: (event) => {
-        boxOptions.onMouseUp?.call(this, event);
-        if (
-          event.defaultPrevented ||
-          event.button !== 0 ||
-          this.toggleStore.state.disabled
-        )
-          return;
-        this.activate(Object.freeze({ button: 0, source: "pointer" }));
-        this.focus();
-      },
-    });
+    super(ctx, boxOptions);
     this.toggleStore =
       store ??
       new ToggleStore({
@@ -319,12 +301,17 @@ export class ToggleRenderable extends BoxRenderable {
       focus: () => this.focus(),
       isAvailable: () => this.isAvailable(),
     });
-    this._focusable = this.canFocus();
-    this.unsubscribe = this.toggleStore.subscribe((state) => {
-      if (state.disabled && this._focused) super.blur();
-      this._focusable = this.canFocus();
-      this.requestRender();
-    });
+    this.attachPressable(this.toggleStore);
+  }
+
+  /** Grouped Toggles stay focusable only while they own the roving tab stop. */
+  protected override pressableFocusable(): boolean {
+    return this.canFocus();
+  }
+
+  /** Requests a Toggle activation for one semantic press. */
+  protected handlePress(details: PressDetails): void {
+    this.activate(details);
   }
 
   /** Store owned by this Toggle. */
@@ -358,37 +345,8 @@ export class ToggleRenderable extends BoxRenderable {
     return this.toggleStore.subscribe(listener);
   }
 
-  /** Requests a semantic Toggle activation. */
-  press(): void {
-    if (this._isDestroyed) return;
-    this.activate(Object.freeze({ source: "imperative" }));
-  }
-
-  /** Handles activation and grouped roving-focus keys. */
-  override handleKeyPress(key: KeyEvent): boolean {
-    if (
-      this._isDestroyed ||
-      key.defaultPrevented ||
-      this.toggleStore.state.disabled
-    )
-      return false;
-    if (
-      key.ctrl ||
-      key.meta ||
-      key.shift ||
-      key.option ||
-      key.super ||
-      key.hyper
-    )
-      return false;
-    if (key.name === "space") {
-      this.activate(Object.freeze({ key: "space", source: "keyboard" }));
-      return true;
-    }
-    if (key.name === "return" || key.name === "enter") {
-      this.activate(Object.freeze({ key: "enter", source: "keyboard" }));
-      return true;
-    }
+  /** Handles grouped roving-focus keys outside the shared activation map. */
+  protected override handleUnclaimedKey(key: KeyEvent): boolean {
     if (!this.group) return false;
     const orientation = this.group.state.orientation;
     if (
@@ -411,13 +369,6 @@ export class ToggleRenderable extends BoxRenderable {
     if (this.toggleStore.state.disabled || !this.refreshCollection()) return;
     this._focusable = true;
     super.focus();
-    this.toggleStore.setFocused(this._focused);
-  }
-
-  /** Blurs this Toggle and releases active collection ownership. */
-  override blur(): void {
-    super.blur();
-    this.toggleStore.setFocused(false);
   }
 
   /** Current pressed state. */
@@ -471,7 +422,7 @@ export class ToggleRenderable extends BoxRenderable {
 
   /** Releases Store and group registration ownership. */
   override destroy(): void {
-    this.unsubscribe();
+    this.detachPressable();
     this.detach();
     super.destroy();
     this.toggleStore.setFocused(false);
@@ -486,7 +437,7 @@ export class ToggleRenderable extends BoxRenderable {
     return true;
   }
 
-  private activate(details: ToggleChangeDetails): void {
+  private activate(details: PressDetails): void {
     if (this._isDestroyed) return;
     if (this.group && !this.refreshCollection()) return;
     this.toggleStore.requestToggle(details);
@@ -531,5 +482,3 @@ export class ToggleRenderable extends BoxRenderable {
     return false;
   }
 }
-
-export type { ToggleChangeDetails } from "../internal/toggle-change-details";


### PR DESCRIPTION
## Summary

Concentrates the activation behavior that Checkbox, Switch, Button, Toggle, Radio, and Dialog Trigger/Close each re-implemented (~70–80 lines apiece) into one internal base class: `PressableRenderable` (`core/src/internal/pressable.ts`). The base owns the gesture contract; subclasses define what one semantic press means via `handlePress(details)`.

Recorded as **ADR-0007**, with the shared interaction rules added to `FOUNDATION_PRIMITIVE_CONTRACT.md`.

## Why

The five copies had measurably drifted — four different keyboard guard sets were shipping at once:

| Root | `defaultPrevented` | modifiers |
|---|---|---|
| Checkbox / Switch | ✗ ignored | ✗ Ctrl+Space toggled |
| Button | ✓ | ✗ ignored |
| Toggle | ✓ | ✓ |
| Radio | ✗ ignored | ✓ |
| Dialog Trigger/Close | ✗ nothing checked | ✗ nothing checked |

Two pointer models also coexisted: Button required a press to start **and** end on the node; everything else activated on any primary release over it, including drags that started elsewhere.

## Behavior changes

- **Keyboard**: activation everywhere is an uncancelled, unmodified Space/Enter press. Modifier chords and `defaultPrevented` keys never activate.
- **Pointer**: activation everywhere uses Button's model — uncancelled primary-button press that starts and ends on the node; drag-off, release-elsewhere, or cancellation abandons the gesture.
- **Dialog Trigger/Close** now honor both rules (previously checked nothing).

## Breaking (pre-release, before first published foundation version)

- `RadioGroupChangeDetails.source`: `"programmatic"` → `"imperative"`, unifying the press vocabulary.
- `PressDetails` exported from the core root as the canonical gesture type; `ButtonPressDetails` and `ToggleChangeDetails` remain as aliases.

## Design

- `PressableRenderable` owns: activation key map, pointer press tracking, disabled-driven focusability/blur, focus mirroring, public `press()`, teardown.
- Subclass hooks: `handlePress` (required), `handleUnclaimedKey` (Toggle/Radio navigation), `pressableDisabled`/`pressableFocusable` (Radio's collection state, Toggle's tab stop), `onPointerPressedChanged` (Button's visual pressed state).
- `PressableStore` is a minimal interface (`state.disabled`, `subscribe`, optional `setFocused`) satisfied structurally by every foundation Store — Roots attach their Store directly; Radio and Dialog parts attach nothing.

## Tests

- Activation matrix (guards, pointer model, disabled sync, focus mirroring, lifecycle) proven once in `internal/pressable.test.ts` via a fake subclass — including new regression coverage for modifier chords, cancelled keys, and drag-off releases.
- Root suites trimmed to one pointer + one keyboard wiring round-trip plus genuinely unique behavior; the three copies of the pointer-matrix test are gone.
- Net non-test source: **−352/+286** — primitives shrank by more than the base class costs.

## Validation

`pnpm validate:foundation` passes end-to-end: lint, typecheck, core 83 / react 34 / solid 34 tests, build, packed-package checks, all 30 registry consumers against packed tarballs, release scope.
