### PR TITLE
test: restore the testing pyramid — each layer tests only its own seam

### DIFF
--- a/.changeset/restore-test-pyramid.md
+++ b/.changeset/restore-test-pyramid.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test and documentation changes only: restore the testing pyramid (adapter and registry suites test their own seam; Core owns behavior). No published package changes.

--- a/FOUNDATION_PRIMITIVE_CONTRACT.md
+++ b/FOUNDATION_PRIMITIVE_CONTRACT.md
@@ -353,9 +353,9 @@ below. `N/A` requires a reason; it is not a silent omission.
 | Surface | Required evidence |
 | --- | --- |
 | Core | Public owner/Renderable tests for ownership, state snapshots, actions, key and pointer behavior, disabled behavior, dynamic lifecycle, teardown, and event details. Tests use the OpenTUI test renderer and public seams. |
-| React | `testRender` coverage using real Core Renderables for initial props, reactive updates, prop removal, callback replacement, actual ref targets, Renderable identity across retained updates, conditional-part ref lifecycle, context errors, and interaction parity. |
-| Solid | The React adapter matrix repeated through Solid's real rendering seam, including reactive getters, cleanup, prop removal, actual ref targets, retained Renderable identity, and interaction parity. |
-| Registry | Core, React, and Solid recipes compile under strict TypeScript in clean consumers, import only published primitive subpaths, keep visual ownership local, and pass runtime smoke coverage. Official shadcn validation and installation cover dependency metadata. |
+| React | `testRender` coverage using real Core Renderables for first-render authoritative state, frame consistency for controlled updates through the Store, initial props, reactive updates, prop removal, callback replacement, actual ref targets, Renderable identity across retained updates, Store identity, conditional-part ref lifecycle, StrictMode and lifecycle, subscription teardown, context errors, and one interaction wiring round-trip per primitive; behavior semantics are proven once in Core. |
+| Solid | The React adapter matrix repeated through Solid's real rendering seam, including reactive getters, cleanup, first-render authoritative state, frame consistency for controlled updates, prop removal, actual ref targets, retained Renderable identity, Store identity, subscription teardown, and one interaction wiring round-trip per primitive; behavior semantics are proven once in Core. |
+| Registry | Core, React, and Solid recipes compile under strict TypeScript in clean consumers, import only published primitive subpaths, keep visual ownership local, and pass runtime smoke coverage: mounts, one prop round-trip, recipe-owned presentation, and theme restyle. Registry/theme keeps its full suite per ADR-0006 because the registry is the lowest layer for the theme module. Official shadcn validation and installation cover dependency metadata. |
 | Packed | Built tarballs pass Publint, configured Are The Types Wrong checks, strict peer installation, declaration consumption, every documented subpath import, and runtime import smokes without workspace links. |
 | Terminal | A runnable terminal sequence proves user-visible focus, key ordering, pointer or dismissal behavior, and restoration where unit seams cannot establish the complete sequence. |
 
@@ -369,6 +369,11 @@ The minimum behavioral dimensions are:
 - Dynamic registration, mount, unmount, visibility, and teardown.
 - Ref targets and retained identity.
 - Recipe composition without primitive visual defaults.
+
+Core owns full coverage of these behavioral dimensions. React and Solid
+adapters cover only their adaptation concerns plus one interaction wiring
+round-trip per primitive; registry recipes cover only their smoke expectations.
+Neither adapter nor registry surfaces re-prove the Core behavior matrix.
 
 A primitive change is not complete until it passes every applicable surface,
 packed exports are proven, registry consumers are green, and any changed

--- a/docs/adr/0001-react-primitive-store-adaptation.md
+++ b/docs/adr/0001-react-primitive-store-adaptation.md
@@ -213,9 +213,13 @@ carry visual policy.
 6. Store, React, and passive-part subscriptions are removed exactly once.
 7. Published React and Solid Props contain no `store` property.
 
-Tests must inspect initial state, every interaction frame, controlled updates,
-controlled-to-uncontrolled transitions, disablement, focus, retained identity,
-and Store identity. Waiting only for eventual state is insufficient.
+Adapter tests must inspect initial state during the first render, frame
+consistency for controlled updates (waiting only for eventual state is
+insufficient), retained identity, Store identity, and subscription teardown.
+Interaction semantics, including activation guards, disablement rules, and
+keyboard navigation, are owned and proven by Core test suites. Each adapter
+keeps exactly one interaction round-trip per primitive as wiring proof rather
+than re-proving the Core behavior matrix.
 
 ## Considered options
 

--- a/packages/react/src/button/button-primitive.test.tsx
+++ b/packages/react/src/button/button-primitive.test.tsx
@@ -2,11 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import type { TextRenderable } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
-import type {
-  ButtonPressDetails,
-  ButtonRenderable,
-  ButtonState,
-} from "@tuiparts/core/button";
+import type { ButtonRenderable, ButtonState } from "@tuiparts/core/button";
 import { act, createElement, type ReactNode, useState } from "react";
 import { Button } from "./button";
 
@@ -55,36 +51,15 @@ describe("React Button", () => {
     expect(Object.isFrozen(root.getState())).toBe(true);
   });
 
-  it("forwards source-specific press details", async () => {
-    const presses: ButtonPressDetails[] = [];
-    setup = await testRender(
-      createElement(Button, {
-        id: "press-root",
-        onPress: (details) => presses.push(details),
-      }),
-      { width: 30, height: 5 },
-    );
-    const root = setup.renderer.root.findDescendantById(
-      "press-root",
-    ) as ButtonRenderable;
-
-    await act(async () => root.press());
-    expect(presses).toEqual([{ source: "imperative" }]);
-  });
-
-  it("retains Button identity across disabled removal and callback replacement", async () => {
+  it("retains Button identity across callback replacement", async () => {
     const presses: string[] = [];
-    let setDisabled: (disabled: boolean) => void = () => {};
     let setVersion: (version: number) => void = () => {};
     let buttonRef: ButtonRenderable | null = null;
 
     function App() {
-      const [disabled, updateDisabled] = useState(false);
       const [version, updateVersion] = useState(1);
-      setDisabled = updateDisabled;
       setVersion = updateVersion;
       return createElement(Button, {
-        disabled: disabled || undefined,
         id: "reactive-root",
         onPress: (details) => presses.push(`${version}:${details.source}`),
         ref: (value) => {
@@ -99,25 +74,9 @@ describe("React Button", () => {
     ) as ButtonRenderable;
     expect(buttonRef as unknown).toBe(root);
 
+    await act(async () => setVersion(2));
     await act(async () => root.press());
-    expect(presses).toEqual(["1:imperative"]);
-
-    await act(async () => {
-      root.focus();
-      setDisabled(true);
-      setVersion(2);
-    });
-    expect(root.disabled).toBe(true);
-    expect(root.focused).toBe(false);
-    await act(async () => root.press());
-    expect(presses).toHaveLength(1);
-
-    await act(async () => {
-      setDisabled(false);
-      setVersion(3);
-    });
-    await act(async () => root.press());
-    expect(presses).toEqual(["1:imperative", "3:imperative"]);
+    expect(presses).toEqual(["2:imperative"]);
     expect(buttonRef as unknown).toBe(root);
   });
 });

--- a/packages/react/src/checkbox/checkbox-primitive.test.tsx
+++ b/packages/react/src/checkbox/checkbox-primitive.test.tsx
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import type { TextRenderable } from "@opentui/core";
 import { TestRecorder, type TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import {
@@ -12,11 +11,6 @@ import * as Checkbox from "./primitive";
 
 let setup: TestRendererSetup | undefined;
 
-function textContent(id: string): string {
-  const text = setup?.renderer.root.findDescendantById(id) as TextRenderable;
-  return text.content.chunks.map((chunk) => chunk.text).join("");
-}
-
 afterEach(async () => {
   await act(async () => setup?.renderer.destroy());
   setup = undefined;
@@ -25,13 +19,21 @@ afterEach(async () => {
 describe("React Checkbox", () => {
   it("never renders a controlled frame where Root content and Indicator disagree", async () => {
     let setChecked: (checked: boolean) => void = () => {};
+    let initialRoot: CheckboxRootRenderable | null = null;
 
     function App() {
       const [checked, updateChecked] = useState(false);
       setChecked = updateChecked;
       return createElement(
         Checkbox.Root,
-        { checked, flexDirection: "row", id: "frame-root" },
+        {
+          checked,
+          flexDirection: "row",
+          id: "frame-root",
+          ref: (root) => {
+            initialRoot ??= root;
+          },
+        },
         ((state: CheckboxState) =>
           createElement(
             Fragment,
@@ -61,13 +63,21 @@ describe("React Checkbox", () => {
     expect(
       recorder.recordedFrames.map(({ frame }) => visibleState(frame)),
     ).toEqual(recorder.recordedFrames.map(() => "1x"));
+    expect(setup.renderer.root.findDescendantById("frame-root")).toBe(
+      initialRoot ?? undefined,
+    );
   });
 
   it("composes public parts and arbitrary content around shared state", async () => {
+    const changes: boolean[] = [];
     setup = await testRender(
       createElement(
         Checkbox.Root,
-        { id: "root", defaultChecked: false },
+        {
+          id: "root",
+          defaultChecked: true,
+          onCheckedChange: (checked) => changes.push(checked),
+        },
         createElement(
           Checkbox.Indicator,
           { id: "indicator" },
@@ -91,79 +101,22 @@ describe("React Checkbox", () => {
     expect(indicator.constructor).toBe(CheckboxIndicatorRenderable);
     expect(indicator.store).toBe(root.store);
     expect(indicator.getState()).toBe(root.store.state);
-    expect(indicator.visible).toBe(false);
-
-    await act(async () => {
-      root.press();
-      await setup?.waitFor(() => root.checked && indicator.visible);
-    });
-
-    expect(root.checked).toBe(true);
     expect(indicator.visible).toBe(true);
-    expect(indicator.getState()).toBe(root.store.state);
-  });
-
-  it("exposes primitive state to consumer-owned rendering", async () => {
-    let renderedState: CheckboxState | undefined;
-    const renderState = (state: CheckboxState) => {
-      renderedState = state;
-      return createElement("text", {
-        id: "state-label",
-        content: state.checked ? "on" : "off",
-      });
-    };
-    setup = await testRender(
-      createElement(
-        Checkbox.Root,
-        { id: "state-root" },
-        renderState as unknown as ReactNode,
-      ),
-      { width: 30, height: 5 },
-    );
-    const root = setup.renderer.root.findDescendantById(
-      "state-root",
-    ) as CheckboxRootRenderable;
-
-    expect(textContent("state-label")).toBe("off");
-    expect(renderedState).toBe(root.store.state);
 
     await act(async () => {
       root.press();
-      await setup?.waitFor(() => textContent("state-label") === "on");
+      await setup?.waitFor(() => !root.checked && !indicator.visible);
     });
 
-    expect(textContent("state-label")).toBe("on");
-    expect(renderedState).toBe(root.store.state);
-  });
-
-  it("accepts controlled updates without replacing the Root", async () => {
-    function App() {
-      const [checked, setChecked] = useState(false);
-      return createElement(Checkbox.Root, {
-        id: "controlled-root",
-        checked,
-        onCheckedChange: setChecked,
-      });
-    }
-
-    setup = await testRender(createElement(App), { width: 30, height: 5 });
-    const root = setup.renderer.root.findDescendantById(
-      "controlled-root",
-    ) as CheckboxRootRenderable;
-
-    await act(async () => root.press());
-    await setup.waitFor(() => root.checked);
-
-    expect(root.checked).toBe(true);
-    expect(setup.renderer.root.findDescendantById("controlled-root")).toBe(
-      root,
-    );
+    expect(root.checked).toBe(false);
+    expect(indicator.visible).toBe(false);
+    expect(indicator.getState()).toBe(root.store.state);
+    expect(changes).toEqual([false]);
   });
 
   it("retains its Root ref across prop removal and callback replacement", async () => {
     const changes: string[] = [];
     let setControlled: (controlled: boolean) => void = () => {};
-    let setDisabled: (disabled: boolean) => void = () => {};
     let setVersion: (version: number) => void = () => {};
     const rootRef: { current: CheckboxRootRenderable | null } = {
       current: null,
@@ -171,15 +124,12 @@ describe("React Checkbox", () => {
 
     function App() {
       const [controlled, updateControlled] = useState(true);
-      const [disabled, updateDisabled] = useState(false);
       const [version, updateVersion] = useState(1);
       setControlled = updateControlled;
-      setDisabled = updateDisabled;
       setVersion = updateVersion;
       return createElement(Checkbox.Root, {
         id: "reactive-root",
         checked: controlled ? false : undefined,
-        disabled: disabled || undefined,
         onCheckedChange: (checked) =>
           changes.push(`${version}:${String(checked)}`),
         ref: (value) => {
@@ -194,76 +144,13 @@ describe("React Checkbox", () => {
     ) as CheckboxRootRenderable;
     expect(rootRef.current).toBe(root);
 
-    await act(async () => root.press());
-    expect(changes).toEqual(["1:true"]);
-    expect(root.checked).toBe(false);
-
     await act(async () => {
       setControlled(false);
       setVersion(2);
     });
     await act(async () => root.press());
     expect(root.checked).toBe(true);
-    expect(changes).toEqual(["1:true", "2:true"]);
+    expect(changes).toEqual(["2:true"]);
     expect(rootRef.current).toBe(root);
-
-    await act(async () => {
-      root.focus();
-      setDisabled(true);
-    });
-    expect(root.focused).toBe(false);
-    await act(async () => root.press());
-    expect(changes).toHaveLength(2);
-
-    await act(async () => setDisabled(false));
-    await act(async () => root.press());
-    expect(root.checked).toBe(false);
-    expect(changes.at(-1)).toBe("2:false");
-    expect(rootRef.current).toBe(root);
-  });
-
-  it("retains Indicator identity while synchronizing visibility", async () => {
-    const refs: CheckboxIndicatorRenderable[] = [];
-    const rootRef: { current: CheckboxRootRenderable | null } = {
-      current: null,
-    };
-
-    function App() {
-      return createElement(
-        Checkbox.Root,
-        {
-          id: "lifecycle-root",
-          ref: (value) => {
-            rootRef.current = value;
-          },
-        },
-        createElement(Checkbox.Indicator, {
-          id: "lifecycle-indicator",
-          ref: (value) => {
-            if (value) refs.push(value);
-          },
-        }),
-      );
-    }
-
-    setup = await testRender(createElement(App), { width: 30, height: 5 });
-    const root = setup.renderer.root.findDescendantById(
-      "lifecycle-root",
-    ) as CheckboxRootRenderable;
-    expect(rootRef.current).toBe(root);
-    const indicator = setup.renderer.root.findDescendantById(
-      "lifecycle-indicator",
-    ) as CheckboxIndicatorRenderable;
-    expect(refs).toEqual([indicator]);
-    expect(indicator.visible).toBe(false);
-
-    await act(async () => root.press());
-    expect(indicator.visible).toBe(true);
-    await act(async () => root.press());
-    expect(indicator.visible).toBe(false);
-    expect(refs).toEqual([indicator]);
-    expect(setup.renderer.root.findDescendantById("lifecycle-indicator")).toBe(
-      indicator,
-    );
   });
 });

--- a/packages/react/src/dialog/dialog-primitive.test.tsx
+++ b/packages/react/src/dialog/dialog-primitive.test.tsx
@@ -101,8 +101,6 @@ describe("React Dialog", () => {
 
     await act(async () => setup?.mockInput.pressEscape());
     await new Promise((resolve) => setTimeout(resolve, 30));
-    await act(async () => setup?.mockInput.pressEscape());
-    await new Promise((resolve) => setTimeout(resolve, 30));
 
     expect(changes).toEqual(["false:escape"]);
   });
@@ -126,7 +124,7 @@ describe("React Dialog", () => {
     expect(changes).toEqual([]);
   });
 
-  it("retains every part through open, close, focus containment, and reopen", async () => {
+  it("retains every part when opening the dialog", async () => {
     const changes: string[] = [];
     const rootRef = createRef<DialogRootRenderable>();
     const triggerRef = createRef<DialogTriggerRenderable>();
@@ -211,18 +209,8 @@ describe("React Dialog", () => {
 
     await act(async () => triggerRef.current?.press());
     await setup.waitFor(() => rootRef.current?.state.open === true);
-    expect(setup.renderer.currentFocusedRenderable?.id).toBe("react-action");
-    await act(async () => setup?.mockInput.pressTab());
-    expect(closeRef.current?.focused).toBe(true);
-    await act(async () => setup?.mockInput.pressEscape());
-    await new Promise((resolve) => setTimeout(resolve, 30));
-    expect(changes).toContain("false:escape");
-    expect(rootRef.current?.state.open).toBe(false);
-    expect(triggerRef.current?.focused).toBe(true);
-    expect(portalRef.current?.visible).toBe(false);
-
-    await act(async () => triggerRef.current?.press());
-    await setup.waitFor(() => portalRef.current?.visible === true);
+    expect(changes).toContain("true:trigger");
+    expect(portalRef.current?.visible).toBe(true);
     expect(rootRef.current).toBe(retained.root);
     expect(triggerRef.current).toBe(retained.trigger);
     expect(portalRef.current).toBe(retained.portal);
@@ -234,10 +222,6 @@ describe("React Dialog", () => {
     expect(
       setup.renderer.root.findDescendantById("react-open-state"),
     ).toMatchObject({ plainText: "open" });
-
-    await act(async () => closeRef.current?.press());
-    await setup.waitFor(() => rootRef.current?.state.open === false);
-    expect(popupRef.current?.visible).toBe(false);
   });
 
   it("updates initial focus after a descendant ref becomes available", async () => {

--- a/packages/react/src/radio/radio-group-primitive.test.tsx
+++ b/packages/react/src/radio/radio-group-primitive.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import type { TextRenderable } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import { RadioRootRenderable, type RadioState } from "@tuiparts/core/radio";
@@ -9,17 +10,22 @@ import { Radio } from "./index";
 
 let setup: TestRendererSetup | undefined;
 
+function textContent(id: string): string {
+  const text = setup?.renderer.root.findDescendantById(id) as TextRenderable;
+  return text.content.chunks.map((chunk) => chunk.text).join("");
+}
+
 afterEach(async () => {
   await act(async () => setup?.renderer.destroy());
   setup = undefined;
 });
 
 describe("React RadioGroup", () => {
-  it("composes parts and publishes Item-owned focus while navigating", async () => {
+  it("composes parts around a shared Store with authoritative first-render state", async () => {
     const renderState = (state: RadioState) =>
       createElement("text", {
         id: "alpha-state",
-        content: `${state.checked}:${state.focused}:${state.tabbable}`,
+        content: `${state.checked}`,
       });
     setup = await testRender(
       createElement(
@@ -54,16 +60,16 @@ describe("React RadioGroup", () => {
     expect(root.constructor).toBe(RadioGroupRenderable);
     expect(alpha.constructor).toBe(RadioRootRenderable);
     expect(alpha.store).toBe(root.store);
+    expect(beta.store).toBe(root.store);
+    expect(textContent("alpha-state")).toBe("true");
     expect(
       setup.renderer.root.findDescendantById("beta-indicator"),
     ).toMatchObject({ visible: false });
 
-    await act(async () => alpha.focus());
-    await act(async () => setup?.mockInput.pressArrow("down"));
-    await setup.waitFor(() => root.value === "beta" && beta.focused);
+    await act(async () => beta.press());
+    await setup.waitFor(() => textContent("alpha-state") === "false");
 
-    expect(alpha.store.getItemState(alpha.key)).not.toHaveProperty("focused");
-    expect(beta.getState()).toMatchObject({ focused: true, checked: true });
+    expect(root.value).toBe("beta");
     expect(
       setup.renderer.root.findDescendantById("beta-indicator"),
     ).toBeDefined();
@@ -104,7 +110,7 @@ describe("React RadioGroup", () => {
     expect(itemRef.current).toBe(item);
   });
 
-  it("removes focused dynamic Items without stale registration", async () => {
+  it("unmounts dynamic Items without stale registration", async () => {
     const rootRef = createRef<RadioGroupRenderable>();
     const fallbackRef = createRef<RadioRootRenderable>();
     const dynamicRef = createRef<RadioRootRenderable>();
@@ -129,12 +135,9 @@ describe("React RadioGroup", () => {
     }
     setup = await testRender(createElement(App), { width: 30, height: 5 });
     const key = dynamicRef.current?.key;
-    await act(async () => dynamicRef.current?.focus());
     await act(async () => show?.(false));
     await setup.waitFor(
-      () =>
-        rootRef.current?.store.getItemState(key as symbol) === undefined &&
-        fallbackRef.current?.focused === true,
+      () => rootRef.current?.store.getItemState(key as symbol) === undefined,
     );
 
     expect(dynamicRef.current).toBeNull();

--- a/packages/react/src/switch/switch-primitive.test.tsx
+++ b/packages/react/src/switch/switch-primitive.test.tsx
@@ -80,24 +80,20 @@ describe("React Switch", () => {
   it("retains refs across controlled prop removal and callback replacement", async () => {
     const changes: string[] = [];
     let setControlled: (controlled: boolean) => void = () => {};
-    let setDisabled: (disabled: boolean) => void = () => {};
     let setVersion: (version: number) => void = () => {};
     let rootRef: SwitchRootRenderable | null = null;
     let thumbRef: SwitchThumbRenderable | null = null;
 
     function App() {
       const [controlled, updateControlled] = useState(true);
-      const [disabled, updateDisabled] = useState(false);
       const [version, updateVersion] = useState(1);
       setControlled = updateControlled;
-      setDisabled = updateDisabled;
       setVersion = updateVersion;
       return createElement(
         Switch.Root,
         {
           id: "reactive-root",
           checked: controlled ? false : undefined,
-          disabled: disabled || undefined,
           onCheckedChange: (checked) =>
             changes.push(`${version}:${String(checked)}`),
           ref: (value) => {
@@ -134,14 +130,6 @@ describe("React Switch", () => {
     await act(async () => root.press());
     expect(root.checked).toBe(true);
     expect(changes).toEqual(["1:true", "2:true"]);
-
-    await act(async () => {
-      root.focus();
-      setDisabled(true);
-    });
-    expect(root.focused).toBe(false);
-    await act(async () => root.press());
-    expect(changes).toHaveLength(2);
 
     expect(rootRef as unknown).toBe(root);
     expect(thumbRef as unknown).toBe(thumb);

--- a/packages/react/src/toggle-group/toggle-group-primitive.test.tsx
+++ b/packages/react/src/toggle-group/toggle-group-primitive.test.tsx
@@ -60,16 +60,10 @@ describe("React ToggleGroup", () => {
         return key ? group.store.getItemState(key)?.available === true : false;
       }),
     );
-    await act(async () => {
-      left.focus();
-      await setup?.mockInput.pressArrow("right");
-    });
-    expect(right.focused).toBe(true);
-    expect(group.value).toEqual(["left"]);
+
     await act(async () => right.press());
     await setup.waitFor(() => group.value[0] === "right");
-    expect(left.pressed).toBe(false);
-    expect(right.pressed).toBe(true);
+    expect(group.value).toEqual(["right"]);
   });
 
   it("updates controlled group props without replacing Renderables", async () => {
@@ -122,7 +116,7 @@ describe("React ToggleGroup", () => {
     expect(itemRefs.at(-1)).toBe(alpha);
   });
 
-  it("releases controlled group ownership at the observed value", async () => {
+  it("releases controlled ownership when the value prop is removed", async () => {
     const requests: Array<readonly string[]> = [];
     let setValue: (value: readonly string[] | undefined) => void = () => {};
     function App() {
@@ -144,78 +138,19 @@ describe("React ToggleGroup", () => {
 
     setup = await testRender(createElement(App), { width: 30, height: 4 });
     const group = setup.renderer.root.findDescendantById("ownership-group");
-    const alpha = setup.renderer.root.findDescendantById("ownership-alpha");
     const beta = setup.renderer.root.findDescendantById("ownership-beta");
     if (!(group instanceof ToggleGroupRenderable))
       throw new Error("Expected ToggleGroupRenderable ownership-group");
-    if (!(alpha instanceof ToggleRenderable))
-      throw new Error("Expected ToggleRenderable ownership-alpha");
     if (!(beta instanceof ToggleRenderable))
       throw new Error("Expected ToggleRenderable ownership-beta");
 
-    await act(async () => beta.press());
-    expect(requests).toEqual([["beta"]]);
     expect(group.value).toEqual(["alpha"]);
 
-    await act(async () => setValue(["beta"]));
-    expect(group.value).toEqual(["beta"]);
     await act(async () => setValue(undefined));
-    await act(async () => alpha.press());
-    expect(group.value).toEqual(["alpha"]);
-    expect(requests).toEqual([["beta"], ["alpha"]]);
-  });
-
-  it("reactively gates disabled and unavailable group interaction", async () => {
-    const requests: Array<readonly string[]> = [];
-    let enableGroup: () => void = () => {};
-    let hideBeta: () => void = () => {};
-    function App() {
-      const [disabled, setDisabled] = useState(true);
-      const [betaVisible, setBetaVisible] = useState(true);
-      enableGroup = () => setDisabled(false);
-      hideBeta = () => setBetaVisible(false);
-      return createElement(
-        ToggleGroup,
-        {
-          disabled,
-          id: "disabled-group",
-          onValueChange: (value) => requests.push(value),
-        },
-        createElement(Toggle, { id: "disabled-alpha", value: "alpha" }),
-        createElement(Toggle, {
-          id: "disabled-beta",
-          value: "beta",
-          visible: betaVisible,
-        }),
-      );
-    }
-
-    setup = await testRender(createElement(App), { width: 30, height: 4 });
-    const group = setup.renderer.root.findDescendantById("disabled-group");
-    const alpha = setup.renderer.root.findDescendantById("disabled-alpha");
-    const beta = setup.renderer.root.findDescendantById("disabled-beta");
-    if (!(group instanceof ToggleGroupRenderable))
-      throw new Error("Expected ToggleGroupRenderable disabled-group");
-    if (!(alpha instanceof ToggleRenderable))
-      throw new Error("Expected ToggleRenderable disabled-alpha");
-    if (!(beta instanceof ToggleRenderable))
-      throw new Error("Expected ToggleRenderable disabled-beta");
-
-    await act(async () => {
-      alpha.focus();
-      alpha.press();
-      beta.press();
-    });
-    expect(alpha.focused).toBe(false);
-    expect(requests).toEqual([]);
-
-    await act(async () => enableGroup());
-    await act(async () => hideBeta());
     await act(async () => beta.press());
-    expect(requests).toEqual([]);
-    await act(async () => alpha.press());
-    expect(group.value).toEqual(["alpha"]);
-    expect(requests).toEqual([["alpha"]]);
+    await setup.waitFor(() => group.value[0] === "beta");
+    expect(group.value).toEqual(["beta"]);
+    expect(requests).toEqual([["beta"]]);
   });
 
   it("replaces the group callback without replacing its Renderable", async () => {
@@ -250,11 +185,10 @@ describe("React ToggleGroup", () => {
     if (!(beta instanceof ToggleRenderable))
       throw new Error("Expected ToggleRenderable beta-callback");
 
-    await act(async () => beta.press());
     await act(async () => replaceCallback());
     await act(async () => alpha.press());
 
-    expect(calls).toEqual(["old", "new"]);
+    expect(calls).toEqual(["new"]);
     expect(groupRefs.at(-1)).toBe(group);
   });
 

--- a/packages/solid/src/button/button-primitive.test.tsx
+++ b/packages/solid/src/button/button-primitive.test.tsx
@@ -51,10 +51,9 @@ describe("Solid Button", () => {
     root.focus();
     await setup.waitFor(() => textContent("content") === "Focused");
     expect(textContent("content")).toBe("Focused");
-    expect(Object.isFrozen(root.getState())).toBe(true);
   });
 
-  it("retains Button identity across disabled removal and callback replacement", async () => {
+  it("retains Button identity across prop removal and callback replacement", async () => {
     const presses: string[] = [];
     let setDisabled: (disabled: boolean) => void = () => {};
     let setVersion: (version: number) => void = () => {};
@@ -89,18 +88,16 @@ describe("Solid Button", () => {
     root.press();
     expect(presses).toEqual(["1:imperative"]);
 
-    root.focus();
+    // Prop removal: the reactive `disabled` prop propagates and then clears.
     setDisabled(true);
-    setVersion(2);
-    await setup.waitFor(() => root.disabled && !root.focused);
-    root.press();
-    expect(presses).toHaveLength(1);
-
+    await setup.waitFor(() => root.disabled);
     setDisabled(false);
-    setVersion(3);
     await setup.waitFor(() => !root.disabled);
+
+    // Callback replacement fires through the new version on the retained Root.
+    setVersion(2);
     root.press();
-    expect(presses).toEqual(["1:imperative", "3:imperative"]);
+    expect(presses).toEqual(["1:imperative", "2:imperative"]);
     expect(buttonRef).toBe(root);
   });
 });

--- a/packages/solid/src/checkbox/checkbox-primitive.test.tsx
+++ b/packages/solid/src/checkbox/checkbox-primitive.test.tsx
@@ -1,23 +1,16 @@
 /** @jsxImportSource @opentui/solid */
 
 import { afterEach, describe, expect, it } from "bun:test";
-import type { TextRenderable } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/solid";
 import type {
   CheckboxIndicatorRenderable,
   CheckboxRootRenderable,
-  CheckboxState,
 } from "@tuiparts/core/checkbox";
 import { createSignal } from "solid-js";
 import * as Checkbox from "./primitive";
 
 let setup: TestRendererSetup | undefined;
-
-function textContent(id: string): string {
-  const text = setup?.renderer.root.findDescendantById(id) as TextRenderable;
-  return text.content.chunks.map((chunk) => chunk.text).join("");
-}
 
 afterEach(() => {
   setup?.renderer.destroy();
@@ -56,52 +49,6 @@ describe("Solid Checkbox", () => {
     expect(indicator.visible).toBe(true);
   });
 
-  it("exposes primitive state to consumer-owned rendering", async () => {
-    setup = await testRender(
-      () => (
-        <Checkbox.Root id="state-root">
-          {(state: CheckboxState) => (
-            <text id="state-label" content={state.checked ? "on" : "off"} />
-          )}
-        </Checkbox.Root>
-      ),
-      { width: 30, height: 5 },
-    );
-    const root = setup.renderer.root.findDescendantById(
-      "state-root",
-    ) as CheckboxRootRenderable;
-    expect(textContent("state-label")).toBe("off");
-
-    root.press();
-    await setup.waitFor(() => textContent("state-label") === "on");
-    expect(textContent("state-label")).toBe("on");
-  });
-
-  it("accepts controlled updates without replacing the Root", async () => {
-    setup = await testRender(
-      () => {
-        const [checked, setChecked] = createSignal(false);
-        return (
-          <Checkbox.Root
-            id="controlled-root"
-            checked={checked()}
-            onCheckedChange={setChecked}
-          />
-        );
-      },
-      { width: 30, height: 5 },
-    );
-    const root = setup.renderer.root.findDescendantById(
-      "controlled-root",
-    ) as CheckboxRootRenderable;
-
-    root.press();
-    await setup.waitFor(() => root.checked);
-    expect(setup.renderer.root.findDescendantById("controlled-root")).toBe(
-      root,
-    );
-  });
-
   it("retains its Root ref across prop removal and callback replacement", async () => {
     const changes: string[] = [];
     let setControlled: (controlled: boolean) => void = () => {};
@@ -137,33 +84,26 @@ describe("Solid Checkbox", () => {
       "reactive-root",
     ) as CheckboxRootRenderable;
     expect(rootRef).toBe(root);
-
-    root.press();
-    expect(changes).toEqual(["1:true"]);
     expect(root.checked).toBe(false);
 
+    // Prop removal: clearing the controlled `checked` prop releases the Root,
+    // and the replaced callback fires through the new version.
     setControlled(false);
     setVersion(2);
     root.press();
     await setup.waitFor(() => root.checked);
-    expect(changes).toEqual(["1:true", "2:true"]);
+    expect(changes).toEqual(["2:true"]);
     expect(rootRef).toBe(root);
 
-    root.focus();
+    // Reactive disabled prop propagation and removal on the retained Root.
     setDisabled(true);
-    await setup.waitFor(() => !root.focused && root.disabled);
-    root.press();
-    expect(changes).toHaveLength(2);
-
+    await setup.waitFor(() => root.disabled);
     setDisabled(false);
     await setup.waitFor(() => !root.disabled);
-    root.press();
-    await setup.waitFor(() => !root.checked);
-    expect(changes.at(-1)).toBe("2:false");
     expect(rootRef).toBe(root);
   });
 
-  it("retains Indicator identity while synchronizing visibility", async () => {
+  it("retains Indicator identity across a state update", async () => {
     let rootRef: CheckboxRootRenderable | undefined;
     let indicatorRef: CheckboxIndicatorRenderable | undefined;
     setup = await testRender(
@@ -196,8 +136,6 @@ describe("Solid Checkbox", () => {
 
     root.press();
     await setup.waitFor(() => indicator.visible);
-    root.press();
-    await setup.waitFor(() => !indicator.visible);
     expect(setup.renderer.root.findDescendantById("lifecycle-indicator")).toBe(
       indicator,
     );

--- a/packages/solid/src/dialog/dialog-primitive.test.tsx
+++ b/packages/solid/src/dialog/dialog-primitive.test.tsx
@@ -161,32 +161,6 @@ describe("Solid Dialog", () => {
     expect(popup?.visible).toBe(false);
   });
 
-  it("follows rendered descendant order when choosing initial focus", async () => {
-    let trigger: DialogTriggerRenderable | undefined;
-    let close: DialogCloseRenderable | undefined;
-    setup = await testRender(
-      () => (
-        <Dialog.Root>
-          <Dialog.Trigger ref={(value) => (trigger = value)} />
-          <Dialog.Portal>
-            <Dialog.Popup>
-              <box id="solid-first-action" focusable />
-              <Dialog.Close ref={(value) => (close = value)} />
-            </Dialog.Popup>
-          </Dialog.Portal>
-        </Dialog.Root>
-      ),
-      { width: 40, height: 10 },
-    );
-
-    trigger?.press();
-    expect(setup.renderer.currentFocusedRenderable?.id).toBe(
-      "solid-first-action",
-    );
-    await setup.mockInput.pressTab();
-    expect(close?.focused).toBe(true);
-  });
-
   it("updates initial focus after a descendant ref becomes available", async () => {
     let trigger: DialogTriggerRenderable | undefined;
     let popup: DialogPopupRenderable | undefined;

--- a/packages/solid/src/radio/radio-group-primitive.test.tsx
+++ b/packages/solid/src/radio/radio-group-primitive.test.tsx
@@ -39,7 +39,7 @@ describe("Solid RadioGroup", () => {
     ).rejects.toThrow("Radio.Root must be rendered inside RadioGroup");
   });
 
-  it("composes parts with public state and keyboard navigation", async () => {
+  it("composes parts with public state and a single selection round-trip", async () => {
     let indicatorRef: RadioIndicatorRenderable | undefined;
     let alphaRef: RadioRootRenderable | undefined;
     setup = await testRender(
@@ -103,17 +103,10 @@ describe("Solid RadioGroup", () => {
       tabbable: true,
     });
 
-    alpha.focus();
-    await setup.waitFor(() => textContent("alpha-state").includes("focused"));
-    await setup.mockInput.pressArrow("down");
-    await setup.waitFor(() => textContent("group-state") === "beta");
-
+    // One selection round-trip: pressing beta updates the group value.
+    beta.press();
+    await setup.waitFor(() => root.value === "beta");
     expect(root.value).toBe("beta");
-    expect(beta.focused).toBe(true);
-    expect(textContent("alpha-state")).toBe("off:blurred:available:untabbable");
-    expect(
-      setup.renderer.root.findDescendantById("alpha-indicator"),
-    ).toBeUndefined();
   });
 
   it("reactively updates disabled props on a retained group", async () => {
@@ -148,15 +141,17 @@ describe("Solid RadioGroup", () => {
     const beta = setup.renderer.root.findDescendantById(
       "uncontrolled-beta",
     ) as RadioRootRenderable;
+    expect(beta.disabled).toBe(true);
 
-    beta.press();
-    expect(root.value).toBe("alpha");
+    // Reactive group and item disabled propagation, then prop removal.
     setItemDisabled(false);
     await setup.waitFor(() => !beta.disabled);
     setGroupDisabled(true);
     await setup.waitFor(() => root.disabled && beta.disabled);
     setGroupDisabled(false);
     await setup.waitFor(() => !root.disabled && !beta.disabled);
+
+    // One selection round-trip on the re-enabled retained group.
     beta.press();
     expect(root.value).toBe("beta");
     expect(setup.renderer.root.findDescendantById("uncontrolled-root")).toBe(
@@ -279,9 +274,6 @@ describe("Solid RadioGroup", () => {
     const item = setup.renderer.root.findDescendantById(
       "dynamic-item",
     ) as RadioRootRenderable;
-    const fallback = setup.renderer.root.findDescendantById(
-      "fallback-item",
-    ) as RadioRootRenderable;
     const indicator = setup.renderer.root.findDescendantById(
       "dynamic-indicator",
     ) as RadioIndicatorRenderable;
@@ -289,14 +281,11 @@ describe("Solid RadioGroup", () => {
 
     expect(root.store.getItemState(key)).toBeDefined();
     expect(indicator.visible).toBe(false);
-    item.focus();
+
     setVisible(false);
-    await setup.waitFor(
-      () => root.store.getItemState(key) === undefined && fallback.focused,
-    );
+    await setup.waitFor(() => root.store.getItemState(key) === undefined);
     expect(
       setup.renderer.root.findDescendantById("dynamic-item"),
     ).toBeUndefined();
-    expect(indicator.getState().checked).toBe(false);
   });
 });

--- a/packages/solid/src/switch/switch-primitive.test.tsx
+++ b/packages/solid/src/switch/switch-primitive.test.tsx
@@ -1,23 +1,16 @@
 /** @jsxImportSource @opentui/solid */
 
 import { afterEach, describe, expect, it } from "bun:test";
-import type { TextRenderable } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/solid";
 import type {
   SwitchRootRenderable,
-  SwitchState,
   SwitchThumbRenderable,
 } from "@tuiparts/core/switch";
 import { createSignal } from "solid-js";
 import * as Switch from "./primitive";
 
 let setup: TestRendererSetup | undefined;
-
-function textContent(id: string): string {
-  const text = setup?.renderer.root.findDescendantById(id) as TextRenderable;
-  return text.content.chunks.map((chunk) => chunk.text).join("");
-}
 
 afterEach(() => {
   setup?.renderer.destroy();
@@ -62,27 +55,6 @@ describe("Solid Switch", () => {
 
     expect(root.checked).toBe(true);
     expect(setup.renderer.root.findDescendantById("thumb")).toBe(thumb);
-  });
-
-  it("exposes readonly state to consumer-owned rendering", async () => {
-    setup = await testRender(
-      () => (
-        <Switch.Root id="state-root">
-          {(state: SwitchState) => (
-            <text id="state-label" content={state.checked ? "on" : "off"} />
-          )}
-        </Switch.Root>
-      ),
-      { width: 30, height: 5 },
-    );
-    const root = setup.renderer.root.findDescendantById(
-      "state-root",
-    ) as SwitchRootRenderable;
-
-    expect(textContent("state-label")).toBe("off");
-    root.press();
-    await setup.waitFor(() => textContent("state-label") === "on");
-    expect(textContent("state-label")).toBe("on");
   });
 
   it("retains refs across controlled prop removal and callback replacement", async () => {
@@ -132,22 +104,21 @@ describe("Solid Switch", () => {
     ) as SwitchThumbRenderable;
     expect(rootRef).toBe(root);
     expect(thumbRef).toBe(thumb);
-
-    root.press();
-    expect(changes).toEqual(["1:true"]);
     expect(root.checked).toBe(false);
 
+    // Prop removal: clearing the controlled `checked` prop releases the Root,
+    // and the replaced callback fires through the new version.
     setControlled(false);
     setVersion(2);
     root.press();
     await setup.waitFor(() => root.checked);
-    expect(changes).toEqual(["1:true", "2:true"]);
+    expect(changes).toEqual(["2:true"]);
 
-    root.focus();
+    // Reactive disabled prop propagation and removal on the retained parts.
     setDisabled(true);
-    await setup.waitFor(() => root.disabled && !root.focused);
-    root.press();
-    expect(changes).toHaveLength(2);
+    await setup.waitFor(() => root.disabled);
+    setDisabled(false);
+    await setup.waitFor(() => !root.disabled);
 
     expect(rootRef).toBe(root);
     expect(thumbRef).toBe(thumb);

--- a/packages/solid/src/toggle-group/toggle-group-primitive.test.tsx
+++ b/packages/solid/src/toggle-group/toggle-group-primitive.test.tsx
@@ -25,7 +25,7 @@ afterEach(() => {
 });
 
 describe("Solid ToggleGroup", () => {
-  it("provides grouped state and keeps selection separate from focus movement", async () => {
+  it("provides grouped state with a single toggle round-trip", async () => {
     setup = await testRender(
       () => (
         <ToggleGroup defaultValue={["left"]} id="group">
@@ -43,22 +43,18 @@ describe("Solid ToggleGroup", () => {
       { width: 30, height: 4 },
     );
     const group = setup.renderer.root.findDescendantById("group");
-    const left = setup.renderer.root.findDescendantById("left");
     const right = setup.renderer.root.findDescendantById("right");
     if (!(group instanceof ToggleGroupRenderable))
       throw new Error("Expected ToggleGroupRenderable group");
-    if (!(left instanceof ToggleRenderable))
-      throw new Error("Expected ToggleRenderable left");
     if (!(right instanceof ToggleRenderable))
       throw new Error("Expected ToggleRenderable right");
 
     expect(textContent("left-state")).toBe("pressed");
-    left.focus();
-    await setup.mockInput.pressArrow("right");
-    expect(right.focused).toBe(true);
     expect(group.value).toEqual(["left"]);
+
     right.press();
     await setup.waitFor(() => group.value[0] === "right");
+    expect(group.value).toEqual(["right"]);
   });
 
   it("reactively updates controlled values without replacing Renderables", async () => {
@@ -140,12 +136,15 @@ describe("Solid ToggleGroup", () => {
     if (!(beta instanceof ToggleRenderable))
       throw new Error("Expected ToggleRenderable ownership-beta");
 
+    // The change callback fires while controlled.
     beta.press();
     expect(requests).toEqual([["beta"]]);
-    expect(group.value).toEqual(["alpha"]);
 
+    // Controlled prop commits through the Store.
     setValue(["beta"]);
     await setup.waitFor(() => group.value[0] === "beta");
+
+    // Prop removal: clearing the controlled value releases ownership.
     setValue(undefined);
     await Promise.resolve();
     alpha.press();
@@ -153,7 +152,7 @@ describe("Solid ToggleGroup", () => {
     expect(requests).toEqual([["beta"], ["alpha"]]);
   });
 
-  it("reactively gates disabled and unavailable group interaction", async () => {
+  it("reactively propagates disabled and visible props on a retained group", async () => {
     const requests: Array<readonly string[]> = [];
     let enableGroup: () => void = () => {};
     let hideBeta: () => void = () => {};
@@ -187,19 +186,15 @@ describe("Solid ToggleGroup", () => {
       throw new Error("Expected ToggleRenderable disabled-alpha");
     if (!(beta instanceof ToggleRenderable))
       throw new Error("Expected ToggleRenderable disabled-beta");
+    expect(group.disabled).toBe(true);
 
-    alpha.focus();
-    alpha.press();
-    beta.press();
-    expect(alpha.focused).toBe(false);
-    expect(requests).toEqual([]);
-
+    // Reactive disabled and visible prop propagation.
     enableGroup();
     await setup.waitFor(() => !group.disabled);
     hideBeta();
     await setup.waitFor(() => !beta.visible);
-    beta.press();
-    expect(requests).toEqual([]);
+
+    // One selection round-trip on the re-enabled group.
     alpha.press();
     expect(group.value).toEqual(["alpha"]);
     expect(requests).toEqual([["alpha"]]);

--- a/packages/solid/src/toggle/toggle-primitive.test.tsx
+++ b/packages/solid/src/toggle/toggle-primitive.test.tsx
@@ -51,20 +51,17 @@ describe("Solid Toggle", () => {
     await setup.waitFor(() => textContent("state") === "off");
   });
 
-  it("reactively clears controlled and disabled props on a retained Toggle", async () => {
+  it("reactively clears disabled props on a retained Toggle", async () => {
     let release: () => void = () => {};
     let toggleRef: ToggleRenderable | undefined;
     setup = await testRender(
       () => {
         const [controlled, setControlled] = createSignal(true);
-        const [pressed, setPressed] = createSignal(true);
         release = () => setControlled(false);
         return (
           <Toggle
             disabled={controlled() || undefined}
             id="retained"
-            onPressedChange={setPressed}
-            pressed={controlled() ? pressed() : undefined}
             ref={(value) => {
               toggleRef = value;
             }}
@@ -77,8 +74,6 @@ describe("Solid Toggle", () => {
     expect(toggle).toBeDefined();
     release();
     await setup.waitFor(() => toggle?.disabled === false);
-    toggle?.press();
-    expect(toggle?.pressed).toBe(false);
     expect(toggleRef).toBe(toggle);
   });
 

--- a/registry/button/smoke/core.test.ts
+++ b/registry/button/smoke/core.test.ts
@@ -34,22 +34,6 @@ describe("installed Core Button recipe", () => {
     expect(presses).toEqual([{ source: "imperative" }]);
   });
 
-  it("suppresses disabled focus and activation", async () => {
-    let presses = 0;
-    setup = await createTestRenderer({ width: 30, height: 3 });
-    const button = createButton(setup.renderer, {
-      disabled: true,
-      label: "Wait",
-      onPress: () => presses++,
-    });
-    setup.renderer.root.add(button);
-
-    button.focus();
-    button.press();
-    expect(button.focused).toBe(false);
-    expect(presses).toBe(0);
-  });
-
   it("derives a pressed shade distinct from the focus color", async () => {
     theme.register("smoke-pressed", {
       tokens: { colors: { focus: "#0000FF", foreground: "#FFFFFF" } },

--- a/registry/button/smoke/react.test.tsx
+++ b/registry/button/smoke/react.test.tsx
@@ -22,36 +22,22 @@ afterEach(async () => {
 test("installed React Button recipe runtime smoke", async () => {
   const presses: ButtonPressDetails[] = [];
   setup = await testRender(
-    <box flexDirection="column">
-      <Button
-        id="active"
-        intent="neutral"
-        label="Run"
-        onPress={(details) => presses.push(details)}
-      />
-      <Button
-        id="disabled"
-        disabled
-        label="Wait"
-        onPress={() => presses.push({ source: "imperative" })}
-      />
-    </box>,
-    { width: 30, height: 5 },
+    <Button
+      id="active"
+      intent="neutral"
+      label="Run"
+      onPress={(details) => presses.push(details)}
+    />,
+    { width: 30, height: 3 },
   );
   const active = setup.renderer.root.findDescendantById(
     "active",
-  ) as ButtonRenderable;
-  const disabled = setup.renderer.root.findDescendantById(
-    "disabled",
   ) as ButtonRenderable;
 
   await setup.renderOnce();
   expect(setup.captureCharFrame().split("\n")[0]?.includes("Run")).toBe(true);
   await act(async () => active.press());
-  disabled.focus();
-  disabled.press();
   expect(presses).toEqual([{ source: "imperative" }]);
-  expect(disabled.focused).toBe(false);
 });
 
 test("restyles rendered buttons on theme switch", async () => {

--- a/registry/button/smoke/solid.test.tsx
+++ b/registry/button/smoke/solid.test.tsx
@@ -23,37 +23,23 @@ describe("installed Solid Button recipe", () => {
     const presses: ButtonPressDetails[] = [];
     setup = await testRender(
       () => (
-        <box flexDirection="column">
-          <Button
-            id="active"
-            intent="neutral"
-            label="Run"
-            onPress={(details) => presses.push(details)}
-          />
-          <Button
-            id="disabled"
-            disabled
-            label="Wait"
-            onPress={(details) => presses.push(details)}
-          />
-        </box>
+        <Button
+          id="active"
+          intent="neutral"
+          label="Run"
+          onPress={(details) => presses.push(details)}
+        />
       ),
-      { width: 30, height: 5 },
+      { width: 30, height: 3 },
     );
     const active = setup.renderer.root.findDescendantById(
       "active",
-    ) as ButtonRenderable;
-    const disabled = setup.renderer.root.findDescendantById(
-      "disabled",
     ) as ButtonRenderable;
 
     await setup.renderOnce();
     expect(setup.captureCharFrame().split("\n")[0]?.includes("Run")).toBe(true);
     active.press();
-    disabled.focus();
-    disabled.press();
     expect(presses).toEqual([{ source: "imperative" }]);
-    expect(disabled.focused).toBe(false);
   });
 
   it("restyles rendered buttons on theme switch", async () => {

--- a/registry/checkbox/smoke/core.test.ts
+++ b/registry/checkbox/smoke/core.test.ts
@@ -48,40 +48,6 @@ describe("installed Core Checkbox recipe", () => {
     expect(firstLine()).toBe("x Ready");
   });
 
-  it("reports controlled intent without owning the update", async () => {
-    const changes: boolean[] = [];
-    const checkbox = await render({
-      checked: false,
-      label: "Controlled",
-      mark: "x",
-      onCheckedChange: (checked) => changes.push(checked),
-    });
-
-    checkbox.press();
-    expect(changes).toEqual([true]);
-    expect(checkbox.checked).toBe(false);
-
-    checkbox.checked = true;
-    await setup?.renderOnce();
-    expect(firstLine()).toBe("x Controlled");
-  });
-
-  it("suppresses disabled interaction", async () => {
-    const changes: boolean[] = [];
-    const checkbox = await render({
-      disabled: true,
-      label: "Disabled",
-      onCheckedChange: (checked) => changes.push(checked),
-    });
-
-    checkbox.focus();
-    checkbox.press();
-
-    expect(checkbox.focused).toBe(false);
-    expect(checkbox.checked).toBe(false);
-    expect(changes).toEqual([]);
-  });
-
   it("renders a consumer-owned mark", async () => {
     await render({ defaultChecked: true, label: "Custom", mark: "*" });
     expect(firstLine()).toBe("* Custom");

--- a/registry/checkbox/smoke/react.test.tsx
+++ b/registry/checkbox/smoke/react.test.tsx
@@ -5,7 +5,7 @@ import { type BaseRenderable, TextRenderable } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import type { CheckboxRootRenderable } from "@tuiparts/core/checkbox";
-import { act, useState } from "react";
+import { act } from "react";
 import { Checkbox } from "./components/ui/checkbox";
 import { theme } from "./components/ui/theme";
 
@@ -29,33 +29,12 @@ afterEach(async () => {
 });
 
 test("installed React Checkbox recipe runtime smoke", async () => {
-  let disabledChanges = 0;
-
-  function Controlled() {
-    const [checked, setChecked] = useState(false);
-    return (
-      <Checkbox
-        id="controlled"
-        label="Controlled"
-        checked={checked}
-        onCheckedChange={setChecked}
-      />
-    );
-  }
-
   setup = await testRender(
     <box flexDirection="column">
       <Checkbox id="uncontrolled" label="Uncontrolled" />
-      <Controlled />
-      <Checkbox
-        id="disabled"
-        label="Disabled"
-        disabled
-        onCheckedChange={() => disabledChanges++}
-      />
       <Checkbox id="custom-mark" label="Custom mark" defaultChecked mark="x" />
     </box>,
-    { width: 40, height: 8 },
+    { width: 40, height: 4 },
   );
 
   const uncontrolled = root("uncontrolled");
@@ -64,18 +43,6 @@ test("installed React Checkbox recipe runtime smoke", async () => {
   await act(async () => uncontrolled.press());
   await setup.waitFor(() => uncontrolled.checked);
   expect(text(uncontrolled)).toEqual(["✓", "Uncontrolled"]);
-
-  const controlled = root("controlled");
-  await act(async () => controlled.press());
-  await setup.waitFor(() => controlled.checked);
-  expect(root("controlled")).toBe(controlled);
-
-  const disabled = root("disabled");
-  disabled.focus();
-  disabled.press();
-  expect(disabled.checked).toBe(false);
-  expect(disabled.focused).toBe(false);
-  expect(disabledChanges).toBe(0);
 
   expect(text(root("custom-mark"))).toEqual(["x", "Custom mark"]);
 });

--- a/registry/checkbox/smoke/solid.test.tsx
+++ b/registry/checkbox/smoke/solid.test.tsx
@@ -5,7 +5,6 @@ import { type BaseRenderable, TextRenderable } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/solid";
 import type { CheckboxRootRenderable } from "@tuiparts/core/checkbox";
-import { createSignal } from "solid-js";
 import { Checkbox } from "./components/ui/checkbox";
 import { theme } from "./components/ui/theme";
 
@@ -38,56 +37,6 @@ describe("installed Solid Checkbox recipe", () => {
     await setup.waitFor(() => root.checked);
 
     expect(root.checked).toBe(true);
-  });
-
-  it("applies controlled owner updates", async () => {
-    setup = await testRender(
-      () => {
-        const [checked, setChecked] = createSignal(false);
-        return (
-          <Checkbox
-            id="controlled"
-            label="Controlled"
-            checked={checked()}
-            onCheckedChange={setChecked}
-          />
-        );
-      },
-      { width: 30, height: 5 },
-    );
-    const root = setup.renderer.root.findDescendantById(
-      "controlled",
-    ) as CheckboxRootRenderable;
-
-    root.press();
-    await setup.waitFor(() => root.checked);
-
-    expect(root.checked).toBe(true);
-  });
-
-  it("suppresses disabled interaction", async () => {
-    const changes: boolean[] = [];
-    setup = await testRender(
-      () => (
-        <Checkbox
-          id="disabled"
-          label="Disabled"
-          disabled
-          onCheckedChange={(checked) => changes.push(checked)}
-        />
-      ),
-      { width: 30, height: 5 },
-    );
-    const root = setup.renderer.root.findDescendantById(
-      "disabled",
-    ) as CheckboxRootRenderable;
-
-    root.focus();
-    root.press();
-
-    expect(root.focused).toBe(false);
-    expect(root.checked).toBe(false);
-    expect(changes).toEqual([]);
   });
 
   it("renders a consumer-owned mark", async () => {

--- a/registry/dialog/smoke/core.test.ts
+++ b/registry/dialog/smoke/core.test.ts
@@ -34,10 +34,6 @@ test("installed Core Dialog recipe composes and delegates trigger, close, and ba
   expect(dialog.portal.visible).toBe(true);
   close.press();
   expect(dialog.root.state.open).toBe(false);
-  dialog.trigger.press();
-  expect(dialog.popup.visible).toBe(true);
-  dialog.backdrop.processMouseEvent({ type: "up" } as never);
-  expect(dialog.root.state.open).toBe(false);
 });
 
 test("restyles from the theme store on theme switch", async () => {

--- a/registry/dialog/smoke/react.test.tsx
+++ b/registry/dialog/smoke/react.test.tsx
@@ -30,51 +30,30 @@ afterEach(async () => {
   setup = undefined;
 });
 
-test("installed React Dialog recipe delegates controlled intent once and retains parts", async () => {
+test("installed React Dialog recipe composes parts and delegates trigger and close", async () => {
   const root = createRef<DialogRootRenderable>();
-  let changes = 0;
   setup = await testRender(
-    <box flexDirection="column">
-      <Dialog ref={root} defaultOpen={false}>
-        <DialogTrigger>
-          <text content="Open" />
-        </DialogTrigger>
-        <DialogContent>
-          <DialogTitle content="Delete file?" />
-          <text content="Body" />
-          <DialogClose>
-            <text content="Close" />
-          </DialogClose>
-        </DialogContent>
-      </Dialog>
-      <Dialog open={false} onOpenChange={() => changes++}>
-        <DialogTrigger>
-          <text content="Controlled open" />
-        </DialogTrigger>
-        <DialogContent>
-          <DialogTitle content="Controlled" />
-        </DialogContent>
-      </Dialog>
-    </box>,
+    <Dialog ref={root} defaultOpen={false}>
+      <DialogTrigger>
+        <text content="Open" />
+      </DialogTrigger>
+      <DialogContent>
+        <DialogTitle content="Delete file?" />
+        <text content="Body" />
+        <DialogClose>
+          <text content="Close" />
+        </DialogClose>
+      </DialogContent>
+    </Dialog>,
     { width: 60, height: 16 },
   );
   const recipeTrigger =
     root.current?.getChildren()[0] as DialogTriggerRenderable;
   await act(async () => recipeTrigger.press());
   expect(root.current?.state.open).toBe(true);
-  const retainedRoot = root.current;
   const recipeClose = findClose(setup.renderer.root);
   await act(async () => recipeClose.press());
   expect(root.current?.state.open).toBe(false);
-  await act(async () => recipeTrigger.press());
-  expect(root.current?.state.open).toBe(true);
-  expect(root.current).toBe(retainedRoot);
-  const controlledRoot =
-    root.current?.parent?.getChildren()[1] as DialogRootRenderable;
-  const controlledTrigger =
-    controlledRoot.getChildren()[0] as DialogTriggerRenderable;
-  await act(async () => controlledTrigger.press());
-  expect(changes).toBe(1);
 });
 
 test("restyles rendered dialog parts on theme switch", async () => {

--- a/registry/dialog/smoke/solid.test.tsx
+++ b/registry/dialog/smoke/solid.test.tsx
@@ -13,7 +13,6 @@ import {
   type DialogRootRenderable,
   type DialogTriggerRenderable,
 } from "@tuiparts/core/dialog";
-import { createSignal } from "solid-js";
 import {
   Dialog,
   DialogClose,
@@ -30,64 +29,30 @@ afterEach(() => {
   setup = undefined;
 });
 
-test("installed Solid Dialog recipe delegates controlled intent once and retains parts", async () => {
+test("installed Solid Dialog recipe composes parts and delegates trigger and close", async () => {
   let root: DialogRootRenderable | undefined;
-  let controlledRoot: DialogRootRenderable | undefined;
-  let controlledChanges = 0;
   setup = await testRender(
-    () => {
-      const [controlledOpen, setControlledOpen] = createSignal(false);
-      return (
-        <box flexDirection="column">
-          <Dialog ref={(node) => (root = node)} defaultOpen={false}>
-            <DialogTrigger>
-              <text content="Open" />
-            </DialogTrigger>
-            <DialogContent>
-              <DialogTitle content="Delete file?" />
-              <text content="Body" />
-              <DialogClose>
-                <text content="Close" />
-              </DialogClose>
-            </DialogContent>
-          </Dialog>
-          <Dialog
-            ref={(node) => {
-              controlledRoot = node;
-            }}
-            open={controlledOpen()}
-            onOpenChange={(open) => {
-              controlledChanges++;
-              setControlledOpen(open);
-            }}
-          >
-            <DialogTrigger>
-              <text content="Controlled open" />
-            </DialogTrigger>
-            <DialogContent>
-              <DialogTitle content="Controlled" />
-            </DialogContent>
-          </Dialog>
-        </box>
-      );
-    },
+    () => (
+      <Dialog ref={(node) => (root = node)} defaultOpen={false}>
+        <DialogTrigger>
+          <text content="Open" />
+        </DialogTrigger>
+        <DialogContent>
+          <DialogTitle content="Delete file?" />
+          <text content="Body" />
+          <DialogClose>
+            <text content="Close" />
+          </DialogClose>
+        </DialogContent>
+      </Dialog>
+    ),
     { width: 60, height: 16 },
   );
   const trigger = root?.getChildren()[0] as DialogTriggerRenderable;
-  const controlledTrigger =
-    controlledRoot?.getChildren()[0] as DialogTriggerRenderable;
   trigger.press();
   expect(root?.state.open).toBe(true);
-  const retainedRoot = root;
   findClose(setup.renderer.root).press();
   expect(root?.state.open).toBe(false);
-  trigger.press();
-  expect(root?.state.open).toBe(true);
-  expect(root).toBe(retainedRoot);
-
-  controlledTrigger.press();
-  await setup.waitFor(() => controlledRoot?.state.open === true);
-  expect(controlledChanges).toBe(1);
 });
 
 test("restyles rendered dialog parts on theme switch", async () => {

--- a/registry/radio-group/smoke/core.test.ts
+++ b/registry/radio-group/smoke/core.test.ts
@@ -49,7 +49,7 @@ function frameLines(): string[] {
 }
 
 describe("installed Core RadioGroup recipe", () => {
-  it("renders consumer-owned horizontal layout and mark while updating uncontrolled selection", async () => {
+  it("renders consumer-owned layout and mark while updating uncontrolled selection", async () => {
     const changes: string[] = [];
     const { root, items } = await renderGroup(
       {
@@ -78,79 +78,6 @@ describe("installed Core RadioGroup recipe", () => {
     expect(beta?.checked).toBe(true);
     expect(changes).toEqual(["beta"]);
     expect(frameLines()[0]).toContain("* Beta");
-  });
-
-  it("reports controlled intent without owning the update", async () => {
-    const changes: string[] = [];
-    const { root, items } = await renderGroup(
-      {
-        value: "alpha",
-        onValueChange: (value) => changes.push(value),
-      },
-      [
-        { value: "alpha", label: "Alpha", mark: "x" },
-        { value: "beta", label: "Beta", mark: "x" },
-      ],
-    );
-
-    items[1]?.press();
-    expect(changes).toEqual(["beta"]);
-    expect(root.value).toBe("alpha");
-    expect(items[0]?.checked).toBe(true);
-
-    root.value = "beta";
-    await setup?.renderOnce();
-    expect(items[1]?.checked).toBe(true);
-    expect(frameLines()[1]).toBe("x Beta");
-  });
-
-  it("skips disabled items, wraps with arrows, and supports Home and End", async () => {
-    const { items } = await renderGroup({ defaultValue: "alpha" }, [
-      { value: "alpha", label: "Alpha" },
-      { value: "beta", label: "Beta", disabled: true },
-      { value: "gamma", label: "Gamma" },
-    ]);
-    const alpha = items[0];
-    const beta = items[1];
-    const gamma = items[2];
-    alpha?.focus();
-
-    await setup?.mockInput.pressArrow("down");
-    expect(beta?.focused).toBe(false);
-    expect(gamma?.focused).toBe(true);
-    expect(gamma?.checked).toBe(true);
-
-    await setup?.mockInput.pressArrow("right");
-    expect(alpha?.focused).toBe(true);
-    expect(alpha?.checked).toBe(true);
-
-    await setup?.mockInput.pressKey("END");
-    expect(gamma?.focused).toBe(true);
-    await setup?.mockInput.pressKey("HOME");
-    expect(alpha?.focused).toBe(true);
-    expect(frameLines()[0]).toBe("● Alpha");
-    expect(frameLines()[1]).toBe("  Beta");
-  });
-
-  it("falls forward when the focused dynamic item is removed", async () => {
-    const { root, items } = await renderGroup({ defaultValue: "beta" }, [
-      { value: "alpha", label: "Alpha" },
-      { value: "beta", label: "Beta" },
-      { value: "gamma", label: "Gamma" },
-    ]);
-    const beta = items[1];
-    const gamma = items[2];
-    beta?.focus();
-    expect(beta?.focused).toBe(true);
-
-    beta?.destroy();
-    await setup?.renderOnce();
-
-    expect(root.value).toBeNull();
-    expect(beta?.focused).toBe(false);
-    expect(gamma?.focused).toBe(true);
-    expect(frameLines()).not.toContain("  Beta");
-    expect(frameLines()[1]).toBe("  Gamma");
   });
 
   it("restyles from the theme store on theme switch", async () => {

--- a/registry/radio-group/smoke/react.test.tsx
+++ b/registry/radio-group/smoke/react.test.tsx
@@ -11,15 +11,11 @@ import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import type { RadioRootRenderable } from "@tuiparts/core/radio";
 import type { RadioGroupRenderable } from "@tuiparts/core/radio-group";
-import { act, createRef, useState } from "react";
+import { act, createRef } from "react";
 import { RadioGroup, RadioGroupItem } from "./components/ui/radio-group";
 import { theme } from "./components/ui/theme";
 
 let setup: TestRendererSetup | undefined;
-
-function root(id: string): RadioGroupRenderable {
-  return setup?.renderer.root.findDescendantById(id) as RadioGroupRenderable;
-}
 
 function item(id: string): RadioRootRenderable {
   return setup?.renderer.root.findDescendantById(id) as RadioRootRenderable;
@@ -32,15 +28,6 @@ function text(node: BaseRenderable): string[] {
   ];
 }
 
-function frameLines(): string[] {
-  return (
-    setup
-      ?.captureCharFrame()
-      .split("\n")
-      .map((line) => line.trimEnd()) ?? []
-  );
-}
-
 afterEach(async () => {
   await act(async () => setup?.renderer.destroy());
   setup = undefined;
@@ -49,119 +36,31 @@ afterEach(async () => {
 describe("installed React RadioGroup recipe", () => {
   it("runs the collection behavior through consumer-owned presentation", async () => {
     const rootRef = createRef<RadioGroupRenderable>();
-    const retainedRef = createRef<RadioRootRenderable>();
-    const dynamicRef = createRef<RadioRootRenderable>();
-    let removeDynamic: (() => void) | undefined;
 
-    function Uncontrolled() {
-      const [showDynamic, setShowDynamic] = useState(true);
-      removeDynamic = () => setShowDynamic(false);
-      return (
-        <RadioGroup id="uncontrolled" defaultValue="alpha" ref={rootRef}>
-          <RadioGroupItem
-            id="alpha"
-            value="alpha"
-            label="Alpha"
-            ref={retainedRef}
-          />
-          <RadioGroupItem id="beta" value="beta" label="Beta" disabled />
-          <RadioGroupItem
-            id="gamma"
-            value="gamma"
-            label="Gamma"
-            mark="*"
-            tone="success"
-          />
-          {showDynamic ? (
-            <RadioGroupItem
-              id="dynamic"
-              value="dynamic"
-              label="Dynamic"
-              ref={dynamicRef}
-            />
-          ) : null}
-        </RadioGroup>
-      );
-    }
-
-    setup = await testRender(<Uncontrolled />, { width: 30, height: 8 });
+    setup = await testRender(
+      <RadioGroup id="uncontrolled" defaultValue="alpha" ref={rootRef}>
+        <RadioGroupItem id="alpha" value="alpha" label="Alpha" />
+        <RadioGroupItem
+          id="gamma"
+          value="gamma"
+          label="Gamma"
+          mark="*"
+          tone="success"
+        />
+      </RadioGroup>,
+      { width: 30, height: 4 },
+    );
     await act(async () => setup?.renderOnce());
-    const retainedRoot = rootRef.current;
-    const retainedItem = retainedRef.current;
     const alpha = item("alpha");
     const gamma = item("gamma");
 
-    expect(root("uncontrolled").value).toBe("alpha");
+    expect(rootRef.current?.value).toBe("alpha");
     expect(text(alpha)).toEqual(["●", "Alpha"]);
-    expect(frameLines().slice(0, 4)).toEqual([
-      "● Alpha",
-      "  Beta",
-      "  Gamma",
-      "  Dynamic",
-    ]);
 
-    await act(async () => alpha.focus());
-    await act(async () => setup?.mockInput.pressArrow("down"));
-    await setup.waitFor(() => gamma.focused && gamma.checked);
-    expect(root("uncontrolled").value).toBe("gamma");
-    expect(item("beta").checked).toBe(false);
+    await act(async () => gamma.press());
+    await setup.waitFor(() => gamma.checked);
+    expect(rootRef.current?.value).toBe("gamma");
     expect(text(gamma)).toEqual(["*", "Gamma"]);
-
-    await act(async () => setup?.mockInput.pressArrow("right"));
-    await setup.waitFor(() => item("dynamic").focused);
-    await act(async () => setup?.mockInput.pressArrow("down"));
-    await setup.waitFor(() => alpha.focused && alpha.checked);
-
-    await act(async () => setup?.mockInput.pressKey("END"));
-    await setup.waitFor(() => item("dynamic").focused);
-    await act(async () => setup?.mockInput.pressKey("HOME"));
-    await setup.waitFor(() => alpha.focused);
-
-    await act(async () => dynamicRef.current?.focus());
-    await act(async () => removeDynamic?.());
-    await setup.waitFor(
-      () => dynamicRef.current === null && item("gamma").focused,
-    );
-
-    expect(rootRef.current).toBe(retainedRoot);
-    expect(retainedRef.current).toBe(retainedItem);
-  });
-
-  it("applies controlled owner updates without replacing parts", async () => {
-    const rootRef = createRef<RadioGroupRenderable>();
-    const itemRef = createRef<RadioRootRenderable>();
-
-    function Controlled() {
-      const [value, setValue] = useState<string | null>("alpha");
-      return (
-        <RadioGroup
-          id="controlled"
-          value={value}
-          onValueChange={setValue}
-          ref={rootRef}
-        >
-          <RadioGroupItem
-            id="controlled-alpha"
-            value="alpha"
-            label="Alpha"
-            ref={itemRef}
-          />
-          <RadioGroupItem id="controlled-beta" value="beta" label="Beta" />
-        </RadioGroup>
-      );
-    }
-
-    setup = await testRender(<Controlled />, { width: 30, height: 4 });
-    await act(async () => setup?.renderOnce());
-    const retainedRoot = rootRef.current;
-    const retainedItem = itemRef.current;
-
-    await act(async () => item("controlled-beta").press());
-    await setup.waitFor(() => root("controlled").value === "beta");
-
-    expect(item("controlled-beta").checked).toBe(true);
-    expect(rootRef.current).toBe(retainedRoot);
-    expect(itemRef.current).toBe(retainedItem);
   });
 
   it("restyles rendered items on theme switch", async () => {

--- a/registry/radio-group/smoke/solid.test.tsx
+++ b/registry/radio-group/smoke/solid.test.tsx
@@ -6,7 +6,6 @@ import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/solid";
 import type { RadioRootRenderable } from "@tuiparts/core/radio";
 import type { RadioGroupRenderable } from "@tuiparts/core/radio-group";
-import { createSignal } from "solid-js";
 import { RadioGroup, RadioGroupItem } from "./components/ui/radio-group";
 import { theme } from "./components/ui/theme";
 
@@ -29,143 +28,33 @@ afterEach(() => {
 });
 
 test("installed Solid RadioGroup recipe runtime smoke", async () => {
-  let setDynamicVisible: (visible: boolean) => void = () => {};
-  let uncontrolledRootRef: RadioGroupRenderable | undefined;
-  let retainedAlphaRef: RadioRootRenderable | undefined;
-  let controlledRootRef: RadioGroupRenderable | undefined;
-  let controlledBetaRef: RadioRootRenderable | undefined;
+  let rootRef: RadioGroupRenderable | undefined;
 
   setup = await testRender(
-    () => {
-      const [dynamicVisible, updateDynamicVisible] = createSignal(true);
-      const [controlledValue, setControlledValue] =
-        createSignal("controlled-a");
-      setDynamicVisible = updateDynamicVisible;
-
-      return (
-        <box flexDirection="column">
-          <RadioGroup
-            id="uncontrolled-root"
-            defaultValue="alpha"
-            ref={(value) => {
-              uncontrolledRootRef = value;
-            }}
-          >
-            <RadioGroupItem
-              id="alpha"
-              value="alpha"
-              label="Alpha"
-              mark="x"
-              ref={(value) => {
-                retainedAlphaRef = value;
-              }}
-            />
-            <RadioGroupItem
-              id="disabled"
-              value="disabled"
-              label="Disabled"
-              disabled
-            />
-            {dynamicVisible() ? (
-              <RadioGroupItem id="dynamic" value="dynamic" label="Dynamic" />
-            ) : null}
-            <RadioGroupItem id="omega" value="omega" label="Omega" />
-          </RadioGroup>
-          <RadioGroup
-            id="controlled-root"
-            value={controlledValue()}
-            onValueChange={setControlledValue}
-            ref={(value) => {
-              controlledRootRef = value;
-            }}
-          >
-            <RadioGroupItem
-              id="controlled-a"
-              value="controlled-a"
-              label="Controlled A"
-            />
-            <RadioGroupItem
-              id="controlled-b"
-              value="controlled-b"
-              label="Controlled B"
-              ref={(value) => {
-                controlledBetaRef = value;
-              }}
-            />
-          </RadioGroup>
-        </box>
-      );
-    },
-    { width: 40, height: 12 },
+    () => (
+      <RadioGroup
+        id="uncontrolled"
+        defaultValue="alpha"
+        ref={(value) => {
+          rootRef = value;
+        }}
+      >
+        <RadioGroupItem id="alpha" value="alpha" label="Alpha" mark="x" />
+        <RadioGroupItem id="omega" value="omega" label="Omega" />
+      </RadioGroup>
+    ),
+    { width: 30, height: 4 },
   );
   await setup.renderOnce();
 
-  const uncontrolledRoot = uncontrolledRootRef;
-  const alpha = retainedAlphaRef;
-  const controlledRoot = controlledRootRef;
-  const controlledBeta = controlledBetaRef;
-  expect(uncontrolledRoot).toBeDefined();
-  expect(alpha).toBeDefined();
-  expect(controlledRoot).toBeDefined();
-  expect(controlledBeta).toBeDefined();
-  if (!uncontrolledRoot || !alpha || !controlledRoot || !controlledBeta) {
-    throw new Error("RadioGroup recipe refs were not assigned");
-  }
-
-  expect(uncontrolledRoot.value).toBe("alpha");
+  expect(rootRef).toBeDefined();
+  const alpha = item("alpha");
+  expect(rootRef?.value).toBe("alpha");
   expect(text(alpha)).toEqual(["x", "Alpha"]);
-  expect(text(uncontrolledRoot)).toEqual([
-    "x",
-    "Alpha",
-    "Disabled",
-    "Dynamic",
-    "Omega",
-  ]);
-  expect(uncontrolledRoot.getChildren()).toHaveLength(4);
-  expect(alpha.getChildren()).toHaveLength(2);
 
   item("omega").press();
-  await setup.waitFor(() => uncontrolledRoot.value === "omega");
+  await setup.waitFor(() => rootRef?.value === "omega");
   expect(text(alpha)).toEqual(["Alpha"]);
-
-  alpha.focus();
-  await setup.mockInput.pressArrow("down");
-  await setup.waitFor(() => item("dynamic").focused);
-  expect(item("disabled").focused).toBe(false);
-  expect(uncontrolledRoot.value).toBe("dynamic");
-
-  await setup.mockInput.pressArrow("down");
-  await setup.waitFor(() => item("omega").focused);
-  await setup.mockInput.pressArrow("down");
-  await setup.waitFor(() => alpha.focused);
-  expect(uncontrolledRoot.value).toBe("alpha");
-
-  await setup.mockInput.pressKey("END");
-  await setup.waitFor(() => item("omega").focused);
-  await setup.mockInput.pressKey("HOME");
-  await setup.waitFor(() => alpha.focused);
-
-  item("dynamic").focus();
-  item("dynamic").press();
-  await setup.waitFor(() => uncontrolledRoot.value === "dynamic");
-  setDynamicVisible(false);
-  await setup.waitFor(
-    () =>
-      setup?.renderer.root.findDescendantById("dynamic") === undefined &&
-      item("omega").focused,
-  );
-  expect(uncontrolledRoot.value).toBeNull();
-  expect(setup.renderer.root.findDescendantById("uncontrolled-root")).toBe(
-    uncontrolledRoot,
-  );
-  expect(item("alpha")).toBe(alpha);
-
-  controlledBeta.press();
-  await setup.waitFor(() => controlledRoot.value === "controlled-b");
-  expect(setup.renderer.root.findDescendantById("controlled-root")).toBe(
-    controlledRoot,
-  );
-  expect(item("controlled-b")).toBe(controlledBeta);
 });
 
 test("restyles rendered items on theme switch", async () => {

--- a/registry/switch/smoke/core.test.ts
+++ b/registry/switch/smoke/core.test.ts
@@ -44,24 +44,6 @@ describe("installed Core Switch recipe", () => {
     expect(firstLine()).toBe("----*  Ready");
   });
 
-  it("reports controlled intent and suppresses disabled interaction", async () => {
-    const changes: boolean[] = [];
-    setup = await createTestRenderer({ width: 30, height: 3 });
-    const toggle = createSwitch(setup.renderer, {
-      checked: false,
-      disabled: true,
-      label: "Disabled",
-      onCheckedChange: (checked) => changes.push(checked),
-    });
-    setup.renderer.root.add(toggle);
-
-    toggle.focus();
-    toggle.press();
-    expect(toggle.focused).toBe(false);
-    expect(toggle.checked).toBe(false);
-    expect(changes).toEqual([]);
-  });
-
   it("restyles from the theme store on theme switch", async () => {
     theme.register("smoke", {
       tokens: {

--- a/registry/switch/smoke/react.test.tsx
+++ b/registry/switch/smoke/react.test.tsx
@@ -5,7 +5,7 @@ import { type BaseRenderable, TextRenderable } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/react/test-utils";
 import type { SwitchRootRenderable } from "@tuiparts/core/switch";
-import { act, useState } from "react";
+import { act } from "react";
 import { Switch } from "./components/ui/switch";
 import { theme } from "./components/ui/theme";
 
@@ -21,29 +21,9 @@ function root(id: string): SwitchRootRenderable {
 }
 
 test("installed React Switch recipe runtime smoke", async () => {
-  let disabledChanges = 0;
-  function Controlled() {
-    const [checked, setChecked] = useState(false);
-    return (
-      <Switch
-        id="controlled"
-        label="Controlled"
-        checked={checked}
-        onCheckedChange={setChecked}
-      />
-    );
-  }
-
   setup = await testRender(
     <box flexDirection="column">
       <Switch id="uncontrolled" label="Uncontrolled" />
-      <Controlled />
-      <Switch
-        id="disabled"
-        label="Disabled"
-        disabled
-        onCheckedChange={() => disabledChanges++}
-      />
       <Switch
         id="custom"
         label="Custom"
@@ -52,25 +32,13 @@ test("installed React Switch recipe runtime smoke", async () => {
         symbols="ascii"
       />
     </box>,
-    { width: 40, height: 8 },
+    { width: 40, height: 4 },
   );
 
   const uncontrolled = root("uncontrolled");
   await act(async () => uncontrolled.press());
   await setup.waitFor(() => uncontrolled.checked);
   expect(uncontrolled.checked).toBe(true);
-
-  const controlled = root("controlled");
-  await act(async () => controlled.press());
-  await setup.waitFor(() => controlled.checked);
-  expect(root("controlled")).toBe(controlled);
-
-  const disabled = root("disabled");
-  disabled.focus();
-  disabled.press();
-  expect(disabled.focused).toBe(false);
-  expect(disabled.checked).toBe(false);
-  expect(disabledChanges).toBe(0);
 
   expect(root("custom").checked).toBe(true);
 });

--- a/registry/switch/smoke/solid.test.tsx
+++ b/registry/switch/smoke/solid.test.tsx
@@ -5,7 +5,6 @@ import { type BaseRenderable, TextRenderable } from "@opentui/core";
 import type { TestRendererSetup } from "@opentui/core/testing";
 import { testRender } from "@opentui/solid";
 import type { SwitchRootRenderable } from "@tuiparts/core/switch";
-import { createSignal } from "solid-js";
 import { Switch } from "./components/ui/switch";
 import { theme } from "./components/ui/theme";
 
@@ -21,54 +20,26 @@ function root(id: string): SwitchRootRenderable {
 }
 
 describe("installed Solid Switch recipe", () => {
-  it("covers controlled, uncontrolled, disabled, symbols, and density", async () => {
-    const disabledChanges: boolean[] = [];
+  it("updates uncontrolled state and renders consumer-owned symbols", async () => {
     setup = await testRender(
-      () => {
-        const [checked, setChecked] = createSignal(false);
-        return (
-          <box flexDirection="column">
-            <Switch id="uncontrolled" label="Uncontrolled" />
-            <Switch
-              id="controlled"
-              label="Controlled"
-              checked={checked()}
-              onCheckedChange={setChecked}
-            />
-            <Switch
-              id="disabled"
-              label="Disabled"
-              disabled
-              onCheckedChange={(value) => disabledChanges.push(value)}
-            />
-            <Switch
-              id="custom"
-              label="Custom"
-              defaultChecked
-              density="comfortable"
-              symbols="ascii"
-            />
-          </box>
-        );
-      },
-      { width: 40, height: 8 },
+      () => (
+        <box flexDirection="column">
+          <Switch id="uncontrolled" label="Uncontrolled" />
+          <Switch
+            id="custom"
+            label="Custom"
+            defaultChecked
+            density="comfortable"
+            symbols="ascii"
+          />
+        </box>
+      ),
+      { width: 40, height: 4 },
     );
 
     root("uncontrolled").press();
     await setup.waitFor(() => root("uncontrolled").checked);
     expect(root("uncontrolled").checked).toBe(true);
-
-    const controlled = root("controlled");
-    controlled.press();
-    await setup.waitFor(() => controlled.checked);
-    expect(root("controlled")).toBe(controlled);
-
-    const disabled = root("disabled");
-    disabled.focus();
-    disabled.press();
-    expect(disabled.focused).toBe(false);
-    expect(disabled.checked).toBe(false);
-    expect(disabledChanges).toEqual([]);
 
     expect(root("custom").checked).toBe(true);
   });


### PR DESCRIPTION
## Summary

Restores the testing pyramid: Core owns behavior semantics and proves them once; React and Solid adapters test only their adaptation seam; registry smokes are actual smoke tests. Net **−1,171/+208 test lines** with zero behavior-coverage loss.

Amends ADR-0001's test mandate and the `FOUNDATION_PRIMITIVE_CONTRACT.md` conformance rows first, so the deleted re-proofs are not re-required at the next conformance review.

## Why

Core is the behavior owner yet held only ~26% of test lines. Adapter and registry suites re-proved Core semantics through JSX: disabled gating was asserted in six files for Checkbox alone; the radio-group keyboard tour (arrows, disabled-skip, Home/End, dynamic removal) ran five times across layers. The 194-line `registry/radio-group/smoke/react.test.tsx` was a behavior suite wearing a smoke test's name. Every Core change broke up to five suites — #44 (the Pressable base class) paid that tax directly.

## Policy change (the load-bearing part)

**ADR-0001, Consistency invariants** — the old mandate ("Tests must inspect … every interaction frame, controlled updates, … disablement, focus …") conflated adapter-owned consistency with Core-owned behavior. New scoping:

> Adapter tests must inspect initial state during the first render, frame consistency for controlled updates (waiting only for eventual state is insufficient), retained identity, Store identity, and subscription teardown. Interaction semantics, including activation guards, disablement rules, and keyboard navigation, are owned and proven by Core test suites. Each adapter keeps exactly one interaction round-trip per primitive as wiring proof rather than re-proving the Core behavior matrix.

The seven numbered invariants are untouched.

**Contract conformance rows** — React/Solid rows drop "interaction parity" for the enumerated adaptation concerns plus one wiring round-trip; the Registry row enumerates smoke expectations (mounts, one prop round-trip, recipe-owned presentation, theme restyle) with the registry/theme full-suite exception per ADR-0006.

## What each layer keeps

| Layer | Contract |
|---|---|
| core (unchanged, 83 tests) | Full semantics: activation matrix (ADR-0007, proven once in `internal/pressable.test.ts`), roving navigation incl. Home/End/disabled-skip, controlled intent, re-entrancy, lifecycle |
| react (29 tests) | First-render authoritative state, frame consistency, StrictMode/portal lifecycle, refs, retained + Store identity, prop removal, callback replacement, context errors, one round-trip per primitive |
| solid (30 tests) | Same matrix through Solid's seam: reactive getters, cleanup-once, retained identity, context errors, one round-trip per primitive |
| registry smokes | Mounts, one prop round-trip, recipe-owned presentation, theme restyle. `registry/theme` keeps its full suite (ADR-0006: registry is the lowest layer for that module) |

## Coverage audit

Every deleted tour has a Core owner:

- Radio arrow/Home/End/disabled-skip → `core/src/radio/radio-group-parts.test.ts` ("moves roving focus, skips disabled Items, wraps, and handles Home/End")
- Toggle-group navigation/orientation/boundaries → `core/src/toggle-group/toggle-group-primitive.test.ts`
- Disabled gating and keyboard/pointer guards → `core/src/internal/pressable.test.ts` matrix
- Controlled-rejection semantics → core Store suites ("reports controlled intent without committing it")
- Re-entrancy → `core/src/radio/radio-group-primitive.test.ts` ("serializes reentrant selection")

Two reviewed edge cases: the Dialog StrictMode test's double-escape was reduced to one — sound because the `listenerCount === 2` assertion already proves no ghost layer exists from discarded renders, so one escape → exactly one `"false:escape"` completes the proof. The open/close/reopen retention cycle was reduced to one closed→open transition, which crosses the remount boundary once; portal retention across updates and controlled open without remount remain separately covered.

## Numbers

| | before | after |
|---|---|---|
| react | 1,525 ln / 34 tests | 1,164 ln / 29 tests |
| solid | 1,529 ln / 34 tests | 1,504 ln / 30 tests |
| registry smokes | 2,762 ln | 2,120 ln |
| core | ~2,050 ln / 83 tests | unchanged |

No changeset: tests and docs only, nothing published changes.

## Validation

`pnpm validate:foundation` passes end-to-end: lint, typecheck, core 83 / react 29 / solid 30 tests, build, packed-package checks, all 30 registry consumers against packed tarballs, release scope.

Follow-up (out of scope here): shared test-harness consolidation (~700–900 further lines) noted in the architecture review.
