### PR TITLE
refactor(core): collapse Checkbox and Switch onto one branded CheckedStore

### DIFF
--- a/.changeset/collapse-checked-store.md
+++ b/.changeset/collapse-checked-store.md
@@ -1,0 +1,5 @@
+---
+"@tuiparts/core": patch
+---
+
+Collapse Checkbox and Switch Store facades onto the shared internal checked-state implementation. This is an internal refactor; public APIs and behavior are unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,8 @@ tuiparts/
 | Symbol | Type | Location | Role |
 |--------|------|----------|------|
 | `PressableRenderable` | Class | `packages/core/src/internal/pressable.ts` | Shared activation behavior (guards, pointer model, focus sync) for all press-activated Roots (ADR-0007) |
-| `CheckboxRootRenderable` | Class | `packages/core/src/checkbox/primitive.ts` | Checkbox state, activation, and Indicator owner |
+| `CheckboxRootRenderable` | Class | `packages/core/src/checkbox/primitive.ts` | Checkbox Root adapter over shared checked state and activation |
+| `CheckedStore` | Class | `packages/core/src/internal/checked-store.ts` | Shared checked-state behavior for Checkbox and Switch |
 | `toast` | Object | `packages/toast/src/state.ts` | Global toast API (toast.success, toast.error, etc.) |
 | `ToasterRenderable` | Class | `packages/toast/src/renderables/toaster.ts` | Container that manages toast notifications |
 | `DialogStore` | Class | `packages/core/src/dialog/index.ts` | Foundation Dialog state and layer coordination |

--- a/docs/adr/0008-checked-store-collapse.md
+++ b/docs/adr/0008-checked-store-collapse.md
@@ -1,0 +1,60 @@
+---
+status: accepted
+---
+
+# Collapse Checkbox and Switch onto one internal CheckedStore
+
+Checkbox and Switch expose distinct public Stores, but their state behavior is
+identical. Their facades duplicated every operation while their Root
+Renderables duplicated the same Store plumbing.
+
+## Context
+
+`CheckboxStore` and `SwitchStore` were one-line delegation facades over an
+internal `CheckedStore`, including duplicate state and options types. The two
+Roots also repeated adoption, prop application, activation, accessors, and
+replacement guards. This was a deletion test: removing either facade should
+not remove behavior that belongs to the checked-state model.
+
+## Decision
+
+`CheckedStore` is the single internal implementation and carries a phantom
+string brand. `CheckboxStore extends CheckedStore<"checkbox">` and
+`SwitchStore extends CheckedStore<"switch">` remain empty public subclasses;
+their state and options names are aliases. The brand preserves the nominal
+separation that the old private facade fields provided, so a Checkbox Store
+cannot be passed where a Switch Store is expected.
+
+A new internal `CheckedRootRenderable` owns shared checked Root plumbing:
+Store construction and adoption, explicit prop application, Pressable
+attachment, state access, subscriptions, checked/disabled callbacks, and the
+exact per-primitive replacement errors. Checkbox and Switch Roots only supply
+their Store type, label, and constructor.
+
+Public module exports and adapter construction remain unchanged. The internal
+`CheckedStore` is not exported from the core root index. Parts stay in their
+primitive modules because Indicator and Thumb have different rendering
+behavior.
+
+## Alternatives considered
+
+- Keep the facades: rejected because they preserve pure delegation and type
+  duplication with no independent policy.
+- Use type-only aliases with a const-cast constructor: rejected because it
+  obscures the declaration output and weakens nominal identity at the public
+  Store boundary.
+- Merge Checkbox and Switch into one public primitive: rejected. They are
+  distinct Catalog products with different public parts (Indicator versus
+  Thumb), even though their checked-state behavior is shared.
+
+## Consequences
+
+- Checked-state fixes and tests have one owner, while Checkbox and Switch keep
+  their existing public names, constructors, and module seams.
+- The branded subclasses retain compile-time separation between the two
+  Stores without runtime fields.
+- Root plumbing changes land once and future checked Roots can reuse the
+  internal base.
+- The core package has an internal file dependency that is intentionally not a
+  public export; framework adapters continue to construct the unchanged public
+  subclasses.

--- a/packages/core/src/checkbox/checkbox-primitive.test.ts
+++ b/packages/core/src/checkbox/checkbox-primitive.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import type { KeyEvent } from "@opentui/core";
 import {
   createTestRenderer,
   type TestRendererSetup,
@@ -11,140 +10,60 @@ import {
 } from "./primitive";
 
 let setup: TestRendererSetup | undefined;
-
 afterEach(() => {
   setup?.renderer.destroy();
   setup = undefined;
 });
 
 describe("Checkbox primitive", () => {
-  it("accepts an externally owned Store without replacing it", async () => {
+  it("wires a press through the Root to its Store", async () => {
+    setup = await createTestRenderer({ width: 30, height: 5 });
+    const root = new CheckboxRootRenderable(setup.renderer);
+    root.press();
+    expect(root.checked).toBe(true);
+  });
+
+  it("adopts a Store and rejects replacement", async () => {
     setup = await createTestRenderer({ width: 30, height: 5 });
     const store = new CheckboxStore({ defaultChecked: true });
     const root = new CheckboxRootRenderable(setup.renderer, { store });
-
     expect(root.store).toBe(store);
-    expect(root.getState()).toBe(store.state);
-    root.press();
-    expect(store.state.checked).toBe(false);
+    expect(() => {
+      root.store = new CheckboxStore();
+    }).toThrow("Checkbox.Root store cannot be replaced");
   });
 
-  it("leaves visual assembly to the caller while sharing behavior with parts", async () => {
+  it("applies explicit behavior props to a supplied Store", async () => {
     setup = await createTestRenderer({ width: 30, height: 5 });
+    const changes: boolean[] = [];
+    const store = new CheckboxStore({ defaultChecked: false });
     const root = new CheckboxRootRenderable(setup.renderer, {
-      defaultChecked: false,
-      id: "checkbox-root",
-    });
-    const indicator = new CheckboxIndicatorRenderable(setup.renderer, {
-      id: "checkbox-indicator",
-      store: root.store,
-    });
-
-    expect(root.getChildren()).toEqual([]);
-    root.add(indicator);
-    setup.renderer.root.add(root);
-
-    expect(root.checked).toBe(false);
-    expect(indicator.visible).toBe(false);
-    expect(indicator.store).toBe(root.store);
-
-    root.press();
-
-    expect(root.checked).toBe(true);
-    expect(indicator.visible).toBe(true);
-    expect(indicator.getState()).toEqual({
       checked: true,
-      disabled: false,
-      focused: false,
-    });
-    expect(Object.isFrozen(indicator.getState())).toBe(true);
-  });
-
-  it("reports controlled changes without mutating parent-owned state", async () => {
-    setup = await createTestRenderer({ width: 30, height: 5 });
-    const changes: boolean[] = [];
-    const root = new CheckboxRootRenderable(setup.renderer, {
-      checked: false,
-      onCheckedChange: (checked) => changes.push(checked),
-    });
-    setup.renderer.root.add(root);
-
-    root.handleKeyPress({ name: "space" } as KeyEvent);
-
-    expect(changes).toEqual([true]);
-    expect(root.checked).toBe(false);
-
-    root.checked = true;
-    expect(root.checked).toBe(true);
-  });
-
-  it("suppresses focus and activation while disabled", async () => {
-    setup = await createTestRenderer({ width: 30, height: 5 });
-    const changes: boolean[] = [];
-    const root = new CheckboxRootRenderable(setup.renderer, {
       disabled: true,
       onCheckedChange: (checked) => changes.push(checked),
+      store,
     });
-    setup.renderer.root.add(root);
-
-    expect(root.focusable).toBe(false);
-    root.focus();
+    expect(root.getState()).toEqual({
+      checked: true,
+      disabled: true,
+      focused: false,
+    });
+    root.disabled = false;
     root.press();
-
-    expect(root.focused).toBe(false);
-    expect(root.checked).toBe(false);
-    expect(changes).toEqual([]);
-
-    root.disabled = undefined;
-    expect(root.focusable).toBe(true);
-    root.press();
+    expect(changes).toEqual([false]);
     expect(root.checked).toBe(true);
   });
 
-  // The shared activation matrix (guards, pointer model, disabled sync) is
-  // proven once in internal/pressable.test.ts; this is the wiring round-trip.
-  it("toggles from a primary-button click", async () => {
+  it("syncs Indicator visibility and unsubscribes on destroy", async () => {
     setup = await createTestRenderer({ width: 30, height: 5 });
-    const changes: boolean[] = [];
-    const root = new CheckboxRootRenderable(setup.renderer, {
-      width: 5,
-      height: 1,
-      onCheckedChange: (checked) => changes.push(checked),
+    const store = new CheckboxStore();
+    const indicator = new CheckboxIndicatorRenderable(setup.renderer, {
+      store,
     });
-    setup.renderer.root.add(root);
-    await setup.renderOnce();
-
-    await setup.mockMouse.click(0, 0);
-
-    expect(root.checked).toBe(true);
-    expect(root.focused).toBe(true);
-    expect(changes).toEqual([true]);
-  });
-
-  it("returns to uncontrolled ownership when checked is removed", async () => {
-    setup = await createTestRenderer({ width: 30, height: 5 });
-    const root = new CheckboxRootRenderable(setup.renderer, { checked: false });
-    setup.renderer.root.add(root);
-
-    root.checked = undefined;
-    root.press();
-
-    expect(root.checked).toBe(true);
-  });
-
-  it("stops accepting semantic actions after destruction", async () => {
-    setup = await createTestRenderer({ width: 30, height: 5 });
-    const changes: boolean[] = [];
-    const root = new CheckboxRootRenderable(setup.renderer, {
-      onCheckedChange: (checked) => changes.push(checked),
-    });
-    setup.renderer.root.add(root);
-
-    root.destroy();
-
-    root.press();
-    expect(root.handleKeyPress({ name: "space" } as KeyEvent)).toBe(false);
-    expect(root.checked).toBe(false);
-    expect(changes).toEqual([]);
+    store.setChecked(true);
+    expect(indicator.visible).toBe(true);
+    indicator.destroy();
+    store.setChecked(false);
+    expect(indicator.visible).toBe(true);
   });
 });

--- a/packages/core/src/checkbox/primitive.ts
+++ b/packages/core/src/checkbox/primitive.ts
@@ -3,137 +3,28 @@ import {
   BoxRenderable,
   type RenderContext,
 } from "@opentui/core";
-import { CheckedStore } from "../internal/checked-store";
-import { PressableRenderable } from "../internal/pressable";
+import { CheckedRootRenderable } from "../internal/checked-root";
+import {
+  type CheckedState,
+  CheckedStore,
+  type CheckedStoreOptions,
+} from "../internal/checked-store";
 
-export interface CheckboxState {
-  readonly checked: boolean;
-  readonly disabled: boolean;
-  readonly focused: boolean;
-}
+export type CheckboxState = CheckedState;
+export type CheckboxStoreOptions = CheckedStoreOptions;
 
-export interface CheckboxStoreOptions {
-  checked?: boolean;
-  defaultChecked?: boolean;
-  disabled?: boolean;
-  onCheckedChange?: (checked: boolean) => void;
-}
-
-type CheckboxStateListener = (state: CheckboxState) => void;
-
-export class CheckboxStore {
-  private readonly checkedStore: CheckedStore;
-
-  constructor(options: CheckboxStoreOptions = {}) {
-    this.checkedStore = new CheckedStore(options);
-  }
-
-  get state(): CheckboxState {
-    return this.checkedStore.state;
-  }
-
-  getState(): CheckboxState {
-    return this.checkedStore.state;
-  }
-
-  subscribe(listener: CheckboxStateListener): () => void {
-    return this.checkedStore.subscribe(listener);
-  }
-
-  requestToggle(): void {
-    this.checkedStore.requestToggle();
-  }
-
-  setChecked(checked: boolean | null | undefined): void {
-    this.checkedStore.setChecked(checked);
-  }
-
-  setDisabled(disabled: boolean): void {
-    this.checkedStore.setDisabled(disabled);
-  }
-
-  setFocused(focused: boolean): void {
-    this.checkedStore.setFocused(focused);
-  }
-
-  setOnCheckedChange(callback: ((checked: boolean) => void) | undefined): void {
-    this.checkedStore.setOnCheckedChange(callback);
-  }
-}
+export class CheckboxStore extends CheckedStore<"checkbox"> {}
 
 export interface CheckboxRootOptions extends BoxOptions, CheckboxStoreOptions {
   store?: CheckboxStore;
 }
 
-export class CheckboxRootRenderable extends PressableRenderable {
-  protected _store: CheckboxStore;
-
+export class CheckboxRootRenderable extends CheckedRootRenderable<CheckboxStore> {
   constructor(ctx: RenderContext, options: CheckboxRootOptions = {}) {
-    const {
-      checked,
-      defaultChecked,
-      disabled,
-      onCheckedChange,
-      store,
-      ...boxOptions
-    } = options;
-    super(ctx, boxOptions);
-    this._store =
-      store ??
-      new CheckboxStore({
-        checked,
-        defaultChecked,
-        disabled,
-        onCheckedChange,
-      });
-    if (store) {
-      if (checked !== undefined) store.setChecked(checked);
-      if (disabled !== undefined) store.setDisabled(disabled);
-      if (onCheckedChange !== undefined)
-        store.setOnCheckedChange(onCheckedChange);
-    }
-    this.attachPressable(this._store);
-  }
-
-  protected handlePress(): void {
-    this._store.requestToggle();
-  }
-
-  getState(): CheckboxState {
-    return this._store.state;
-  }
-
-  subscribe(listener: CheckboxStateListener): () => void {
-    return this._store.subscribe(listener);
-  }
-
-  get store(): CheckboxStore {
-    return this._store;
-  }
-
-  set store(store: CheckboxStore) {
-    if (store !== this._store)
-      throw new Error("Checkbox.Root store cannot be replaced");
-  }
-
-  get checked(): boolean {
-    return this._store.state.checked;
-  }
-
-  set checked(checked: boolean | null | undefined) {
-    this._store.setChecked(checked);
-  }
-
-  get disabled(): boolean {
-    return this._store.state.disabled;
-  }
-
-  set disabled(disabled: boolean | null | undefined) {
-    this._store.setDisabled(disabled ?? false);
-  }
-
-  set onCheckedChange(callback: ((checked: boolean) => void) | undefined) {
-    this._store.setOnCheckedChange(callback);
+    super(ctx, options, {
+      label: "Checkbox.Root",
+      createStore: (storeOptions) => new CheckboxStore(storeOptions),
+    });
   }
 }
 

--- a/packages/core/src/internal/checked-root.ts
+++ b/packages/core/src/internal/checked-root.ts
@@ -1,0 +1,95 @@
+import type { BoxOptions, RenderContext } from "@opentui/core";
+import type {
+  CheckedState,
+  CheckedStore,
+  CheckedStoreOptions,
+} from "./checked-store";
+import { PressableRenderable } from "./pressable";
+
+type CheckedRootOptions<TStore extends CheckedStore<string>> = BoxOptions &
+  CheckedStoreOptions & { store?: TStore };
+
+interface CheckedRootConfig<TStore extends CheckedStore<string>> {
+  label: string;
+  createStore: (options: CheckedStoreOptions) => TStore;
+}
+
+export abstract class CheckedRootRenderable<
+  TStore extends CheckedStore<string>,
+> extends PressableRenderable {
+  protected _store: TStore;
+  private readonly _storeLabel: string;
+
+  constructor(
+    ctx: RenderContext,
+    options: CheckedRootOptions<TStore> = {},
+    config: CheckedRootConfig<TStore>,
+  ) {
+    const {
+      checked,
+      defaultChecked,
+      disabled,
+      onCheckedChange,
+      store,
+      ...boxOptions
+    } = options;
+    super(ctx, boxOptions);
+    this._storeLabel = config.label;
+    this._store =
+      store ??
+      config.createStore({
+        checked,
+        defaultChecked,
+        disabled,
+        onCheckedChange,
+      });
+    if (store) {
+      if (checked !== undefined) store.setChecked(checked);
+      if (disabled !== undefined) store.setDisabled(disabled);
+      if (onCheckedChange !== undefined)
+        store.setOnCheckedChange(onCheckedChange);
+    }
+    this.attachPressable(this._store);
+  }
+
+  protected handlePress(): void {
+    this._store.requestToggle();
+  }
+
+  getState(): CheckedState {
+    return this._store.getState();
+  }
+
+  subscribe(listener: (state: CheckedState) => void): () => void {
+    return this._store.subscribe(listener);
+  }
+
+  get store(): TStore {
+    return this._store;
+  }
+
+  set store(store: TStore) {
+    if (store !== this._store)
+      throw new Error(`${this._storeLabel} store cannot be replaced`);
+  }
+
+  get checked(): boolean {
+    return this._store.getState().checked;
+  }
+
+  set checked(checked: boolean | null | undefined) {
+    this._store.setChecked(checked);
+  }
+
+  get disabled(): boolean {
+    return this._store.getState().disabled;
+  }
+
+  set disabled(disabled: boolean | null | undefined) {
+    this._store.setDisabled(disabled ?? false);
+  }
+
+  set onCheckedChange(callback: ((checked: boolean) => void) | undefined) {
+    this._store.setOnCheckedChange(callback);
+  }
+}

--- a/packages/core/src/internal/checked-store.test.ts
+++ b/packages/core/src/internal/checked-store.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+import { CheckedStore } from "./checked-store";
+
+describe("CheckedStore", () => {
+  it("toggles uncontrolled state and invokes the callback", () => {
+    const changes: boolean[] = [];
+    const store = new CheckedStore({
+      defaultChecked: false,
+      onCheckedChange: (checked) => changes.push(checked),
+    });
+
+    store.requestToggle();
+
+    expect(store.state.checked).toBe(true);
+    expect(changes).toEqual([true]);
+  });
+
+  it("reports controlled intent without committing it", () => {
+    const changes: boolean[] = [];
+    const store = new CheckedStore({
+      checked: false,
+      onCheckedChange: (checked) => changes.push(checked),
+    });
+
+    store.requestToggle();
+
+    expect(store.state.checked).toBe(false);
+    expect(changes).toEqual([true]);
+  });
+
+  it("releases control when checked is null or undefined", () => {
+    const store = new CheckedStore({ checked: false });
+
+    store.setChecked(null);
+    store.requestToggle();
+    expect(store.state.checked).toBe(true);
+
+    store.setChecked(true);
+    store.setChecked(undefined);
+    store.requestToggle();
+    expect(store.state.checked).toBe(false);
+  });
+
+  it("gates toggles while disabled", () => {
+    const changes: boolean[] = [];
+    const store = new CheckedStore({
+      disabled: true,
+      onCheckedChange: (checked) => changes.push(checked),
+    });
+
+    store.requestToggle();
+
+    expect(store.state.checked).toBe(false);
+    expect(changes).toEqual([]);
+  });
+
+  it("clears focus when disabled and refuses focus while disabled", () => {
+    const store = new CheckedStore();
+    store.setFocused(true);
+    store.setDisabled(true);
+
+    expect(store.state.focused).toBe(false);
+    store.setFocused(true);
+    expect(store.state.focused).toBe(false);
+  });
+
+  it("publishes frozen snapshots and getState returns the snapshot", () => {
+    const store = new CheckedStore();
+    const snapshot = store.getState();
+
+    expect(store.state).toBe(snapshot);
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    store.setChecked(true);
+    expect(store.getState()).not.toBe(snapshot);
+    expect(Object.isFrozen(store.getState())).toBe(true);
+  });
+
+  it("notifies only when state changes", () => {
+    const states: unknown[] = [];
+    const store = new CheckedStore();
+    store.subscribe((state) => states.push(state));
+
+    store.setChecked(false);
+    store.setDisabled(false);
+    store.setFocused(false);
+    store.setChecked(true);
+
+    expect(states).toHaveLength(1);
+  });
+
+  it("supports subscribe and unsubscribe", () => {
+    let calls = 0;
+    const store = new CheckedStore();
+    const unsubscribe = store.subscribe(() => calls++);
+
+    store.setChecked(true);
+    unsubscribe();
+    store.setChecked(false);
+
+    expect(calls).toBe(1);
+  });
+
+  it("replaces the checked-change callback", () => {
+    const first: boolean[] = [];
+    const second: boolean[] = [];
+    const store = new CheckedStore({
+      onCheckedChange: (value) => first.push(value),
+    });
+
+    store.setOnCheckedChange((value) => second.push(value));
+    store.requestToggle();
+
+    expect(first).toEqual([]);
+    expect(second).toEqual([true]);
+  });
+});

--- a/packages/core/src/internal/checked-store.ts
+++ b/packages/core/src/internal/checked-store.ts
@@ -13,7 +13,8 @@ export interface CheckedStoreOptions {
 
 type ToggleStateListener = (state: CheckedState) => void;
 
-export class CheckedStore {
+export class CheckedStore<Brand extends string = string> {
+  private declare readonly __brand?: Brand;
   private controlled: boolean;
   private snapshot: CheckedState;
   private onCheckedChange?: (checked: boolean) => void;
@@ -30,6 +31,10 @@ export class CheckedStore {
   }
 
   get state(): CheckedState {
+    return this.snapshot;
+  }
+
+  getState(): CheckedState {
     return this.snapshot;
   }
 

--- a/packages/core/src/switch/primitive.ts
+++ b/packages/core/src/switch/primitive.ts
@@ -3,129 +3,28 @@ import {
   BoxRenderable,
   type RenderContext,
 } from "@opentui/core";
-import { CheckedStore } from "../internal/checked-store";
-import { PressableRenderable } from "../internal/pressable";
+import { CheckedRootRenderable } from "../internal/checked-root";
+import {
+  type CheckedState,
+  CheckedStore,
+  type CheckedStoreOptions,
+} from "../internal/checked-store";
 
-export interface SwitchState {
-  readonly checked: boolean;
-  readonly disabled: boolean;
-  readonly focused: boolean;
-}
+export type SwitchState = CheckedState;
+export type SwitchStoreOptions = CheckedStoreOptions;
 
-export interface SwitchStoreOptions {
-  checked?: boolean;
-  defaultChecked?: boolean;
-  disabled?: boolean;
-  onCheckedChange?: (checked: boolean) => void;
-}
-
-type SwitchStateListener = (state: SwitchState) => void;
-
-export class SwitchStore {
-  private readonly checkedStore: CheckedStore;
-
-  constructor(options: SwitchStoreOptions = {}) {
-    this.checkedStore = new CheckedStore(options);
-  }
-
-  get state(): SwitchState {
-    return this.checkedStore.state;
-  }
-  getState(): SwitchState {
-    return this.checkedStore.state;
-  }
-  subscribe(listener: SwitchStateListener): () => void {
-    return this.checkedStore.subscribe(listener);
-  }
-  requestToggle(): void {
-    this.checkedStore.requestToggle();
-  }
-  setChecked(checked: boolean | null | undefined): void {
-    this.checkedStore.setChecked(checked);
-  }
-  setDisabled(disabled: boolean): void {
-    this.checkedStore.setDisabled(disabled);
-  }
-  setFocused(focused: boolean): void {
-    this.checkedStore.setFocused(focused);
-  }
-  setOnCheckedChange(callback: ((checked: boolean) => void) | undefined): void {
-    this.checkedStore.setOnCheckedChange(callback);
-  }
-}
+export class SwitchStore extends CheckedStore<"switch"> {}
 
 export interface SwitchRootOptions extends BoxOptions, SwitchStoreOptions {
   store?: SwitchStore;
 }
 
-export class SwitchRootRenderable extends PressableRenderable {
-  protected _store: SwitchStore;
-
+export class SwitchRootRenderable extends CheckedRootRenderable<SwitchStore> {
   constructor(ctx: RenderContext, options: SwitchRootOptions = {}) {
-    const {
-      checked,
-      defaultChecked,
-      disabled,
-      onCheckedChange,
-      store,
-      ...boxOptions
-    } = options;
-    super(ctx, boxOptions);
-    this._store =
-      store ??
-      new SwitchStore({
-        checked,
-        defaultChecked,
-        disabled,
-        onCheckedChange,
-      });
-    if (store) {
-      if (checked !== undefined) store.setChecked(checked);
-      if (disabled !== undefined) store.setDisabled(disabled);
-      if (onCheckedChange !== undefined)
-        store.setOnCheckedChange(onCheckedChange);
-    }
-    this.attachPressable(this._store);
-  }
-
-  protected handlePress(): void {
-    this._store.requestToggle();
-  }
-
-  getState(): SwitchState {
-    return this._store.state;
-  }
-
-  subscribe(listener: SwitchStateListener): () => void {
-    return this._store.subscribe(listener);
-  }
-
-  get store(): SwitchStore {
-    return this._store;
-  }
-  set store(store: SwitchStore) {
-    if (store !== this._store)
-      throw new Error("Switch.Root store cannot be replaced");
-  }
-
-  get checked(): boolean {
-    return this._store.state.checked;
-  }
-
-  set checked(checked: boolean | null | undefined) {
-    this._store.setChecked(checked);
-  }
-
-  get disabled(): boolean {
-    return this._store.state.disabled;
-  }
-
-  set disabled(disabled: boolean | null | undefined) {
-    this._store.setDisabled(disabled ?? false);
-  }
-
-  set onCheckedChange(callback: ((checked: boolean) => void) | undefined) {
-    this._store.setOnCheckedChange(callback);
+    super(ctx, options, {
+      label: "Switch.Root",
+      createStore: (storeOptions) => new SwitchStore(storeOptions),
+    });
   }
 }
 

--- a/packages/core/src/switch/switch-primitive.test.ts
+++ b/packages/core/src/switch/switch-primitive.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import type { KeyEvent } from "@opentui/core";
 import {
   createTestRenderer,
   type TestRendererSetup,
@@ -11,139 +10,60 @@ import {
 } from "./primitive";
 
 let setup: TestRendererSetup | undefined;
-
 afterEach(() => {
   setup?.renderer.destroy();
   setup = undefined;
 });
 
 describe("Switch primitive", () => {
-  it("accepts an externally owned Store without replacing it", async () => {
+  it("wires a press through the Root to its Store", async () => {
+    setup = await createTestRenderer({ width: 30, height: 5 });
+    const root = new SwitchRootRenderable(setup.renderer);
+    root.press();
+    expect(root.checked).toBe(true);
+  });
+
+  it("adopts a Store and rejects replacement", async () => {
     setup = await createTestRenderer({ width: 30, height: 5 });
     const store = new SwitchStore({ defaultChecked: true });
     const root = new SwitchRootRenderable(setup.renderer, { store });
-
     expect(root.store).toBe(store);
-    expect(root.getState()).toBe(store.state);
-    root.press();
-    expect(store.state.checked).toBe(false);
+    expect(() => {
+      root.store = new SwitchStore();
+    }).toThrow("Switch.Root store cannot be replaced");
   });
 
-  it("leaves visual assembly to the caller while sharing readonly state with Thumb", async () => {
-    setup = await createTestRenderer({ width: 30, height: 5 });
-    const root = new SwitchRootRenderable(setup.renderer, {
-      defaultChecked: false,
-      id: "switch-root",
-    });
-    const thumb = new SwitchThumbRenderable(setup.renderer, {
-      id: "switch-thumb",
-      store: root.store,
-    });
-
-    expect(root.getChildren()).toEqual([]);
-    root.add(thumb);
-    setup.renderer.root.add(root);
-
-    expect(root.checked).toBe(false);
-    expect(thumb.store).toBe(root.store);
-    expect(thumb.getState()).toEqual({
-      checked: false,
-      disabled: false,
-      focused: false,
-    });
-    expect(Object.isFrozen(thumb.getState())).toBe(true);
-
-    root.press();
-
-    expect(root.checked).toBe(true);
-    expect(thumb.getState().checked).toBe(true);
-    expect(thumb.visible).toBe(true);
-    expect(root.getChildren()[0]).toBe(thumb);
-  });
-
-  it("reports controlled requests and resumes ownership when checked is removed", async () => {
+  it("applies explicit behavior props to a supplied Store", async () => {
     setup = await createTestRenderer({ width: 30, height: 5 });
     const changes: boolean[] = [];
+    const store = new SwitchStore({ defaultChecked: false });
     const root = new SwitchRootRenderable(setup.renderer, {
-      checked: false,
-      onCheckedChange: (checked) => changes.push(checked),
-    });
-    setup.renderer.root.add(root);
-
-    root.press();
-    expect(changes).toEqual([true]);
-    expect(root.checked).toBe(false);
-
-    root.checked = true;
-    expect(root.checked).toBe(true);
-
-    root.checked = undefined;
-    root.press();
-    expect(root.checked).toBe(false);
-    expect(changes).toEqual([true, false]);
-  });
-
-  it("shares activation across press, Enter, and Space while disabled gates focus", async () => {
-    setup = await createTestRenderer({ width: 30, height: 5 });
-    const changes: boolean[] = [];
-    const root = new SwitchRootRenderable(setup.renderer, {
+      checked: true,
       disabled: true,
       onCheckedChange: (checked) => changes.push(checked),
+      store,
     });
-    setup.renderer.root.add(root);
-
-    expect(root.focusable).toBe(false);
-    root.focus();
+    expect(root.getState()).toEqual({
+      checked: true,
+      disabled: true,
+      focused: false,
+    });
+    root.disabled = false;
     root.press();
-    expect(root.handleKeyPress({ name: "space" } as KeyEvent)).toBe(false);
-    expect(root.focused).toBe(false);
-    expect(changes).toEqual([]);
-
-    root.disabled = undefined;
-    expect(root.focusable).toBe(true);
-    expect(root.handleKeyPress({ name: "enter" } as KeyEvent)).toBe(true);
+    expect(changes).toEqual([false]);
     expect(root.checked).toBe(true);
-    expect(root.handleKeyPress({ name: "return" } as KeyEvent)).toBe(true);
-    expect(root.checked).toBe(false);
-    expect(root.handleKeyPress({ name: "space" } as KeyEvent)).toBe(true);
-    expect(root.checked).toBe(true);
-    expect(root.handleKeyPress({ name: "a" } as KeyEvent)).toBe(false);
-    expect(changes).toEqual([true, false, true]);
   });
 
-  // The shared activation matrix (guards, pointer model, disabled sync) is
-  // proven once in internal/pressable.test.ts; this is the wiring round-trip.
-  it("toggles from a primary-button click", async () => {
+  it("requests renders from Store changes and unsubscribes on destroy", async () => {
     setup = await createTestRenderer({ width: 30, height: 5 });
-    const changes: boolean[] = [];
-    const root = new SwitchRootRenderable(setup.renderer, {
-      width: 5,
-      height: 1,
-      onCheckedChange: (checked) => changes.push(checked),
-    });
-    setup.renderer.root.add(root);
-    await setup.renderOnce();
-
-    await setup.mockMouse.click(0, 0);
-
-    expect(root.checked).toBe(true);
-    expect(root.focused).toBe(true);
-    expect(changes).toEqual([true]);
-  });
-
-  it("stops accepting semantic actions after destruction", async () => {
-    setup = await createTestRenderer({ width: 30, height: 5 });
-    const changes: boolean[] = [];
-    const root = new SwitchRootRenderable(setup.renderer, {
-      onCheckedChange: (checked) => changes.push(checked),
-    });
-    setup.renderer.root.add(root);
-
-    root.destroy();
-
-    root.press();
-    expect(root.handleKeyPress({ name: "space" } as KeyEvent)).toBe(false);
-    expect(root.checked).toBe(false);
-    expect(changes).toEqual([]);
+    const store = new SwitchStore();
+    const thumb = new SwitchThumbRenderable(setup.renderer, { store });
+    let renders = 0;
+    thumb.requestRender = () => renders++;
+    store.setChecked(true);
+    expect(renders).toBe(1);
+    thumb.destroy();
+    store.setChecked(false);
+    expect(renders).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

Collapses the Checkbox and Switch Store facades onto the internal `CheckedStore` and extracts their duplicated Root plumbing into one internal `CheckedRootRenderable` base. Public seams, adapter construction, and behavior are unchanged. Recorded as **ADR-0008**.

**Stacked on #45** — builds on the restored testing pyramid (the trimmed adapter suites no longer re-prove the behavior this refactor touches).

## Why

Checkbox and Switch were the same primitive twice:

- `CheckboxStore` and `SwitchStore` were pure pass-through facades — every method one line of delegation to `CheckedStore`, state/options types re-declared. Deletion test: removing them removes no behavior.
- The two Roots duplicated ~90 lines of identical Store plumbing (adoption, prop application, accessors, replacement guards) — the residue left after #44 extracted activation.

## Design

- `CheckedStore<Brand extends string>` gains a phantom brand (`declare private readonly __brand?` — zero runtime presence). The public Stores become empty branded subclasses:

  ```ts
  export class CheckboxStore extends CheckedStore<"checkbox"> {}
  export class SwitchStore extends CheckedStore<"switch"> {}
  ```

  The brand preserves the nominal separation the old private facade fields provided — a `SwitchStore` still cannot be passed where a `CheckboxStore` is expected (verified with a tsc probe). `new CheckboxStore(...)` keeps working; React/Solid adapters compile **untouched**.

- New internal `CheckedRootRenderable<TStore>` extends `PressableRenderable` and owns the shared Root plumbing: Store construction/adoption, explicit prop application to a supplied Store, `attachPressable`, `handlePress → requestToggle`, state access/subscriptions, checked/disabled accessors, and the exact per-primitive replacement errors. Each Root supplies only its Store type, label, and constructor.

- `CheckboxIndicatorRenderable` and `SwitchThumbRenderable` stay per-primitive — they are genuinely different (visibility sync vs re-render subscription), which is also why merging Checkbox and Switch into one public primitive was rejected (distinct Catalog products; see ADR-0008 alternatives).

- `CheckboxState`/`CheckboxStoreOptions` (and Switch equivalents) become aliases of the Checked types; the 8 exported names per module do not move. `CheckedStore` remains internal — not exported from the core root.

## Tests

Following the pyramid policy from #45: the shared store matrix (uncontrolled toggle, controlled intent without commit, control release, disabled gating, focus rules, frozen snapshots, notify-on-change, subscription lifecycle, callback replacement) is proven once in `internal/checked-store.test.ts` (9 tests). Checkbox and Switch suites keep only primitive-specific behavior: one press round-trip, Store adoption/replacement error, prop application, and Indicator visibility / Thumb re-render + destroy-unsubscribe (4 tests each). Core 83 → 87 tests.

## Numbers

| file | before | after |
|---|---|---|
| checkbox/primitive.ts | 182 ln | 73 ln |
| switch/primitive.ts | 166 ln | 65 ln |
| internal/checked-store.ts | 81 ln | 86 ln |
| internal/checked-root.ts (new) | — | 95 ln |

Net **−459/+370** including tests and docs.

## Validation

`pnpm validate:foundation` passes end-to-end: lint, typecheck, core 87 / react 29 / solid 30 tests, build, packed-package checks (including declaration consumption with the new internal base types in public d.ts), all 30 registry consumers against packed tarballs, release scope.

Changeset: `patch` on `@tuiparts/core` — internal refactor, public API and behavior unchanged.
