### PR TITLE
Add Collapsible primitive and recipe

### DIFF
--- a/.changeset/calm-panels-open.md
+++ b/.changeset/calm-panels-open.md
@@ -1,0 +1,7 @@
+---
+"@tuiparts/core": patch
+"@tuiparts/react": patch
+"@tuiparts/solid": patch
+---
+
+Add the Collapsible Primitive and matching Core, React, and Solid package subpaths with controlled and uncontrolled open state, shared Trigger activation, disabled behavior, and conditional Panel lifecycle.

--- a/PRIMITIVES_AND_RECIPES.md
+++ b/PRIMITIVES_AND_RECIPES.md
@@ -121,6 +121,31 @@ Reference implementations:
 recipes reserve one terminal cell for `mark`; applications that need a wide
 mark own the corresponding recipe layout change.
 
+## Collapsible Primitive
+
+Collapsible packages disclosure behavior without choosing Trigger content or
+Panel presentation:
+
+- `Collapsible.Root` and `CollapsibleStore` own controlled or uncontrolled
+  open state and Root disablement.
+- `Collapsible.Trigger` is a focusable Pressable that requests the inverse open
+  state and exposes open, disabled, and actual focused state.
+- `Collapsible.Panel` reflects open state through native visibility. React and
+  Solid unmount it while closed by default and support `keepMounted`; a
+  constructed Core Panel remains retained.
+- Editable Core, React, and Solid Recipes own labels, open/closed markers,
+  layout, indentation, colors, and Panel content.
+
+Reference implementations:
+
+- `packages/core/src/collapsible/primitive.ts`
+- `packages/react/src/collapsible/primitive.ts`
+- `packages/solid/src/collapsible/primitive.tsx`
+- `registry/collapsible/`
+
+The focused public contract and conformance disposition are recorded in
+`docs/primitive-contracts/collapsible.md`.
+
 ## Switch primitive
 
 Switch follows the same frozen ownership and activation rules without treating

--- a/PRIMITIVE_CONTRACT.md
+++ b/PRIMITIVE_CONTRACT.md
@@ -263,6 +263,9 @@ public base class.
   selection, dynamic Toggle identity, rendered order, and roving focus. A
   standalone Toggle owns pressed state; a grouped Toggle reads selection from
   its group through the same Toggle Store before Renderable construction.
+- Collapsible retains a public Store for controlled or uncontrolled open state,
+  Root disablement, Trigger activation, and Panel visibility. Root owns the
+  Store while Trigger and Panel consume it directly.
 - Tabs retains a public Store for controlled or uncontrolled selection,
   dynamic Tab/Panel association, automatic or manual activation, rendered
   order, roving focus, repair, and Panel visibility. Root owns the Store, List
@@ -417,6 +420,9 @@ The shipped primitives establish these precedents:
   adopt explicit ToggleGroup selection without changing its public component
   identity. ToggleGroup proves array-valued single/multiple selection and
   roving focus that does not imply selection.
+- Collapsible proves a Root/Trigger/Panel disclosure composition with
+  controlled or uncontrolled open state, Trigger-owned focus, and conditional
+  or retained Panel lifecycle.
 - Tabs proves a genuine Root/List/Tab/Panel composition with value-based
   association, automatic or manual keyboard activation, uncontrolled
   selection repair, and conditionally or retained mounted Panels without

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ version together.
 | [`@tuiparts/react`](./packages/react) | React compound-part Adapter |
 | [`@tuiparts/solid`](./packages/solid) | Solid compound-part Adapter |
 
-Button, Checkbox, Dialog, Input, RadioGroup, Switch, Tabs, Textarea, Toggle,
-and ToggleGroup expose Primitive
+Button, Checkbox, Collapsible, Dialog, Input, RadioGroup, Switch, Tabs,
+Textarea, Toggle, and ToggleGroup expose Primitive
 behavior. Badge is distributed only as editable Recipe source because it has
 no reusable interaction behavior.
 
@@ -82,9 +82,8 @@ See the package READMEs for exact peer ranges and usage.
 ## Install a Recipe
 
 Recipes are installed with the official shadcn CLI and become
-application-owned source. The Catalog contains Checkbox, Switch, Button,
-RadioGroup/Radio, Tabs, Toggle, ToggleGroup, Input, Textarea, Dialog, and Badge
-Recipes; every Recipe targets exactly one Adapter, so choose the `core/*`,
+application-owned source. The Catalog contains Checkbox, Collapsible, Switch, Button, RadioGroup/Radio,
+Tabs, Toggle, ToggleGroup, Input, Textarea, Dialog, and Badge Recipes; every Recipe targets exactly one Adapter, so choose the `core/*`,
 `react/*`, or `solid/*` item for your runtime:
 
 ```bash

--- a/apps/www/docs/catalog/collapsible.mdx
+++ b/apps/www/docs/catalog/collapsible.mdx
@@ -1,0 +1,104 @@
+---
+title: Collapsible
+description: Reveal optional terminal content with an editable labeled Trigger.
+---
+
+Collapsible reveals content beneath a labeled Trigger. The packaged Primitive
+owns open state, activation, focus, disabled behavior, and content lifecycle.
+The Recipe adds disclosure markers, themed text, indentation, and starter
+layout.
+
+## Install
+
+<CodeGroup>
+
+```bash React
+pnpm dlx shadcn@4.13.0 add @tuiparts/react/collapsible
+```
+
+```bash Solid
+pnpm dlx shadcn@4.13.0 add @tuiparts/solid/collapsible
+```
+
+```bash Core
+pnpm dlx shadcn@4.13.0 add @tuiparts/core/collapsible
+```
+
+</CodeGroup>
+
+## Use the Recipe
+
+### React and Solid
+
+```tsx
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./components/ui/collapsible";
+
+<Collapsible defaultOpen>
+  <CollapsibleTrigger label="Connection details" />
+  <CollapsibleContent>
+    <text content="Region: eu-west" />
+  </CollapsibleContent>
+</Collapsible>;
+```
+
+### Core
+
+```ts
+import { TextRenderable } from "@opentui/core";
+import {
+  createCollapsible,
+  createCollapsibleContent,
+  createCollapsibleTrigger,
+} from "./components/ui/collapsible";
+
+const collapsible = createCollapsible(ctx, { defaultOpen: true });
+const trigger = createCollapsibleTrigger(ctx, collapsible, {
+  label: "Connection details",
+});
+const content = createCollapsibleContent(ctx, collapsible);
+content.add(new TextRenderable(ctx, { content: "Region: eu-west" }));
+
+collapsible.add(trigger);
+collapsible.add(content);
+parent.add(collapsible);
+```
+
+The Core factories receive the created Root so Trigger and Content use its
+Store.
+
+## Customize the Recipe
+
+`CollapsibleTrigger` uses `›` while closed and `⌄` while open. Override them
+with `closedMark` and `openMark`, or edit the copied source to change the
+Trigger composition. The Recipe owns its vertical gap, marker and label
+colors, and content indentation. Native OpenTUI properties can override those
+starter choices.
+
+Shared colors and density come from the [Theme Recipe](/theming). Panel content
+always belongs to your application.
+
+## Behavior
+
+Enter, Return, Space, and a primary-pointer press toggle the content. The
+Trigger retains focus while opening or closing. A disabled Root makes the
+Trigger inert and non-focusable. React and Solid Content unmounts while closed
+unless `keepMounted` is set; Core Content remains mounted and synchronizes its
+native visibility. Controlled ownership and lifecycle details belong to the
+[Collapsible Primitive](/primitives/collapsible).
+
+## Recipe API
+
+`Collapsible` forwards Root props and supplies a vertical layout with a
+one-cell gap. `CollapsibleTrigger` requires `label`, accepts `closedMark` and
+`openMark`, and forwards remaining Trigger props. Its children are owned by the
+Recipe presentation. `CollapsibleContent` forwards Panel props and preserves
+caller-owned children while adding starter indentation.
+
+Core exposes `createCollapsible`, `createCollapsibleTrigger`, and
+`createCollapsibleContent`. Compose the packaged
+[Collapsible Primitive](/primitives/collapsible) directly when these names or
+presentation boundaries do not fit.

--- a/apps/www/docs/catalog/collapsible.mdx
+++ b/apps/www/docs/catalog/collapsible.mdx
@@ -1,12 +1,12 @@
 ---
 title: Collapsible
-description: Reveal optional terminal content with an editable labeled Trigger.
+description: Reveal optional terminal content with a themed disclosure Trigger.
 ---
 
-Collapsible reveals content beneath a labeled Trigger. The packaged Primitive
-owns open state, activation, focus, disabled behavior, and content lifecycle.
-The Recipe adds disclosure markers, themed text, indentation, and starter
-layout.
+Collapsible reveals supporting content beneath a disclosure Trigger. The
+packaged Primitive owns open state, activation, focus, disabled behavior, and
+content lifecycle. The Recipe adds a label, disclosure marker, themed text,
+indentation, and starter layout.
 
 ## Install
 

--- a/apps/www/docs/catalog/index.mdx
+++ b/apps/www/docs/catalog/index.mdx
@@ -25,6 +25,7 @@ install commands alongside usage and customization guidance.
 | [Switch](/catalog/switch) | A setting that takes effect immediately | Checked state and activation |
 | [Toggle](/catalog/toggle) | An action whose pressed state remains visible | Pressed state and activation |
 | [Toggle Group](/catalog/toggle-group) | Related toggles sharing one keyboard stop | Selection and roving focus |
+| [Collapsible](/catalog/collapsible) | Reveal optional content beneath one Trigger | Open state, activation, and Panel lifecycle |
 | [Tabs](/catalog/tabs) | Switch between associated content panels | Selection, association, and roving focus |
 | [Radio Group](/catalog/radio-group) | One mutually exclusive selection from a set | Selection and roving focus |
 | [Dialog](/catalog/dialog) | A short modal task or decision | Layers, dismissal, and focus containment |

--- a/apps/www/docs/catalog/meta.ts
+++ b/apps/www/docs/catalog/meta.ts
@@ -12,6 +12,7 @@ export default defineMeta({
     "switch",
     "toggle",
     "toggle-group",
+    "collapsible",
     "tabs",
     "radio-group",
     "dialog",

--- a/apps/www/docs/primitives/collapsible.mdx
+++ b/apps/www/docs/primitives/collapsible.mdx
@@ -1,0 +1,141 @@
+---
+title: Collapsible
+description: Compose controlled or uncontrolled disclosure behavior from three genuine Parts.
+---
+
+Collapsible owns open state, Trigger activation and focus, disabled behavior,
+and Panel lifecycle without choosing labels, markers, layout, or styling.
+
+## Install
+
+Install the [package for your runtime](/primitives#install), then import the
+`collapsible` subpath:
+
+```ts
+import { Collapsible } from "@tuiparts/react/collapsible";
+```
+
+Replace `react` with `solid`. Core exports `CollapsibleStore` and the three
+matching Renderables from `@tuiparts/core/collapsible`.
+
+## Anatomy
+
+| Part | Responsibility |
+| --- | --- |
+| `Collapsible.Root` | Owns controlled or uncontrolled open and disabled state. |
+| `Collapsible.Trigger` | Focusable press target that requests the inverse open state. |
+| `Collapsible.Panel` | Content region whose lifecycle and visibility reflect open state. |
+
+Framework Trigger and Panel Parts must be composed inside `Collapsible.Root`.
+Core callers pass the matching Store explicitly.
+
+## Compose the Primitive
+
+<CodeGroup>
+
+```tsx React
+import { Collapsible } from "@tuiparts/react/collapsible";
+
+<Collapsible.Root defaultOpen>
+  <Collapsible.Trigger>
+    {(state) => (
+      <text content={`${state.open ? "-" : "+"} Connection details`} />
+    )}
+  </Collapsible.Trigger>
+  <Collapsible.Panel>
+    <text content="Region: eu-west" />
+  </Collapsible.Panel>
+</Collapsible.Root>;
+```
+
+```tsx Solid
+import { Collapsible } from "@tuiparts/solid/collapsible";
+
+<Collapsible.Root defaultOpen>
+  <Collapsible.Trigger>
+    {(state) => (
+      <text content={`${state.open ? "-" : "+"} Connection details`} />
+    )}
+  </Collapsible.Trigger>
+  <Collapsible.Panel>
+    <text content="Region: eu-west" />
+  </Collapsible.Panel>
+</Collapsible.Root>;
+```
+
+```ts Core
+import { TextRenderable } from "@opentui/core";
+import {
+  CollapsiblePanelRenderable,
+  CollapsibleRootRenderable,
+  CollapsibleTriggerRenderable,
+} from "@tuiparts/core/collapsible";
+
+const root = new CollapsibleRootRenderable(ctx, { defaultOpen: true });
+const trigger = new CollapsibleTriggerRenderable(ctx, { store: root.store });
+const panel = new CollapsiblePanelRenderable(ctx, { store: root.store });
+
+trigger.add(new TextRenderable(ctx, { content: "Connection details" }));
+panel.add(new TextRenderable(ctx, { content: "Region: eu-west" }));
+root.add(trigger);
+root.add(panel);
+parent.add(root);
+```
+
+</CodeGroup>
+
+Framework adapters provide the Root Store through context. Core callers pass
+`root.store` to Trigger and Panel.
+
+## State ownership
+
+Use `open` with `onOpenChange` for controlled ownership or `defaultOpen` for
+uncontrolled state. A controlled request reports intent without changing open
+state until its owner supplies the next value. Uncontrolled Collapsible commits
+an accepted request before calling `onOpenChange`.
+
+Root state contains `open` and `disabled`. Trigger state adds actual `focused`
+state. Panel state contains `open`. Snapshots are readonly and remain stable
+until observable state changes.
+
+Core `store.setOpen(open)` and `store.toggle()` make imperative semantic
+requests. `store.setControlledOpen(value)` supplies a controlled value or
+releases control with `undefined`; it does not invoke `onOpenChange`.
+
+## Interaction
+
+| Input | Behavior |
+| --- | --- |
+| `Enter`, `Return`, or `Space` | Toggles the open state from the focused Trigger. |
+| Primary-pointer release | Focuses Trigger and toggles when the press starts and ends on it. |
+| `trigger.press()` | Makes the same request with an imperative source. |
+
+Cancelled input, modifier chords, secondary pointer buttons, and disabled
+requests are ignored. Disabling Root blurs Trigger and removes it from focus.
+Opening and closing otherwise preserve Trigger focus.
+
+Inactive React and Solid Panels unmount by default. `keepMounted` retains the
+same Panel Renderable and reflects closed state with `visible=false`. A Core
+Panel remains mounted once constructed and synchronizes its native visibility.
+Removing Root or a Part permanently ends that Renderable's coordination
+lifetime; re-create removed Parts instead of reattaching them.
+
+## API reference
+
+| Surface | API |
+| --- | --- |
+| React and Solid | `Collapsible.Root`, `Collapsible.Trigger`, `Collapsible.Panel`, and scoped types |
+| Core | `CollapsibleStore`, three matching Renderables, and option/state types |
+| Root options | `open`, `defaultOpen`, `onOpenChange`, `disabled` |
+| Trigger actions | `press()` and inherited native focus methods |
+| Panel options | Native Box options; React and Solid additionally accept `keepMounted` |
+| Change details | `source` is `"imperative"`, `"keyboard"`, or `"pointer"`; keyboard details include `key`, pointer details include `button: 0` |
+
+Framework refs target the actual matching Core Renderable. Core may adopt an
+external `CollapsibleStore`; framework adapters create and retain it for Root.
+
+## Start with the Recipe
+
+The editable [Collapsible Recipe](/catalog/collapsible) supplies a labeled
+Trigger, disclosure markers, theme-derived colors, indentation, and starter
+layout.

--- a/apps/www/docs/primitives/collapsible.mdx
+++ b/apps/www/docs/primitives/collapsible.mdx
@@ -85,7 +85,10 @@ parent.add(root);
 </CodeGroup>
 
 Framework adapters provide the Root Store through context. Core callers pass
-`root.store` to Trigger and Panel.
+`root.store` to Trigger and Panel. The repository includes focused runnable
+tracers for [Core](https://github.com/tuiparts/tuiparts/blob/main/packages/core/examples/collapsible.ts),
+[React](https://github.com/tuiparts/tuiparts/blob/main/packages/react/examples/collapsible.tsx),
+and [Solid](https://github.com/tuiparts/tuiparts/blob/main/packages/solid/examples/collapsible.tsx).
 
 ## State ownership
 

--- a/apps/www/docs/primitives/index.mdx
+++ b/apps/www/docs/primitives/index.mdx
@@ -48,6 +48,7 @@ Import each Primitive from its package subpath, such as
 | [Switch](/primitives/switch) | A checked setting | `Root`, `Thumb` |
 | [Toggle](/primitives/toggle) | An action with retained pressed state | `Toggle` |
 | [Toggle Group](/primitives/toggle-group) | Related Toggles with shared selection and roving focus | `ToggleGroup`, `Toggle` |
+| [Collapsible](/primitives/collapsible) | Reveal one optional content region | `Root`, `Trigger`, `Panel` |
 | [Tabs](/primitives/tabs) | Select one associated content panel | `Root`, `List`, `Tab`, `Panel` |
 | [Radio Group](/primitives/radio-group) | One mutually exclusive selection from a collection | `RadioGroup`, `Radio.Root`, `Radio.Indicator` |
 | [Dialog](/primitives/dialog) | A modal layer with dismissal and focus containment | Eight composable Parts |

--- a/apps/www/docs/primitives/meta.ts
+++ b/apps/www/docs/primitives/meta.ts
@@ -12,6 +12,7 @@ export default defineMeta({
     "switch",
     "toggle",
     "toggle-group",
+    "collapsible",
     "tabs",
     "radio-group",
     "dialog",

--- a/docs/adr/0007-pressable-base-class.md
+++ b/docs/adr/0007-pressable-base-class.md
@@ -4,8 +4,8 @@ status: accepted
 
 # Concentrate activation behavior in one internal Pressable base class
 
-Every press-activated Root — Checkbox, Switch, Button, Toggle, Radio, and the
-Dialog Trigger and Close parts — subclasses the internal
+Every press-activated control or Part — Checkbox, Switch, Button, Toggle,
+Radio, Collapsible Trigger, and the Dialog Trigger and Close parts — subclasses the internal
 `PressableRenderable` (`core/src/internal/pressable.ts`). The base owns the
 gesture contract; subclasses own what one semantic press means.
 

--- a/docs/primitive-contracts/collapsible.md
+++ b/docs/primitive-contracts/collapsible.md
@@ -1,0 +1,87 @@
+# Collapsible Primitive contract
+
+## Product boundary
+
+Collapsible is a packaged Primitive because open-state ownership, equivalent
+keyboard and pointer activation, disabled gating, focus reflection, and
+conditional Panel lifecycle would otherwise be repeated by applications. Core
+owns that behavior. Recipes own labels, disclosure glyphs, layout, spacing,
+colors, animation, and Panel content.
+
+## Public shape and ownership
+
+- `Collapsible.Root` is the non-focusable ownership boundary. It owns or
+  receives one attachable `CollapsibleStore` in Core. React and Solid create
+  the Store and hide it from framework consumers.
+- `Collapsible.Trigger` is the pressable focus target that requests the inverse
+  open state.
+- `Collapsible.Panel` is the state-reflecting content region. A constructed
+  Core Panel remains mounted and synchronizes native visibility with open
+  state.
+- A framework Part outside `Collapsible.Root` fails with a part-specific error.
+  Core callers pass the Store explicitly and compose matching Parts beneath
+  the Root.
+
+`open` and `defaultOpen` provide controlled and uncontrolled ownership. The
+public Root state is a frozen, referentially stable snapshot containing `open`
+and `disabled`. Trigger state extends those facts with actual `focused` state;
+Panel state contains `open`.
+
+`onOpenChange(open, details)` receives one frozen press detail with
+`source: "imperative" | "keyboard" | "pointer"`. In uncontrolled mode a valid
+request commits before the callback. In controlled mode it reports intent
+without committing. Passing `undefined` after a controlled value releases
+control at the last observed value. Disabled requests do not notify.
+
+`CollapsibleStore.toggle()`, `CollapsibleStore.setOpen()`, and
+`CollapsibleTriggerRenderable.press()` are semantic actions. `setOpen()` and
+`toggle()` report an imperative request through the same ownership and callback
+rules as Trigger activation. `setControlledOpen()` supplies or releases an
+external owner's authoritative value without emitting `onOpenChange`. Refs
+resolve to the actual Root, Trigger, or Panel Core Renderable.
+
+## Interaction and lifecycle
+
+An uncancelled, unmodified Enter, Return, or Space press activates Trigger.
+An uncancelled primary pointer press must start and end on Trigger. Keyboard,
+pointer, and imperative activation share `PressableRenderable`; invalid or
+modified interactions are not consumed.
+
+Root disablement makes Trigger non-focusable and inert. Disabling while Trigger
+is focused blurs it. Opening and closing otherwise retain actual Trigger focus.
+Collapsible does not move focus into Panel or back to Trigger because no open
+transition moves it away.
+
+React and Solid Panels are conditional by default: a closed Panel has no
+Renderable and its ref is cleared. `keepMounted` retains the same Panel
+Renderable and reflects closed state through `visible=false`. `keepMounted` is
+adapter mounting policy and is not forwarded as an OpenTUI property. A Core
+caller chooses whether to construct a Panel; a constructed Panel remains
+mounted and synchronizes visibility.
+
+Mounting claims one Root coordination lifetime. Removing or destroying Root
+permanently ends every same-Store descendant Trigger and Panel lifetime before
+releasing Store ownership. Removing a Part releases its subscriptions and
+makes that Renderable inert even if physically reattached. Teardown is
+idempotent. An externally created Store may be adopted by a new complete Root
+after the previous Root releases it.
+
+## Conformance evidence plan
+
+| Surface | Applicability and evidence |
+| --- | --- |
+| Core | Applicable. Public Store and Renderable tests own controlled/uncontrolled state, frozen snapshots/details, semantic actions, keyboard/pointer wiring, disabled gating, focus, Panel visibility, Root/Part teardown, reentrancy, and retained identity. |
+| React | Applicable. Real `testRender` tests own authoritative first render, controlled frame consistency, prop removal, callback replacement, actual refs, retained identity, default/retained Panel ref lifecycle, Strict Mode, subscription teardown, context errors, and one interaction round-trip. |
+| Solid | Applicable. The adapter matrix is repeated through signals and Solid's real rendering seam, including cleanup and one interaction round-trip. |
+| Registry | Applicable. Core, React, and Solid Recipes import only `/collapsible`, compile in isolated strict consumers, mount, perform one open-state round-trip, prove Recipe-owned presentation, and restyle from the consumer-owned Theme. |
+| Packed | Applicable. All three `/collapsible` subpaths are included in tarball declaration and runtime-import checks; the compiled packed-consumer check executes representative Core Collapsible behavior. |
+| Terminal | N/A. Core tests use the real OpenTUI test renderer to prove focus, keyboard, pointer, and Panel visibility. Collapsible has no renderer-global listener, portal, ordering, dismissal, or restoration sequence hidden from that seam. |
+
+OpenTUI-native state ownership is **N/A** because Collapsible owns its boolean
+open state. Collection registration and unavailable-item repair are **N/A**
+because Collapsible has no dynamic collection or selectable items. Overlay
+coordination and cancellation are **N/A** because Collapsible creates no layer
+and open requests have no synchronously cancellable default action. A public
+Root state hook is **N/A** because no current Recipe composition consumer needs
+Root state outside Trigger or Panel state callbacks; ADR-0010 forbids adding
+that supplementary surface speculatively.

--- a/docs/primitives-and-recipes.md
+++ b/docs/primitives-and-recipes.md
@@ -83,6 +83,7 @@ root.add(indicator);
 | --- | --- | --- | --- | --- |
 | Button | `Button` | disabled, focused, pressed | `press()`; Enter/Return, Space, primary pointer | `ButtonRenderable` |
 | Checkbox | `Checkbox.Root`, `Checkbox.Indicator` | checked, disabled, focused | `press()`; Enter/Return, Space, primary pointer | matching Root or Indicator Renderable |
+| Collapsible | `Collapsible.Root`, `Collapsible.Trigger`, `Collapsible.Panel` | open, disabled; Trigger focus | Trigger `press()`; Enter/Return, Space, primary pointer | matching Part Renderable |
 | Switch | `Switch.Root`, `Switch.Thumb` | checked, disabled, focused | `press()`; Enter/Return, Space, primary pointer | matching Root or Thumb Renderable |
 | Tabs | `Tabs.Root`, `Tabs.List`, `Tabs.Tab`, `Tabs.Panel` | value, activation mode, orientation; Tab/Panel local state | arrows and Home/End move focus; Tab activation selects | matching Part Renderable |
 | Toggle | `Toggle` | pressed, disabled, focused | `press()`; Enter/Return, Space, primary pointer | `ToggleRenderable` |
@@ -92,7 +93,7 @@ root.add(indicator);
 | Textarea | `Textarea` | OpenTUI-owned `EditBuffer` | native multiline editing; content, cursor, submit callbacks | `TextareaRenderable` |
 | Dialog | `Dialog.Root`, Trigger, Portal, Backdrop, Popup, Title, Description, Close | open | Trigger/Close `press()`; Enter/Return/Space, Escape, Tab containment | matching Dialog part Renderable |
 
-Checkbox, Switch, Toggle, ToggleGroup, Tabs, RadioGroup, and Dialog support controlled and uncontrolled
+Checkbox, Collapsible, Switch, Toggle, ToggleGroup, Tabs, RadioGroup, and Dialog support controlled and uncontrolled
 ownership. RadioGroup owns one collection value and every Radio must belong to
 a group.
 Input and Textarea deliberately preserve OpenTUI's native mutable editing
@@ -119,6 +120,7 @@ pnpm dlx shadcn@4.13.0 add <item-address>
 The starter catalog provides `core/*`, `react/*`, and `solid/*` items for:
 
 - Checkbox
+- Collapsible
 - Switch
 - Button
 - RadioGroup/Radio

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -24,6 +24,7 @@ colors, spacing, glyphs, labels, or fixed visual trees.
 | --- | --- | --- |
 | Button | `ButtonStore` | `ButtonRenderable` |
 | Checkbox | `CheckboxStore` | `CheckboxRootRenderable`, `CheckboxIndicatorRenderable` |
+| Collapsible | `CollapsibleStore` | `CollapsibleRootRenderable`, `CollapsibleTriggerRenderable`, `CollapsiblePanelRenderable` |
 | Dialog | `DialogStore` | Root, Trigger, Portal, Backdrop, Popup, Title, Description, Close Renderables |
 | Input | OpenTUI-native state | `InputRenderable` |
 | Textarea | OpenTUI-native `EditBuffer` | `TextareaRenderable` |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -56,6 +56,9 @@ parent.add(root);
 Consumer-owned recipes assemble these parts with native OpenTUI Renderables and
 choose their presentation. Installable examples live under `registry/`.
 
+From a repository checkout, run the focused Collapsible tracer with
+`pnpm --filter @tuiparts/core demo:collapsible`.
+
 ## Input
 
 `InputRenderable` preserves OpenTUI's mutable `value` and event model instead

--- a/packages/core/examples/collapsible.ts
+++ b/packages/core/examples/collapsible.ts
@@ -1,0 +1,77 @@
+import {
+  BoxRenderable,
+  createCliRenderer,
+  TextRenderable,
+} from "@opentui/core";
+import {
+  CollapsiblePanelRenderable,
+  CollapsibleRootRenderable,
+  CollapsibleTriggerRenderable,
+  type CollapsibleTriggerState,
+} from "../src/collapsible";
+
+const renderer = await createCliRenderer({ exitOnCtrlC: true });
+renderer.setBackgroundColor("#0A0A0A");
+
+const screen = new BoxRenderable(renderer, {
+  flexDirection: "column",
+  gap: 1,
+  padding: 2,
+});
+screen.add(
+  new TextRenderable(renderer, {
+    content: "Core Collapsible Primitive",
+    fg: "#FFFFFF",
+  }),
+);
+screen.add(
+  new TextRenderable(renderer, {
+    content: "Space/Enter toggles the focused Trigger. Ctrl+C quits.",
+    fg: "#737373",
+  }),
+);
+
+const status = new TextRenderable(renderer, {
+  content: "State: closed (ready)",
+  fg: "#60A5FA",
+});
+const root = new CollapsibleRootRenderable(renderer, {
+  flexDirection: "column",
+  gap: 1,
+  onOpenChange: (open, details) => {
+    status.content = `State: ${open ? "open" : "closed"} (${details.source})`;
+  },
+});
+const trigger = new CollapsibleTriggerRenderable(renderer, {
+  height: 1,
+  paddingX: 1,
+  store: root.store,
+});
+const label = new TextRenderable(renderer, { content: "" });
+trigger.add(label);
+
+const syncTrigger = (state: CollapsibleTriggerState) => {
+  label.content = `${state.open ? "⌄" : "›"} Connection details`;
+  label.fg = state.disabled ? "#737373" : state.focused ? "#FFFFFF" : "#D4D4D4";
+  trigger.backgroundColor = state.focused ? "#262626" : "transparent";
+};
+syncTrigger(trigger.getState());
+trigger.subscribe(syncTrigger);
+
+const panel = new CollapsiblePanelRenderable(renderer, {
+  paddingLeft: 3,
+  store: root.store,
+});
+panel.add(
+  new TextRenderable(renderer, {
+    content: "Region: eu-west\nTransport: ssh",
+    fg: "#A3A3A3",
+  }),
+);
+
+root.add(trigger);
+root.add(panel);
+screen.add(root);
+screen.add(status);
+renderer.root.add(screen);
+trigger.focus();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -102,6 +102,7 @@
   ],
   "scripts": {
     "build": "tsdown",
+    "demo:collapsible": "bun run examples/collapsible.ts",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
     ".": "./src/index.ts",
     "./button": "./src/button/index.ts",
     "./checkbox": "./src/checkbox/index.ts",
+    "./collapsible": "./src/collapsible/index.ts",
     "./dialog": "./src/dialog/index.ts",
     "./input": "./src/input/index.ts",
     "./radio": "./src/radio/index.ts",
@@ -40,6 +41,10 @@
       "./checkbox": {
         "types": "./dist/checkbox/index.d.mts",
         "import": "./dist/checkbox/index.mjs"
+      },
+      "./collapsible": {
+        "types": "./dist/collapsible/index.d.mts",
+        "import": "./dist/collapsible/index.mjs"
       },
       "./dialog": {
         "types": "./dist/dialog/index.d.mts",

--- a/packages/core/src/collapsible/collapsible-primitive.test.ts
+++ b/packages/core/src/collapsible/collapsible-primitive.test.ts
@@ -1,0 +1,249 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { type KeyEvent, TextRenderable } from "@opentui/core";
+import {
+  createTestRenderer,
+  type TestRendererSetup,
+} from "@opentui/core/testing";
+import {
+  type CollapsibleOpenChangeDetails,
+  CollapsiblePanelRenderable,
+  CollapsibleRootRenderable,
+  CollapsibleStore,
+  CollapsibleTriggerRenderable,
+} from "./index";
+
+let setup: TestRendererSetup | undefined;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = undefined;
+});
+
+function key(name: string): KeyEvent {
+  // SAFETY: PressableRenderable reads the key name and absent guard fields as
+  // falsy. Tests of the complete OpenTUI KeyEvent guard matrix belong to the
+  // shared Pressable suite.
+  return { name } as KeyEvent;
+}
+
+async function createTree(
+  options: ConstructorParameters<typeof CollapsibleRootRenderable>[1] = {},
+): Promise<{
+  panel: CollapsiblePanelRenderable;
+  root: CollapsibleRootRenderable;
+  trigger: CollapsibleTriggerRenderable;
+}> {
+  setup = await createTestRenderer({ width: 30, height: 6 });
+  const root = new CollapsibleRootRenderable(setup.renderer, options);
+  const trigger = new CollapsibleTriggerRenderable(setup.renderer, {
+    height: 1,
+    store: root.store,
+    width: 10,
+  });
+  const panel = new CollapsiblePanelRenderable(setup.renderer, {
+    store: root.store,
+  });
+  trigger.add(new TextRenderable(setup.renderer, { content: "Details" }));
+  panel.add(new TextRenderable(setup.renderer, { content: "Panel content" }));
+  root.add(trigger);
+  root.add(panel);
+  setup.renderer.root.add(root);
+  await setup.renderOnce();
+  return { panel, root, trigger };
+}
+
+describe("Collapsible primitive", () => {
+  it("owns frozen, referentially stable uncontrolled state", () => {
+    const store = new CollapsibleStore({ defaultOpen: true });
+    const initial = store.state;
+    const observed: boolean[] = [];
+    store.subscribe((state) => observed.push(state.open));
+
+    expect(initial).toEqual({ disabled: false, open: true });
+    expect(Object.isFrozen(initial)).toBe(true);
+    store.setDisabled(false);
+    expect(store.state).toBe(initial);
+
+    store.toggle();
+    expect(store.state).toEqual({ disabled: false, open: false });
+    expect(store.state).not.toBe(initial);
+    expect(Object.isFrozen(store.state)).toBe(true);
+    expect(observed).toEqual([false]);
+  });
+
+  it("reports immutable details once per accepted semantic request", () => {
+    const changes: Array<{
+      details: CollapsibleOpenChangeDetails;
+      open: boolean;
+      observed: boolean;
+    }> = [];
+    const store = new CollapsibleStore({
+      onOpenChange: (open, details) =>
+        changes.push({ details, observed: store.state.open, open }),
+    });
+
+    store.toggle();
+    store.setOpen(true);
+    const keyboard = { key: "space", source: "keyboard" } as const;
+    store.setOpen(false, keyboard);
+
+    expect(changes).toEqual([
+      { details: { source: "imperative" }, observed: true, open: true },
+      { details: keyboard, observed: false, open: false },
+    ]);
+    expect(changes.every(({ details }) => Object.isFrozen(details))).toBe(true);
+  });
+
+  it("reports controlled intent and releases control at the observed value", () => {
+    const requests: boolean[] = [];
+    const store = new CollapsibleStore({
+      onOpenChange: (open) => requests.push(open),
+      open: false,
+    });
+
+    store.toggle();
+    expect(store.state.open).toBe(false);
+    expect(requests).toEqual([true]);
+
+    store.setControlledOpen(true);
+    expect(store.state.open).toBe(true);
+    store.setControlledOpen(undefined);
+    store.toggle();
+    expect(store.state.open).toBe(false);
+    expect(requests).toEqual([true, false]);
+  });
+
+  it("adopts one external Store and applies explicit Root behavior props", async () => {
+    setup = await createTestRenderer({ width: 30, height: 6 });
+    const changes: boolean[] = [];
+    const store = new CollapsibleStore({ defaultOpen: false });
+    const root = new CollapsibleRootRenderable(setup.renderer, {
+      disabled: true,
+      onOpenChange: (open) => changes.push(open),
+      open: true,
+      store,
+    });
+
+    expect(root.store).toBe(store);
+    expect(root.getState()).toEqual({ disabled: true, open: true });
+    expect(() => {
+      root.store = new CollapsibleStore();
+    }).toThrow("Collapsible.Root store cannot be replaced");
+    root.disabled = false;
+    store.toggle();
+    expect(changes).toEqual([false]);
+    expect(root.open).toBe(true);
+  });
+
+  it("wires Trigger activation, focus, and Panel visibility", async () => {
+    const changes: CollapsibleOpenChangeDetails[] = [];
+    const { panel, root, trigger } = await createTree({
+      onOpenChange: (_open, details) => changes.push(details),
+    });
+
+    expect(root.focusable).toBe(false);
+    expect(panel.visible).toBe(false);
+    expect(trigger.getState()).toEqual({
+      disabled: false,
+      focused: false,
+      open: false,
+    });
+
+    trigger.focus();
+    expect(trigger.getState().focused).toBe(true);
+    expect(trigger.handleKeyPress(key("space"))).toBe(true);
+    expect(root.open).toBe(true);
+    expect(panel.visible).toBe(true);
+    expect(trigger.focused).toBe(true);
+    expect(trigger.getState()).toEqual({
+      disabled: false,
+      focused: true,
+      open: true,
+    });
+
+    trigger.press();
+    expect(root.open).toBe(false);
+    expect(panel.visible).toBe(false);
+    expect(trigger.focused).toBe(true);
+    expect(changes).toEqual([
+      { key: "space", source: "keyboard" },
+      { source: "imperative" },
+    ]);
+  });
+
+  it("inherits Root disablement at every Trigger seam", async () => {
+    const requests: boolean[] = [];
+    const { panel, root, trigger } = await createTree({
+      defaultOpen: true,
+      onOpenChange: (open) => requests.push(open),
+    });
+    trigger.focus();
+
+    root.disabled = true;
+    expect(trigger.focused).toBe(false);
+    expect(trigger.focusable).toBe(false);
+    expect(trigger.getState()).toEqual({
+      disabled: true,
+      focused: false,
+      open: true,
+    });
+    trigger.press();
+    expect(trigger.handleKeyPress(key("enter"))).toBe(false);
+    await setup?.mockMouse.click(0, 0);
+    expect(requests).toEqual([]);
+    expect(panel.visible).toBe(true);
+
+    root.disabled = undefined;
+    expect(trigger.focusable).toBe(true);
+  });
+
+  it("wires one primary-pointer round-trip through shared Pressable behavior", async () => {
+    const details: CollapsibleOpenChangeDetails[] = [];
+    const { panel, trigger } = await createTree({
+      onOpenChange: (_open, next) => details.push(next),
+    });
+
+    await setup?.mockMouse.click(0, 0);
+
+    expect(panel.visible).toBe(true);
+    expect(trigger.focused).toBe(true);
+    expect(details).toEqual([{ button: 0, source: "pointer" }]);
+  });
+
+  it("combines consumer visibility with open state", async () => {
+    const { panel, root } = await createTree({ defaultOpen: true });
+    expect(panel.visible).toBe(true);
+
+    panel.visible = false;
+    expect(panel.visible).toBe(false);
+    root.store.toggle();
+    root.store.toggle();
+    expect(panel.visible).toBe(false);
+
+    panel.visible = undefined;
+    expect(panel.visible).toBe(true);
+  });
+
+  it("permanently ends descendant coordination when Root is removed", async () => {
+    const store = new CollapsibleStore();
+    const { panel, root, trigger } = await createTree({ store });
+    if (!setup) throw new Error("Expected test renderer");
+    setup.renderer.root.remove(root);
+    const endedState = trigger.getState();
+
+    trigger.press();
+    store.setOpen(true);
+    expect(trigger.getState()).toBe(endedState);
+    expect(panel.visible).toBe(false);
+
+    setup.renderer.root.add(root);
+    trigger.press();
+    expect(store.state.open).toBe(true);
+
+    const replacement = new CollapsibleRootRenderable(setup.renderer, {
+      store,
+    });
+    expect(replacement.store).toBe(store);
+    replacement.destroy();
+  });
+});

--- a/packages/core/src/collapsible/index.ts
+++ b/packages/core/src/collapsible/index.ts
@@ -1,0 +1,15 @@
+export {
+  type CollapsibleOpenChangeDetails,
+  type CollapsibleOpenChangeHandler,
+  type CollapsiblePanelOptions,
+  CollapsiblePanelRenderable,
+  type CollapsiblePanelState,
+  type CollapsibleRootOptions,
+  CollapsibleRootRenderable,
+  type CollapsibleState,
+  CollapsibleStore,
+  type CollapsibleStoreOptions,
+  type CollapsibleTriggerOptions,
+  CollapsibleTriggerRenderable,
+  type CollapsibleTriggerState,
+} from "./primitive";

--- a/packages/core/src/collapsible/primitive.ts
+++ b/packages/core/src/collapsible/primitive.ts
@@ -1,0 +1,497 @@
+import {
+  type BaseRenderable,
+  type BoxOptions,
+  BoxRenderable,
+  type RenderContext,
+} from "@opentui/core";
+import { PressableRenderable, type PressDetails } from "../internal/pressable";
+
+/** Cause of one accepted Collapsible open-state request. */
+export type CollapsibleOpenChangeDetails = PressDetails;
+
+/** Immutable observable state for one Collapsible Root. */
+export interface CollapsibleState {
+  /** Whether the Panel is open. */
+  readonly open: boolean;
+  /** Whether interaction is disabled. */
+  readonly disabled: boolean;
+}
+
+/** Immutable observable state for one Collapsible Trigger. */
+export interface CollapsibleTriggerState extends CollapsibleState {
+  /** Whether this Trigger owns actual OpenTUI focus. */
+  readonly focused: boolean;
+}
+
+/** Immutable observable state for one Collapsible Panel. */
+export interface CollapsiblePanelState {
+  /** Whether the owning Collapsible is open. */
+  readonly open: boolean;
+}
+
+/** Callback invoked for one accepted semantic open-state request. */
+export type CollapsibleOpenChangeHandler = (
+  open: boolean,
+  details: CollapsibleOpenChangeDetails,
+) => void;
+
+/** Options used to construct a Collapsible Store. */
+export interface CollapsibleStoreOptions {
+  /** Initial open state when uncontrolled. */
+  readonly defaultOpen?: boolean;
+  /** Whether interaction is disabled. */
+  readonly disabled?: boolean;
+  /** Callback for semantic open-state requests. */
+  readonly onOpenChange?: CollapsibleOpenChangeHandler;
+  /** Controlled open state. */
+  readonly open?: boolean;
+}
+
+type CollapsibleStateListener = (state: CollapsibleState) => void;
+
+const IMPERATIVE_DETAILS: CollapsibleOpenChangeDetails = Object.freeze({
+  source: "imperative",
+});
+
+/** Framework-neutral open-state owner for Collapsible Parts. */
+export class CollapsibleStore {
+  private controlled: boolean;
+  private snapshot: CollapsibleState;
+  private onOpenChangeCallback?: CollapsibleOpenChangeHandler;
+  private rootOwner?: object;
+  private readonly listeners = new Set<CollapsibleStateListener>();
+
+  /** Creates a Collapsible Store. */
+  constructor(options: CollapsibleStoreOptions = {}) {
+    this.controlled = options.open !== undefined;
+    this.snapshot = Object.freeze({
+      disabled: options.disabled ?? false,
+      open: options.open ?? options.defaultOpen ?? false,
+    });
+    this.onOpenChangeCallback = options.onOpenChange;
+  }
+
+  /** Current immutable Root state. */
+  get state(): CollapsibleState {
+    return this.snapshot;
+  }
+
+  /** Subscribes to Root state changes. */
+  subscribe(listener: CollapsibleStateListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** Claims this Store for one live Root coordination lifetime. */
+  attachRoot(owner: object): void {
+    if (this.rootOwner && this.rootOwner !== owner) {
+      throw new Error(
+        "Collapsible Store may be adopted by only one live Collapsible.Root",
+      );
+    }
+    this.rootOwner = owner;
+  }
+
+  /** Releases one Root's claim without ending an externally owned Store. */
+  detachRoot(owner: object): void {
+    if (this.rootOwner === owner) this.rootOwner = undefined;
+  }
+
+  /** Requests a specific open state through the active ownership model. */
+  setOpen(
+    open: boolean,
+    details: CollapsibleOpenChangeDetails = IMPERATIVE_DETAILS,
+  ): void {
+    if (this.snapshot.disabled || open === this.snapshot.open) return;
+    const immutableDetails = Object.isFrozen(details)
+      ? details
+      : Object.freeze({ ...details });
+    if (!this.controlled) this.update({ open });
+    this.onOpenChangeCallback?.(open, immutableDetails);
+  }
+
+  /** Requests the inverse open state through the active ownership model. */
+  toggle(details: CollapsibleOpenChangeDetails = IMPERATIVE_DETAILS): void {
+    this.setOpen(!this.snapshot.open, details);
+  }
+
+  /** Applies a controlled value, or releases control when undefined. */
+  setControlledOpen(open: boolean | null | undefined): void {
+    if (typeof open !== "boolean") {
+      this.controlled = false;
+      return;
+    }
+    this.controlled = true;
+    this.update({ open });
+  }
+
+  /** Updates Root disablement. */
+  setDisabled(disabled: boolean): void {
+    this.update({ disabled });
+  }
+
+  /** Replaces the open-change callback. */
+  setOnOpenChange(callback: CollapsibleOpenChangeHandler | undefined): void {
+    this.onOpenChangeCallback = callback;
+  }
+
+  /** Releases Store listeners and callback ownership. */
+  destroy(): void {
+    this.listeners.clear();
+    this.onOpenChangeCallback = undefined;
+    this.rootOwner = undefined;
+  }
+
+  private update(next: Partial<CollapsibleState>): void {
+    const state = { ...this.snapshot, ...next };
+    if (
+      state.disabled === this.snapshot.disabled &&
+      state.open === this.snapshot.open
+    ) {
+      return;
+    }
+    this.snapshot = Object.freeze(state);
+    for (const listener of [...this.listeners]) {
+      if (this.listeners.has(listener)) listener(this.snapshot);
+    }
+  }
+}
+
+/** Native OpenTUI options plus Collapsible Root behavior props. */
+export interface CollapsibleRootOptions
+  extends BoxOptions,
+    CollapsibleStoreOptions {
+  /** Existing Store for imperative composition. */
+  store?: CollapsibleStore;
+}
+
+/** Non-focusable ownership boundary for one Collapsible instance. */
+export class CollapsibleRootRenderable extends BoxRenderable {
+  protected override _focusable = false;
+  private readonly _store: CollapsibleStore;
+  private readonly ownsStore: boolean;
+  private readonly unsubscribe: () => void;
+  private ownershipReleased = false;
+
+  /** Creates a Collapsible Root Renderable. */
+  constructor(ctx: RenderContext, options: CollapsibleRootOptions = {}) {
+    const { defaultOpen, disabled, onOpenChange, open, store, ...boxOptions } =
+      options;
+    super(ctx, boxOptions);
+    this.ownsStore = !store;
+    this._store =
+      store ??
+      new CollapsibleStore({
+        defaultOpen,
+        disabled,
+        onOpenChange,
+        open,
+      });
+    this._store.attachRoot(this);
+    if (store) {
+      if (disabled !== undefined) store.setDisabled(disabled);
+      if (onOpenChange !== undefined) store.setOnOpenChange(onOpenChange);
+      if (open !== undefined) store.setControlledOpen(open);
+    }
+    this.unsubscribe = this._store.subscribe(() => this.requestRender());
+  }
+
+  /** Store owned or adopted by this Root. */
+  get store(): CollapsibleStore {
+    return this._store;
+  }
+
+  /** Prevents replacement of a mounted Root Store. */
+  set store(store: CollapsibleStore) {
+    if (store !== this._store) {
+      throw new Error("Collapsible.Root store cannot be replaced");
+    }
+  }
+
+  /** Current immutable Root state. */
+  getState(): CollapsibleState {
+    return this._store.state;
+  }
+
+  /** Current open state. */
+  get open(): boolean {
+    return this._store.state.open;
+  }
+
+  set open(open: boolean | null | undefined) {
+    if (this.ownershipReleased) return;
+    this._store.setControlledOpen(open);
+  }
+
+  /** Whether interaction is disabled. */
+  get disabled(): boolean {
+    return this._store.state.disabled;
+  }
+
+  set disabled(disabled: boolean | null | undefined) {
+    if (this.ownershipReleased) return;
+    this._store.setDisabled(disabled ?? false);
+  }
+
+  /** Replaces the open-change callback. */
+  set onOpenChange(callback: CollapsibleOpenChangeHandler | undefined) {
+    if (this.ownershipReleased) return;
+    this._store.setOnOpenChange(callback);
+  }
+
+  protected override onRemove(): void {
+    this.endCoordinationLifetime();
+    super.onRemove();
+  }
+
+  /** Releases Root ownership and subscriptions. */
+  override destroy(): void {
+    this.endCoordinationLifetime();
+    super.destroy();
+  }
+
+  /** Permanently ends this Root and every same-Store descendant Part. */
+  endCoordinationLifetime(): void {
+    if (this.ownershipReleased) return;
+    this.ownershipReleased = true;
+    const visit = (node: BaseRenderable): void => {
+      for (const child of node.getChildren()) {
+        if (
+          child instanceof CollapsibleTriggerRenderable &&
+          child.store === this._store
+        ) {
+          child.endCoordinationLifetime();
+        } else if (
+          child instanceof CollapsiblePanelRenderable &&
+          child.store === this._store
+        ) {
+          child.endCoordinationLifetime();
+        }
+        visit(child);
+      }
+    };
+    visit(this);
+    this.unsubscribe();
+    this._store.detachRoot(this);
+    if (this.ownsStore) this._store.destroy();
+  }
+}
+
+/** Native OpenTUI options for a Collapsible Trigger. */
+export interface CollapsibleTriggerOptions extends BoxOptions {
+  /** Store owned by the matching Collapsible Root. */
+  store: CollapsibleStore;
+}
+
+type CollapsibleTriggerListener = (state: CollapsibleTriggerState) => void;
+
+/** Focusable Part that requests the inverse Collapsible open state. */
+export class CollapsibleTriggerRenderable extends PressableRenderable {
+  private readonly _store: CollapsibleStore;
+  private readonly unsubscribe: () => void;
+  private snapshot: CollapsibleTriggerState;
+  private focusedState = false;
+  private coordinationReleased = false;
+  private readonly stateListeners = new Set<CollapsibleTriggerListener>();
+
+  /** Creates a Collapsible Trigger Renderable. */
+  constructor(ctx: RenderContext, options: CollapsibleTriggerOptions) {
+    const { store, ...boxOptions } = options;
+    super(ctx, boxOptions);
+    this._store = store;
+    this.snapshot = this.createState();
+    this.attachPressable({
+      get state() {
+        return store.state;
+      },
+      setFocused: (focused) => this.setFocusedState(focused),
+      subscribe: (listener) => store.subscribe(listener),
+    });
+    this.unsubscribe = store.subscribe(() => this.publishState());
+  }
+
+  /** Store associated with this Trigger. */
+  get store(): CollapsibleStore {
+    return this._store;
+  }
+
+  /** Prevents replacement of a mounted Trigger Store. */
+  set store(store: CollapsibleStore) {
+    if (store !== this._store) {
+      throw new Error("Collapsible.Trigger store cannot be replaced");
+    }
+  }
+
+  /** Current immutable Trigger state. */
+  getState(): CollapsibleTriggerState {
+    return this.snapshot;
+  }
+
+  /** Subscribes to Trigger state changes. */
+  subscribe(listener: CollapsibleTriggerListener): () => void {
+    this.stateListeners.add(listener);
+    return () => this.stateListeners.delete(listener);
+  }
+
+  protected handlePress(details: PressDetails): void {
+    if (this.coordinationReleased) return;
+    this._store.toggle(details);
+  }
+
+  protected override onRemove(): void {
+    this.endCoordinationLifetime();
+    super.onRemove();
+  }
+
+  /** Releases Trigger subscriptions and interaction. */
+  override destroy(): void {
+    this.endCoordinationLifetime();
+    super.destroy();
+  }
+
+  /** Permanently releases this Trigger's coordination lifetime. */
+  endCoordinationLifetime(): void {
+    if (this.coordinationReleased) return;
+    this.coordinationReleased = true;
+    this.detachPressable();
+    this.unsubscribe();
+    this._focusable = false;
+    if (this._focused) super.blur();
+    this.focusedState = false;
+    this.snapshot = this.createState();
+    this.stateListeners.clear();
+  }
+
+  private setFocusedState(focused: boolean): void {
+    if (this.coordinationReleased || this.focusedState === focused) return;
+    this.focusedState = focused;
+    this.publishState();
+  }
+
+  private createState(): CollapsibleTriggerState {
+    return Object.freeze({
+      disabled: this._store.state.disabled,
+      focused: this.focusedState,
+      open: this._store.state.open,
+    });
+  }
+
+  private publishState(): void {
+    if (this.coordinationReleased) return;
+    const next = this.createState();
+    if (
+      next.disabled === this.snapshot.disabled &&
+      next.focused === this.snapshot.focused &&
+      next.open === this.snapshot.open
+    ) {
+      return;
+    }
+    this.snapshot = next;
+    this.requestRender();
+    for (const listener of [...this.stateListeners]) {
+      if (this.stateListeners.has(listener)) listener(next);
+    }
+  }
+}
+
+/** Native OpenTUI options for a Collapsible Panel. */
+export interface CollapsiblePanelOptions extends BoxOptions {
+  /** Store owned by the matching Collapsible Root. */
+  store: CollapsibleStore;
+}
+
+type CollapsiblePanelListener = (state: CollapsiblePanelState) => void;
+
+/** State-reflecting content Panel for one Collapsible instance. */
+export class CollapsiblePanelRenderable extends BoxRenderable {
+  private readonly _store: CollapsibleStore;
+  private consumerVisible: boolean;
+  private snapshot: CollapsiblePanelState;
+  private readonly unsubscribe: () => void;
+  private coordinationReleased = false;
+  private readonly stateListeners = new Set<CollapsiblePanelListener>();
+
+  /** Creates a Collapsible Panel Renderable. */
+  constructor(ctx: RenderContext, options: CollapsiblePanelOptions) {
+    const { store, visible = true, ...boxOptions } = options;
+    super(ctx, { ...boxOptions, visible: visible && store.state.open });
+    this._store = store;
+    this.consumerVisible = visible;
+    this.snapshot = this.createState();
+    this.unsubscribe = store.subscribe(() => this.syncState());
+  }
+
+  /** Store associated with this Panel. */
+  get store(): CollapsibleStore {
+    return this._store;
+  }
+
+  /** Prevents replacement of a mounted Panel Store. */
+  set store(store: CollapsibleStore) {
+    if (store !== this._store) {
+      throw new Error("Collapsible.Panel store cannot be replaced");
+    }
+  }
+
+  /** Current immutable Panel state. */
+  getState(): CollapsiblePanelState {
+    return this.snapshot;
+  }
+
+  /** Subscribes to Panel state changes. */
+  subscribe(listener: CollapsiblePanelListener): () => void {
+    this.stateListeners.add(listener);
+    return () => this.stateListeners.delete(listener);
+  }
+
+  override get visible(): boolean {
+    return super.visible;
+  }
+
+  override set visible(visible: boolean | null | undefined) {
+    if (this.coordinationReleased) return;
+    this.consumerVisible = visible ?? true;
+    this.syncState();
+  }
+
+  protected override onRemove(): void {
+    this.endCoordinationLifetime();
+    super.onRemove();
+  }
+
+  /** Releases Panel subscriptions. */
+  override destroy(): void {
+    this.endCoordinationLifetime();
+    super.destroy();
+  }
+
+  /** Permanently releases this Panel's coordination lifetime. */
+  endCoordinationLifetime(): void {
+    if (this.coordinationReleased) return;
+    this.coordinationReleased = true;
+    this.unsubscribe();
+    super.visible = false;
+    this.snapshot = Object.freeze({ open: false });
+    this.stateListeners.clear();
+  }
+
+  private createState(): CollapsiblePanelState {
+    return Object.freeze({ open: this._store.state.open });
+  }
+
+  private syncState(): void {
+    if (this.coordinationReleased) return;
+    const next = this.createState();
+    if (super.visible !== this.consumerVisible && next.open) {
+      super.visible = this.consumerVisible;
+    } else if (super.visible !== false && !next.open) {
+      super.visible = false;
+    }
+    if (next.open === this.snapshot.open) return;
+    this.snapshot = next;
+    this.requestRender();
+    for (const listener of [...this.stateListeners]) {
+      if (this.stateListeners.has(listener)) listener(next);
+    }
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,21 @@ export {
   type CheckboxStoreOptions,
 } from "./checkbox";
 export {
+  type CollapsibleOpenChangeDetails,
+  type CollapsibleOpenChangeHandler,
+  type CollapsiblePanelOptions,
+  CollapsiblePanelRenderable,
+  type CollapsiblePanelState,
+  type CollapsibleRootOptions,
+  CollapsibleRootRenderable,
+  type CollapsibleState,
+  CollapsibleStore,
+  type CollapsibleStoreOptions,
+  type CollapsibleTriggerOptions,
+  CollapsibleTriggerRenderable,
+  type CollapsibleTriggerState,
+} from "./collapsible";
+export {
   type DialogBackdropOptions,
   DialogBackdropRenderable,
   type DialogCloseOptions,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src"]
+  "include": ["examples", "src"]
 }

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     "src/index.ts",
     "src/button/index.ts",
     "src/checkbox/index.ts",
+    "src/collapsible/index.ts",
     "src/dialog/index.ts",
     "src/input/index.ts",
     "src/radio/index.ts",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -57,6 +57,9 @@ export function Settings() {
 }
 ```
 
+From a repository checkout, run the focused Collapsible tracer with
+`pnpm --filter @tuiparts/react demo:collapsible`.
+
 ## Imports
 
 All Primitives are exported from `@tuiparts/react`. Focused imports are also

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -19,7 +19,7 @@ Peer requirements are `@opentui/core` and `@opentui/react` `^0.4.3`, React
 ## Primitive example
 
 ```tsx
-import { Button, Checkbox, Input, Radio, RadioGroup, Switch, Textarea, Toggle, ToggleGroup } from "@tuiparts/react";
+import { Button, Checkbox, Collapsible, Input, Radio, RadioGroup, Switch, Textarea, Toggle, ToggleGroup } from "@tuiparts/react";
 import { useState } from "react";
 
 export function Settings() {
@@ -65,6 +65,7 @@ supported:
 ```ts
 import { Button } from "@tuiparts/react/button";
 import { Checkbox } from "@tuiparts/react/checkbox";
+import { Collapsible } from "@tuiparts/react/collapsible";
 import { Input } from "@tuiparts/react/input";
 import { Radio } from "@tuiparts/react/radio";
 import { RadioGroup } from "@tuiparts/react/radio-group";

--- a/packages/react/examples/collapsible.tsx
+++ b/packages/react/examples/collapsible.tsx
@@ -1,0 +1,60 @@
+/** @jsxImportSource @opentui/react */
+
+import { createCliRenderer } from "@opentui/core";
+import { createRoot } from "@opentui/react";
+import type { CollapsibleTriggerRenderable } from "@tuiparts/core/collapsible";
+import { useCallback, useState } from "react";
+import { Collapsible } from "../src/collapsible";
+
+function Demo() {
+  const [open, setOpen] = useState(false);
+  const [source, setSource] = useState("ready");
+  const focusTrigger = useCallback(
+    (trigger: CollapsibleTriggerRenderable | null) => trigger?.focus(),
+    [],
+  );
+
+  return (
+    <box flexDirection="column" gap={1} padding={2}>
+      <text content="React Collapsible Primitive" fg="#FFFFFF" />
+      <text
+        content="Space/Enter toggles the focused Trigger. Ctrl+C quits."
+        fg="#737373"
+      />
+
+      <Collapsible.Root
+        open={open}
+        onOpenChange={(nextOpen, details) => {
+          setOpen(nextOpen);
+          setSource(details.source);
+        }}
+        flexDirection="column"
+        gap={1}
+      >
+        <Collapsible.Trigger ref={focusTrigger} height={1} paddingX={1}>
+          {(state) => (
+            <box backgroundColor={state.focused ? "#262626" : "transparent"}>
+              <text
+                content={`${state.open ? "⌄" : "›"} Connection details`}
+                fg={state.focused ? "#FFFFFF" : "#D4D4D4"}
+              />
+            </box>
+          )}
+        </Collapsible.Trigger>
+        <Collapsible.Panel flexDirection="column" paddingLeft={3}>
+          <text content="Region: eu-west" fg="#A3A3A3" />
+          <text content="Transport: ssh" fg="#A3A3A3" />
+        </Collapsible.Panel>
+      </Collapsible.Root>
+
+      <text
+        content={`State: ${open ? "open" : "closed"} (${source})`}
+        fg="#60A5FA"
+      />
+    </box>
+  );
+}
+
+const renderer = await createCliRenderer({ exitOnCtrlC: true });
+renderer.setBackgroundColor("#0A0A0A");
+createRoot(renderer).render(<Demo />);

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,6 +7,7 @@
   "sideEffects": [
     "./dist/button/**",
     "./dist/checkbox/**",
+    "./dist/collapsible/**",
     "./dist/dialog/**",
     "./dist/input/**",
     "./dist/radio/**",
@@ -27,6 +28,7 @@
     ".": "./src/index.ts",
     "./button": "./src/button/index.tsx",
     "./checkbox": "./src/checkbox/index.tsx",
+    "./collapsible": "./src/collapsible/index.ts",
     "./dialog": "./src/dialog/index.ts",
     "./input": "./src/input/index.tsx",
     "./radio": "./src/radio/index.tsx",
@@ -52,6 +54,10 @@
       "./checkbox": {
         "types": "./dist/checkbox/index.d.mts",
         "import": "./dist/checkbox/index.mjs"
+      },
+      "./collapsible": {
+        "types": "./dist/collapsible/index.d.mts",
+        "import": "./dist/collapsible/index.mjs"
       },
       "./dialog": {
         "types": "./dist/dialog/index.d.mts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -115,6 +115,7 @@
   ],
   "scripts": {
     "build": "tsdown",
+    "demo:collapsible": "bun run examples/collapsible.tsx",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/react/src/collapsible/collapsible-primitive.test.tsx
+++ b/packages/react/src/collapsible/collapsible-primitive.test.tsx
@@ -1,0 +1,285 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { TestRecorder, type TestRendererSetup } from "@opentui/core/testing";
+import { testRender } from "@opentui/react/test-utils";
+import {
+  CollapsiblePanelRenderable,
+  CollapsibleRootRenderable,
+  CollapsibleStore,
+  CollapsibleTriggerRenderable,
+} from "@tuiparts/core/collapsible";
+import {
+  act,
+  createElement,
+  createRef,
+  type ReactNode,
+  StrictMode,
+  useState,
+} from "react";
+import { Collapsible } from "./index";
+
+let setup: TestRendererSetup | undefined;
+
+async function destroySetup(): Promise<void> {
+  if (!setup) return;
+  const renderer = setup.renderer;
+  setup = undefined;
+  const key = "IS_REACT_ACT_ENVIRONMENT";
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, key);
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    get: () => true,
+    set: () => {},
+  });
+  try {
+    await act(async () => renderer.destroy());
+  } finally {
+    if (descriptor) Object.defineProperty(globalThis, key, descriptor);
+    else Reflect.deleteProperty(globalThis, key);
+  }
+}
+
+afterEach(async () => {
+  await destroySetup();
+});
+
+function tree(rootProps: Collapsible.Root.Props = {}) {
+  return createElement(
+    Collapsible.Root,
+    { ...rootProps, id: "root" },
+    createElement(
+      Collapsible.Trigger,
+      { id: "trigger" },
+      createElement("text", { content: "Details" }),
+    ),
+    createElement(
+      Collapsible.Panel,
+      { id: "panel" },
+      createElement("text", { content: "Content" }),
+    ),
+  );
+}
+
+describe("React Collapsible", () => {
+  it("uses one authoritative Store and wires one interaction round-trip", async () => {
+    setup = await testRender(tree(), { width: 30, height: 5 });
+    const root = setup.renderer.root.findDescendantById("root");
+    const trigger = setup.renderer.root.findDescendantById("trigger");
+    if (!(root instanceof CollapsibleRootRenderable)) {
+      throw new Error("Expected Collapsible Root");
+    }
+    if (!(trigger instanceof CollapsibleTriggerRenderable)) {
+      throw new Error("Expected Collapsible Trigger");
+    }
+
+    expect(trigger.store).toBe(root.store);
+    await act(async () => trigger.press());
+    await act(async () => setup?.waitFor(() => root.open));
+    expect(setup.renderer.root.findDescendantById("panel")).toBeInstanceOf(
+      CollapsiblePanelRenderable,
+    );
+  });
+
+  it("provides authoritative initial Root and retained Panel state", async () => {
+    const rootStates: Collapsible.Root.State[] = [];
+    const panelStates: Collapsible.Panel.State[] = [];
+    setup = await testRender(
+      createElement(Collapsible.Root, { defaultOpen: true }, ((
+        state: Collapsible.Root.State,
+      ) => {
+        rootStates.push(state);
+        return createElement(Collapsible.Panel, { keepMounted: true }, ((
+          panelState: Collapsible.Panel.State,
+        ) => {
+          panelStates.push(panelState);
+          return null;
+        }) as unknown as ReactNode);
+      }) as unknown as ReactNode),
+      { width: 20, height: 3 },
+    );
+
+    expect(rootStates[0]).toEqual({ disabled: false, open: true });
+    expect(Object.isFrozen(rootStates[0])).toBe(true);
+    expect(panelStates[0]).toEqual({ open: true });
+    expect(Object.isFrozen(panelStates[0])).toBe(true);
+  });
+
+  it("never renders a controlled frame with stale Panel content", async () => {
+    let setOpen: (open: boolean) => void = () => {};
+    function App() {
+      const [open, updateOpen] = useState(false);
+      setOpen = updateOpen;
+      return createElement(
+        Collapsible.Root,
+        { open },
+        createElement(
+          Collapsible.Panel,
+          null,
+          createElement("text", { content: "Open" }),
+        ),
+        createElement("text", { content: open ? "owner-open" : "closed" }),
+      );
+    }
+    setup = await testRender(createElement(App), { width: 20, height: 3 });
+    await act(async () => setup?.renderOnce());
+    expect(setup.captureCharFrame()).not.toContain("Open");
+    const recorder = new TestRecorder(setup.renderer);
+
+    recorder.rec();
+    await act(async () => setOpen(true));
+    await act(async () =>
+      setup?.waitForFrame((frame) => frame.includes("Open")),
+    );
+    recorder.stop();
+
+    expect(recorder.recordedFrames.length).toBeGreaterThan(0);
+    expect(
+      recorder.recordedFrames.every(({ frame }) => frame.includes("Open")),
+    ).toBe(true);
+  });
+
+  it("updates props and callbacks without replacing refs or the Store", async () => {
+    const calls: string[] = [];
+    const rootRef = createRef<CollapsibleRootRenderable>();
+    const triggerRef = createRef<CollapsibleTriggerRenderable>();
+    let release: () => void = () => {};
+    let enable: () => void = () => {};
+    let replace: () => void = () => {};
+    function App() {
+      const [open, setOpen] = useState<boolean | undefined>(false);
+      const [disabled, setDisabled] = useState(true);
+      const [newCallback, setNewCallback] = useState(false);
+      release = () => setOpen(undefined);
+      enable = () => setDisabled(false);
+      replace = () => setNewCallback(true);
+      return createElement(
+        Collapsible.Root,
+        {
+          disabled,
+          onOpenChange: (next) =>
+            calls.push(`${newCallback ? "new" : "old"}:${next}`),
+          open,
+          ref: rootRef,
+        },
+        createElement(Collapsible.Trigger, { ref: triggerRef }),
+        createElement(Collapsible.Panel, { keepMounted: true }),
+      );
+    }
+    setup = await testRender(createElement(App), { width: 20, height: 3 });
+    const retainedRoot = rootRef.current;
+    const retainedTrigger = triggerRef.current;
+    const retainedStore = rootRef.current?.store;
+
+    await act(async () => enable());
+    await act(async () => replace());
+    await act(async () => release());
+    await act(async () => triggerRef.current?.press());
+    await act(async () => setup?.waitFor(() => rootRef.current?.open === true));
+
+    expect(calls).toEqual(["new:true"]);
+    expect(rootRef.current).toBe(retainedRoot);
+    expect(triggerRef.current).toBe(retainedTrigger);
+    expect(rootRef.current?.store).toBe(retainedStore);
+  });
+
+  it("exposes actual refs and conditional versus retained Panel lifecycle", async () => {
+    const conditionalRefs: Array<CollapsiblePanelRenderable | null> = [];
+    const retainedRef = createRef<CollapsiblePanelRenderable>();
+    const triggerRef = createRef<CollapsibleTriggerRenderable>();
+    setup = await testRender(
+      createElement(
+        Collapsible.Root,
+        null,
+        createElement(Collapsible.Trigger, { ref: triggerRef }),
+        createElement(Collapsible.Panel, {
+          id: "conditional",
+          ref: (value) => {
+            conditionalRefs.push(value);
+          },
+        }),
+        createElement(Collapsible.Panel, {
+          id: "retained",
+          keepMounted: true,
+          ref: retainedRef,
+        }),
+      ),
+      { width: 20, height: 3 },
+    );
+    const retained = retainedRef.current;
+    expect(retained).toBeInstanceOf(CollapsiblePanelRenderable);
+    expect(retained?.visible).toBe(false);
+    expect(conditionalRefs).toEqual([]);
+
+    await act(async () => triggerRef.current?.press());
+    await act(async () =>
+      setup?.waitFor(() =>
+        Boolean(setup?.renderer.root.findDescendantById("conditional")),
+      ),
+    );
+    expect(retainedRef.current).toBe(retained);
+    expect(retained?.visible).toBe(true);
+    expect(conditionalRefs.at(-1)).toBeInstanceOf(CollapsiblePanelRenderable);
+
+    await act(async () => triggerRef.current?.press());
+    await act(async () =>
+      setup?.waitFor(
+        () =>
+          setup?.renderer.root.findDescendantById("conditional") === undefined,
+      ),
+    );
+    expect(conditionalRefs.at(-1)).toBeNull();
+    expect(retainedRef.current).toBe(retained);
+    expect(retained?.visible).toBe(false);
+  });
+
+  it("is StrictMode-safe, releases subscriptions, and rejects orphan Parts", async () => {
+    const originalSubscribe = CollapsibleStore.prototype.subscribe;
+    let activeSubscriptions = 0;
+    CollapsibleStore.prototype.subscribe = function subscribe(listener) {
+      activeSubscriptions += 1;
+      const unsubscribe = originalSubscribe.call(this, listener);
+      let active = true;
+      return () => {
+        if (!active) return;
+        active = false;
+        activeSubscriptions -= 1;
+        unsubscribe();
+      };
+    };
+    try {
+      setup = await testRender(createElement(StrictMode, null, tree()), {
+        width: 30,
+        height: 5,
+      });
+      expect(setup.renderer.root.findDescendantById("root")).toBeInstanceOf(
+        CollapsibleRootRenderable,
+      );
+      expect(activeSubscriptions).toBeGreaterThan(0);
+      await destroySetup();
+      expect(activeSubscriptions).toBe(0);
+    } finally {
+      CollapsibleStore.prototype.subscribe = originalSubscribe;
+    }
+
+    const error = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      for (const [part, orphan] of [
+        ["Trigger", createElement(Collapsible.Trigger, { key: "trigger" })],
+        ["Panel", createElement(Collapsible.Panel, { key: "panel" })],
+      ] as const) {
+        setup = await testRender(orphan, { width: 10, height: 2 });
+        expect(
+          error.mock.calls.some((call) =>
+            call.some((value) =>
+              String(value).includes(
+                `Collapsible.${part} must be rendered inside Collapsible.Root`,
+              ),
+            ),
+          ),
+        ).toBe(true);
+        await destroySetup();
+      }
+    } finally {
+      error.mockRestore();
+    }
+  });
+});

--- a/packages/react/src/collapsible/index.ts
+++ b/packages/react/src/collapsible/index.ts
@@ -1,0 +1,1 @@
+export * as Collapsible from "./primitive";

--- a/packages/react/src/collapsible/primitive.ts
+++ b/packages/react/src/collapsible/primitive.ts
@@ -1,0 +1,206 @@
+import { extend } from "@opentui/react";
+import {
+  type CollapsibleOpenChangeDetails,
+  type CollapsibleOpenChangeHandler,
+  type CollapsiblePanelOptions,
+  CollapsiblePanelRenderable,
+  type CollapsiblePanelState,
+  type CollapsibleRootOptions,
+  CollapsibleRootRenderable,
+  type CollapsibleState,
+  CollapsibleStore,
+  type CollapsibleTriggerOptions,
+  CollapsibleTriggerRenderable,
+  type CollapsibleTriggerState,
+} from "@tuiparts/core/collapsible";
+import {
+  createContext,
+  createElement,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+  useCallback,
+  useContext,
+  useImperativeHandle,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { useCoreStore } from "../internal/use-core-store";
+
+const tags = {
+  panel: "otui-collapsible-panel",
+  root: "otui-collapsible-root",
+  trigger: "otui-collapsible-trigger",
+} as const;
+
+extend({
+  [tags.panel]: CollapsiblePanelRenderable,
+  [tags.root]: CollapsibleRootRenderable,
+  [tags.trigger]: CollapsibleTriggerRenderable,
+});
+
+const StoreContext = createContext<CollapsibleStore | null>(null);
+
+type RootProps = Omit<CollapsibleRootOptions, "store"> & {
+  children?: ReactNode | ((state: CollapsibleState) => ReactNode);
+  ref?: Ref<CollapsibleRootRenderable>;
+};
+
+type TriggerProps = Omit<CollapsibleTriggerOptions, "store"> & {
+  children?: ReactNode | ((state: CollapsibleTriggerState) => ReactNode);
+  ref?: Ref<CollapsibleTriggerRenderable>;
+};
+
+type PanelProps = Omit<CollapsiblePanelOptions, "store"> & {
+  children?: ReactNode | ((state: CollapsiblePanelState) => ReactNode);
+  keepMounted?: boolean;
+  ref?: Ref<CollapsiblePanelRenderable>;
+};
+
+function useStore(part: string): CollapsibleStore {
+  const store = useContext(StoreContext);
+  if (!store) {
+    throw new Error(
+      `Collapsible.${part} must be rendered inside Collapsible.Root`,
+    );
+  }
+  return store;
+}
+
+/** React Collapsible Root adapter. */
+export function Root({ children, ...props }: Root.Props): ReactElement {
+  const [store, state] = useCoreStore<CollapsibleState, CollapsibleStore>(
+    () => new CollapsibleStore(props),
+  );
+  const content = typeof children === "function" ? children(state) : children;
+  return createElement(
+    StoreContext.Provider,
+    { value: store },
+    createElement(tags.root, { ...props, store }, content),
+  );
+}
+
+/** React Collapsible Trigger adapter. */
+export function Trigger({
+  children,
+  ref,
+  ...props
+}: Trigger.Props): ReactElement {
+  const store = useStore("Trigger");
+  const [trigger, setTrigger] = useState<CollapsibleTriggerRenderable | null>(
+    null,
+  );
+  return createElement(
+    tags.trigger,
+    { ...props, ref: setTrigger, store },
+    trigger
+      ? createElement(TriggerContent, { children, ref, trigger })
+      : undefined,
+  );
+}
+
+function TriggerContent({
+  children,
+  ref,
+  trigger,
+}: {
+  children: Trigger.Props["children"];
+  ref: Ref<CollapsibleTriggerRenderable> | undefined;
+  trigger: CollapsibleTriggerRenderable;
+}): ReactElement {
+  useImperativeHandle(ref, () => trigger, [trigger]);
+  const state = useSyncExternalStore(
+    (listener) => trigger.subscribe(listener),
+    () => trigger.getState(),
+    () => trigger.getState(),
+  );
+  return createElement(
+    StoreContext.Provider,
+    { value: trigger.store },
+    typeof children === "function" ? children(state) : children,
+  );
+}
+
+/** React Collapsible Panel adapter with optional retained mounting. */
+export function Panel({
+  children,
+  keepMounted = false,
+  ref,
+  ...props
+}: Panel.Props): ReactElement | null {
+  const store = useStore("Panel");
+  const rootState = useSyncExternalStore(
+    (listener) => store.subscribe(listener),
+    () => store.state,
+    () => store.state,
+  );
+  if (!keepMounted && !rootState.open) return null;
+  const initialState: CollapsiblePanelState = Object.freeze({
+    open: rootState.open,
+  });
+  return createElement(PanelHost, {
+    ...props,
+    children,
+    initialState,
+    panelRef: ref,
+    store,
+  });
+}
+
+function PanelHost({
+  children,
+  initialState,
+  panelRef,
+  store,
+  ...props
+}: Omit<Panel.Props, "keepMounted" | "ref"> & {
+  initialState: CollapsiblePanelState;
+  panelRef: Ref<CollapsiblePanelRenderable> | undefined;
+  store: CollapsibleStore;
+}): ReactElement {
+  const [panel, setPanel] = useState<CollapsiblePanelRenderable | null>(null);
+  const handlePanelRef = useCallback(
+    (value: CollapsiblePanelRenderable | null) => {
+      setPanel(value);
+      if (typeof panelRef === "function") panelRef(value);
+      else if (panelRef) panelRef.current = value;
+    },
+    [panelRef],
+  );
+  const state = useSyncExternalStore(
+    (listener) =>
+      panel ? panel.subscribe(listener) : store.subscribe(listener),
+    () => panel?.getState() ?? initialState,
+    () => panel?.getState() ?? initialState,
+  );
+  const content = typeof children === "function" ? children(state) : children;
+  return createElement(
+    tags.panel,
+    { ...props, ref: handlePanelRef, store },
+    content,
+  );
+}
+
+Root.displayName = "Collapsible.Root";
+Trigger.displayName = "Collapsible.Trigger";
+Panel.displayName = "Collapsible.Panel";
+
+/** Types scoped to Collapsible.Root. */
+export namespace Root {
+  export type Props = RootProps;
+  export type State = CollapsibleState;
+  export type ChangeDetails = CollapsibleOpenChangeDetails;
+  export type OpenChangeHandler = CollapsibleOpenChangeHandler;
+}
+
+/** Types scoped to Collapsible.Trigger. */
+export namespace Trigger {
+  export type Props = TriggerProps;
+  export type State = CollapsibleTriggerState;
+}
+
+/** Types scoped to Collapsible.Panel. */
+export namespace Panel {
+  export type Props = PanelProps;
+  export type State = CollapsiblePanelState;
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,6 +1,7 @@
 // Re-export components
 export * from "./button";
 export * from "./checkbox";
+export * from "./collapsible";
 export * from "./dialog";
 export * from "./input";
 export * from "./radio";

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src"]
+  "include": ["examples", "src"]
 }

--- a/packages/react/tsdown.config.ts
+++ b/packages/react/tsdown.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     "src/index.ts",
     "src/button/index.tsx",
     "src/checkbox/index.tsx",
+    "src/collapsible/index.ts",
     "src/dialog/index.ts",
     "src/input/index.tsx",
     "src/radio/index.tsx",

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -19,7 +19,7 @@ Peer requirements are `@opentui/core` and `@opentui/solid` `^0.4.3`, with
 ## Primitive example
 
 ```tsx
-import { Button, Checkbox, Input, Radio, RadioGroup, Switch, Textarea, Toggle, ToggleGroup } from "@tuiparts/solid";
+import { Button, Checkbox, Collapsible, Input, Radio, RadioGroup, Switch, Textarea, Toggle, ToggleGroup } from "@tuiparts/solid";
 import { createSignal } from "solid-js";
 
 export function Settings() {
@@ -65,6 +65,7 @@ update controlled primitive state without remounting.
 ```ts
 import { Button } from "@tuiparts/solid/button";
 import { Checkbox } from "@tuiparts/solid/checkbox";
+import { Collapsible } from "@tuiparts/solid/collapsible";
 import { Input } from "@tuiparts/solid/input";
 import { Radio } from "@tuiparts/solid/radio";
 import { RadioGroup } from "@tuiparts/solid/radio-group";

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -60,6 +60,9 @@ export function Settings() {
 Solid props are spread reactively onto the existing Renderable. Signal changes
 update controlled primitive state without remounting.
 
+From a repository checkout, run the focused Collapsible tracer with
+`pnpm --filter @tuiparts/solid demo:collapsible`.
+
 ## Imports
 
 ```ts

--- a/packages/solid/examples/collapsible.tsx
+++ b/packages/solid/examples/collapsible.tsx
@@ -1,0 +1,64 @@
+/** @jsxImportSource @opentui/solid */
+
+import { createCliRenderer } from "@opentui/core";
+import { render } from "@opentui/solid";
+import { createSignal, onMount } from "solid-js";
+import { Collapsible } from "../src/collapsible";
+
+function Demo() {
+  const [open, setOpen] = createSignal(false);
+  const [source, setSource] = createSignal("ready");
+  let trigger: { focus(): void } | undefined;
+
+  onMount(() => trigger?.focus());
+
+  return (
+    <box flexDirection="column" gap={1} padding={2}>
+      <text content="Solid Collapsible Primitive" fg="#FFFFFF" />
+      <text
+        content="Space/Enter toggles the focused Trigger. Ctrl+C quits."
+        fg="#737373"
+      />
+
+      <Collapsible.Root
+        open={open()}
+        onOpenChange={(nextOpen, details) => {
+          setOpen(nextOpen);
+          setSource(details.source);
+        }}
+        flexDirection="column"
+        gap={1}
+      >
+        <Collapsible.Trigger
+          ref={(value) => {
+            trigger = value;
+          }}
+          height={1}
+          paddingX={1}
+        >
+          {(state: Collapsible.Trigger.State) => (
+            <box backgroundColor={state.focused ? "#262626" : "transparent"}>
+              <text
+                content={`${state.open ? "⌄" : "›"} Connection details`}
+                fg={state.focused ? "#FFFFFF" : "#D4D4D4"}
+              />
+            </box>
+          )}
+        </Collapsible.Trigger>
+        <Collapsible.Panel flexDirection="column" paddingLeft={3}>
+          <text content="Region: eu-west" fg="#A3A3A3" />
+          <text content="Transport: ssh" fg="#A3A3A3" />
+        </Collapsible.Panel>
+      </Collapsible.Root>
+
+      <text
+        content={`State: ${open() ? "open" : "closed"} (${source()})`}
+        fg="#60A5FA"
+      />
+    </box>
+  );
+}
+
+const renderer = await createCliRenderer({ exitOnCtrlC: true });
+renderer.setBackgroundColor("#0A0A0A");
+await render(() => <Demo />, renderer);

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -7,6 +7,7 @@
   "sideEffects": [
     "./dist/button/**",
     "./dist/checkbox/**",
+    "./dist/collapsible/**",
     "./dist/dialog/**",
     "./dist/input/**",
     "./dist/radio/**",
@@ -27,6 +28,7 @@
     ".": "./src/index.ts",
     "./button": "./src/button/index.tsx",
     "./checkbox": "./src/checkbox/index.tsx",
+    "./collapsible": "./src/collapsible/index.ts",
     "./dialog": "./src/dialog/index.ts",
     "./input": "./src/input/index.tsx",
     "./radio": "./src/radio/index.tsx",
@@ -52,6 +54,10 @@
       "./checkbox": {
         "types": "./dist/checkbox/index.d.mts",
         "import": "./dist/checkbox/index.mjs"
+      },
+      "./collapsible": {
+        "types": "./dist/collapsible/index.d.mts",
+        "import": "./dist/collapsible/index.mjs"
       },
       "./dialog": {
         "types": "./dist/dialog/index.d.mts",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -115,6 +115,7 @@
   ],
   "scripts": {
     "build": "tsdown",
+    "demo:collapsible": "bun run --preload @opentui/solid/preload examples/collapsible.tsx",
     "test": "bun test --preload @opentui/solid/preload",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist"

--- a/packages/solid/src/collapsible/collapsible-primitive.test.tsx
+++ b/packages/solid/src/collapsible/collapsible-primitive.test.tsx
@@ -1,0 +1,252 @@
+/** @jsxImportSource @opentui/solid */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import type { TestRendererSetup } from "@opentui/core/testing";
+import { testRender } from "@opentui/solid";
+import {
+  CollapsiblePanelRenderable,
+  type CollapsibleRootRenderable,
+  CollapsibleStore,
+  CollapsibleTriggerRenderable,
+} from "@tuiparts/core/collapsible";
+import { createSignal, ErrorBoundary, Show } from "solid-js";
+import { Collapsible } from "./index";
+
+let setup: TestRendererSetup | undefined;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = undefined;
+});
+
+describe("Solid Collapsible", () => {
+  it("provides reactive state and one Core interaction round-trip", async () => {
+    let root: CollapsibleRootRenderable | undefined;
+    let trigger: CollapsibleTriggerRenderable | undefined;
+    const observed: boolean[] = [];
+    setup = await testRender(
+      () => (
+        <Collapsible.Root ref={(value) => (root = value)}>
+          {(state: Collapsible.Root.State) => {
+            observed.push(state.open);
+            return (
+              <>
+                <Collapsible.Trigger
+                  id="trigger"
+                  ref={(value) => (trigger = value)}
+                />
+                <Collapsible.Panel id="panel" />
+              </>
+            );
+          }}
+        </Collapsible.Root>
+      ),
+      { width: 30, height: 5 },
+    );
+    if (!(trigger instanceof CollapsibleTriggerRenderable)) {
+      throw new Error("Expected Collapsible Trigger");
+    }
+
+    if (!root) throw new Error("Expected Collapsible Root");
+    expect(trigger.store).toBe(root.store);
+    trigger.press();
+    await setup.waitFor(() => root?.open === true);
+    expect(observed.at(-1)).toBe(true);
+    expect(setup.renderer.root.findDescendantById("panel")).toBeInstanceOf(
+      CollapsiblePanelRenderable,
+    );
+  });
+
+  it("reactively updates ownership, props, callback, refs, and retained identity", async () => {
+    const calls: string[] = [];
+    let root: CollapsibleRootRenderable | undefined;
+    let trigger: CollapsibleTriggerRenderable | undefined;
+    let panel: CollapsiblePanelRenderable | undefined;
+    let release: () => void = () => {};
+    let enable: () => void = () => {};
+    let replace: () => void = () => {};
+    setup = await testRender(
+      () => {
+        const [open, setOpen] = createSignal<boolean | undefined>(false);
+        const [disabled, setDisabled] = createSignal(true);
+        const [newCallback, setNewCallback] = createSignal(false);
+        release = () => setOpen(undefined);
+        enable = () => setDisabled(false);
+        replace = () => setNewCallback(true);
+        return (
+          <Collapsible.Root
+            disabled={disabled()}
+            onOpenChange={(next) =>
+              calls.push(`${newCallback() ? "new" : "old"}:${next}`)
+            }
+            open={open()}
+            ref={(value) => (root = value)}
+          >
+            <Collapsible.Trigger ref={(value) => (trigger = value)} />
+            <Collapsible.Panel keepMounted ref={(value) => (panel = value)} />
+          </Collapsible.Root>
+        );
+      },
+      { width: 30, height: 5 },
+    );
+    const retainedRoot = root;
+    const retainedTrigger = trigger;
+    const retainedPanel = panel;
+    const retainedStore = root?.store;
+
+    enable();
+    replace();
+    release();
+    await setup.waitFor(() => root?.disabled === false);
+    trigger?.press();
+    await setup.waitFor(() => root?.open === true);
+
+    expect(calls).toEqual(["new:true"]);
+    expect(root).toBe(retainedRoot);
+    expect(trigger).toBe(retainedTrigger);
+    expect(panel).toBe(retainedPanel);
+    expect(root?.store).toBe(retainedStore);
+    expect(panel?.visible).toBe(true);
+
+    setup.renderer.destroy();
+    setup = undefined;
+    expect(root).toBeUndefined();
+    expect(trigger).toBeUndefined();
+    expect(panel).toBeUndefined();
+  });
+
+  it("mounts conditional Panels and retains keepMounted identity", async () => {
+    let trigger: CollapsibleTriggerRenderable | undefined;
+    let conditional: CollapsiblePanelRenderable | undefined;
+    let retained: CollapsiblePanelRenderable | undefined;
+    setup = await testRender(
+      () => (
+        <Collapsible.Root>
+          <Collapsible.Trigger ref={(value) => (trigger = value)} />
+          <Collapsible.Panel
+            id="conditional"
+            ref={(value) => (conditional = value)}
+          />
+          <Collapsible.Panel
+            id="retained"
+            keepMounted
+            ref={(value) => (retained = value)}
+          />
+        </Collapsible.Root>
+      ),
+      { width: 30, height: 5 },
+    );
+    const retainedPanel = retained;
+    expect(conditional).toBeUndefined();
+    expect(retainedPanel).toBeInstanceOf(CollapsiblePanelRenderable);
+    expect(retainedPanel?.visible).toBe(false);
+
+    trigger?.press();
+    await setup.waitFor(
+      () => conditional instanceof CollapsiblePanelRenderable,
+    );
+    expect(retained).toBe(retainedPanel);
+    expect(retainedPanel?.visible).toBe(true);
+
+    trigger?.press();
+    await setup.waitFor(() => conditional === undefined);
+    expect(retained).toBe(retainedPanel);
+    expect(retainedPanel?.visible).toBe(false);
+  });
+
+  it("reconciles dynamic Parts without replacing Root or Store", async () => {
+    let root: CollapsibleRootRenderable | undefined;
+    let trigger: CollapsibleTriggerRenderable | undefined;
+    let toggleTrigger: () => void = () => {};
+    setup = await testRender(
+      () => {
+        const [shown, setShown] = createSignal(true);
+        toggleTrigger = () => setShown((value) => !value);
+        return (
+          <Collapsible.Root ref={(value) => (root = value)}>
+            <Show when={shown()}>
+              <Collapsible.Trigger ref={(value) => (trigger = value)} />
+            </Show>
+            <Collapsible.Panel keepMounted />
+          </Collapsible.Root>
+        );
+      },
+      { width: 30, height: 5 },
+    );
+    const retainedRoot = root;
+    const retainedStore = root?.store;
+    const firstTrigger = trigger;
+
+    toggleTrigger();
+    await setup.waitFor(() => trigger === undefined);
+    toggleTrigger();
+    await setup.waitFor(
+      () =>
+        trigger instanceof CollapsibleTriggerRenderable &&
+        trigger !== firstTrigger,
+    );
+
+    expect(root).toBe(retainedRoot);
+    expect(root?.store).toBe(retainedStore);
+    trigger?.press();
+    expect(root?.open).toBe(true);
+  });
+
+  it("releases subscriptions and reports orphan Part errors", async () => {
+    const originalSubscribe = CollapsibleStore.prototype.subscribe;
+    let activeSubscriptions = 0;
+    CollapsibleStore.prototype.subscribe = function subscribe(listener) {
+      activeSubscriptions += 1;
+      const unsubscribe = originalSubscribe.call(this, listener);
+      let active = true;
+      return () => {
+        if (!active) return;
+        active = false;
+        activeSubscriptions -= 1;
+        unsubscribe();
+      };
+    };
+    try {
+      setup = await testRender(
+        () => (
+          <Collapsible.Root>
+            <Collapsible.Trigger />
+            <Collapsible.Panel keepMounted />
+          </Collapsible.Root>
+        ),
+        { width: 20, height: 3 },
+      );
+      expect(activeSubscriptions).toBeGreaterThan(0);
+      setup.renderer.destroy();
+      setup = undefined;
+      expect(activeSubscriptions).toBe(0);
+    } finally {
+      CollapsibleStore.prototype.subscribe = originalSubscribe;
+    }
+
+    for (const [expected, child] of [
+      ["Collapsible.Trigger", () => <Collapsible.Trigger />],
+      ["Collapsible.Panel", () => <Collapsible.Panel />],
+    ] as const) {
+      let error = "";
+      setup = await testRender(
+        () => (
+          <ErrorBoundary
+            fallback={(value: unknown) => {
+              error = String(value);
+              return null;
+            }}
+          >
+            {child()}
+          </ErrorBoundary>
+        ),
+        { width: 10, height: 2 },
+      );
+      expect(error).toContain(
+        `${expected} must be rendered inside Collapsible.Root`,
+      );
+      setup.renderer.destroy();
+      setup = undefined;
+    }
+  });
+});

--- a/packages/solid/src/collapsible/index.ts
+++ b/packages/solid/src/collapsible/index.ts
@@ -1,0 +1,1 @@
+export * as Collapsible from "./primitive";

--- a/packages/solid/src/collapsible/primitive.tsx
+++ b/packages/solid/src/collapsible/primitive.tsx
@@ -1,0 +1,209 @@
+/** @jsxImportSource @opentui/solid */
+
+import type { JSX } from "@opentui/solid";
+import { useRenderer } from "@opentui/solid";
+import {
+  type CollapsibleOpenChangeDetails,
+  type CollapsibleOpenChangeHandler,
+  type CollapsiblePanelOptions,
+  CollapsiblePanelRenderable,
+  type CollapsiblePanelState,
+  type CollapsibleRootOptions,
+  CollapsibleRootRenderable,
+  type CollapsibleState,
+  CollapsibleStore,
+  type CollapsibleTriggerOptions,
+  CollapsibleTriggerRenderable,
+  type CollapsibleTriggerState,
+} from "@tuiparts/core/collapsible";
+import {
+  createComponent,
+  createContext,
+  createEffect,
+  onCleanup,
+  type Ref,
+  Show,
+  splitProps,
+  untrack,
+  useContext,
+} from "solid-js";
+import {
+  setRenderableRef,
+  spreadRenderableProps,
+} from "../internal/renderable-props";
+import { createRenderableState } from "../internal/renderable-state";
+
+const StoreContext = createContext<CollapsibleStore>();
+
+type RootProps = Omit<CollapsibleRootOptions, "store"> & {
+  children?: JSX.Element | ((state: CollapsibleState) => JSX.Element);
+  ref?: Ref<CollapsibleRootRenderable>;
+};
+
+type TriggerProps = Omit<CollapsibleTriggerOptions, "store"> & {
+  children?: JSX.Element | ((state: CollapsibleTriggerState) => JSX.Element);
+  ref?: Ref<CollapsibleTriggerRenderable>;
+};
+
+type PanelProps = Omit<CollapsiblePanelOptions, "store"> & {
+  children?: JSX.Element | ((state: CollapsiblePanelState) => JSX.Element);
+  keepMounted?: boolean;
+  ref?: Ref<CollapsiblePanelRenderable>;
+};
+
+function useStore(part: string): CollapsibleStore {
+  const store = useContext(StoreContext);
+  if (!store) {
+    throw new Error(
+      `Collapsible.${part} must be rendered inside Collapsible.Root`,
+    );
+  }
+  return store;
+}
+
+/** Solid Collapsible Root adapter. */
+export function Root(props: Root.Props): JSX.Element {
+  const renderer = useRenderer();
+  const store = new CollapsibleStore(untrack(() => props));
+  const state = createRenderableState(store, store.state);
+  const publicState: CollapsibleState = {
+    get disabled() {
+      return state().disabled;
+    },
+    get open() {
+      return state().open;
+    },
+  };
+  const [local, renderableProps] = splitProps(props, [
+    "children",
+    "defaultOpen",
+    "disabled",
+    "onOpenChange",
+    "open",
+    "ref",
+  ]);
+  const element = new CollapsibleRootRenderable(
+    renderer,
+    untrack(() => ({ ...renderableProps, store })),
+  );
+  createEffect(() => {
+    element.disabled = local.disabled;
+    element.onOpenChange = local.onOpenChange;
+    element.open = local.open;
+  });
+  const ref = untrack(() => local.ref);
+  setRenderableRef(ref, element);
+  onCleanup(() => {
+    setRenderableRef(ref, undefined);
+    element.endCoordinationLifetime();
+    store.destroy();
+  });
+  return createComponent(StoreContext.Provider, {
+    value: store,
+    get children() {
+      spreadRenderableProps(element, () => ({ ...renderableProps }));
+      spreadRenderableProps(element, () => {
+        const child = local.children;
+        return {
+          children: typeof child === "function" ? child(publicState) : child,
+        };
+      });
+      return element;
+    },
+  });
+}
+
+/** Solid Collapsible Trigger adapter. */
+export function Trigger(props: Trigger.Props): JSX.Element {
+  const renderer = useRenderer();
+  const store = useStore("Trigger");
+  const [local, renderableProps] = splitProps(props, ["children", "ref"]);
+  const element = new CollapsibleTriggerRenderable(
+    renderer,
+    untrack(() => ({ ...renderableProps, store })),
+  );
+  const state = createRenderableState(element, element.getState());
+  const publicState: CollapsibleTriggerState = {
+    get disabled() {
+      return state().disabled;
+    },
+    get focused() {
+      return state().focused;
+    },
+    get open() {
+      return state().open;
+    },
+  };
+  const ref = untrack(() => local.ref);
+  setRenderableRef(ref, element);
+  onCleanup(() => setRenderableRef(ref, undefined));
+  spreadRenderableProps(element, () => {
+    const child = local.children;
+    return {
+      ...renderableProps,
+      children: typeof child === "function" ? child(publicState) : child,
+    };
+  });
+  return element;
+}
+
+/** Solid Collapsible Panel adapter with optional retained mounting. */
+export function Panel(props: Panel.Props): JSX.Element {
+  const renderer = useRenderer();
+  const store = useStore("Panel");
+  const rootState = createRenderableState(store, store.state);
+  const [local, renderableProps] = splitProps(props, [
+    "children",
+    "keepMounted",
+    "ref",
+  ]);
+  return createComponent(Show, {
+    keyed: true,
+    get when() {
+      return local.keepMounted || rootState().open;
+    },
+    get children() {
+      const element = new CollapsiblePanelRenderable(
+        renderer,
+        untrack(() => ({ ...renderableProps, store })),
+      );
+      const state = createRenderableState(element, element.getState());
+      const publicState: CollapsiblePanelState = {
+        get open() {
+          return state().open;
+        },
+      };
+      const ref = untrack(() => local.ref);
+      setRenderableRef(ref, element);
+      onCleanup(() => setRenderableRef(ref, undefined));
+      spreadRenderableProps(element, () => {
+        const child = local.children;
+        return {
+          ...renderableProps,
+          children: typeof child === "function" ? child(publicState) : child,
+        };
+      });
+      return element;
+    },
+  });
+}
+
+/** Types scoped to Collapsible.Root. */
+export namespace Root {
+  export type Props = RootProps;
+  export type State = CollapsibleState;
+  export type ChangeDetails = CollapsibleOpenChangeDetails;
+  export type OpenChangeHandler = CollapsibleOpenChangeHandler;
+}
+
+/** Types scoped to Collapsible.Trigger. */
+export namespace Trigger {
+  export type Props = TriggerProps;
+  export type State = CollapsibleTriggerState;
+}
+
+/** Types scoped to Collapsible.Panel. */
+export namespace Panel {
+  export type Props = PanelProps;
+  export type State = CollapsiblePanelState;
+}

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -1,6 +1,7 @@
 // Re-export components
 export * from "./button";
 export * from "./checkbox";
+export * from "./collapsible";
 export * from "./dialog";
 export * from "./input";
 export * from "./radio";

--- a/packages/solid/tsconfig.json
+++ b/packages/solid/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["src"]
+  "include": ["examples", "src"]
 }

--- a/packages/solid/tsdown.config.ts
+++ b/packages/solid/tsdown.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     "src/index.ts",
     "src/button/index.tsx",
     "src/checkbox/index.tsx",
+    "src/collapsible/index.ts",
     "src/dialog/index.ts",
     "src/input/index.tsx",
     "src/radio/index.tsx",

--- a/registry.json
+++ b/registry.json
@@ -640,6 +640,69 @@
       "registryDependencies": ["https://tuiparts.sh/r/solid/theme.json"]
     },
     {
+      "name": "core/collapsible",
+      "type": "registry:item",
+      "title": "Collapsible (Core)",
+      "description": "Editable imperative Collapsible Recipe built on the tuiparts.sh packaged Primitive.",
+      "dependencies": ["@tuiparts/core@>=0.0.1 <0.1.0"],
+      "files": [
+        {
+          "path": "registry/collapsible/core.ts",
+          "type": "registry:file",
+          "target": "components/ui/collapsible.ts"
+        }
+      ],
+      "meta": {
+        "framework": "core",
+        "primitiveStatus": "primitive",
+        "sourceOwnership": "consumer",
+        "updateStrategy": "shadcn-add"
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"]
+    },
+    {
+      "name": "react/collapsible",
+      "type": "registry:item",
+      "title": "Collapsible (React)",
+      "description": "Editable React Collapsible Recipe built on the tuiparts.sh packaged Primitive.",
+      "dependencies": ["@tuiparts/react@>=0.0.1 <0.1.0"],
+      "files": [
+        {
+          "path": "registry/collapsible/react.tsx",
+          "type": "registry:file",
+          "target": "components/ui/collapsible.tsx"
+        }
+      ],
+      "meta": {
+        "framework": "react",
+        "primitiveStatus": "primitive",
+        "sourceOwnership": "consumer",
+        "updateStrategy": "shadcn-add"
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/react/theme.json"]
+    },
+    {
+      "name": "solid/collapsible",
+      "type": "registry:item",
+      "title": "Collapsible (Solid)",
+      "description": "Editable Solid Collapsible Recipe built on the tuiparts.sh packaged Primitive.",
+      "dependencies": ["@tuiparts/solid@>=0.0.1 <0.1.0"],
+      "files": [
+        {
+          "path": "registry/collapsible/solid.tsx",
+          "type": "registry:file",
+          "target": "components/ui/collapsible.tsx"
+        }
+      ],
+      "meta": {
+        "framework": "solid",
+        "primitiveStatus": "primitive",
+        "sourceOwnership": "consumer",
+        "updateStrategy": "shadcn-add"
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/solid/theme.json"]
+    },
+    {
       "name": "core/tabs",
       "type": "registry:item",
       "title": "Tabs (Core)",

--- a/registry/README.md
+++ b/registry/README.md
@@ -15,6 +15,7 @@ Each catalog recipe is available as `core/<name>`, `react/<name>`, and
 | Recipe | Packaged behavior | Installed vocabulary |
 | --- | --- | --- |
 | Checkbox | Checkbox Root and Indicator | `Checkbox` |
+| Collapsible | Open state, activation, focus, and Panel lifecycle | `Collapsible`, `CollapsibleTrigger`, `CollapsibleContent` |
 | Switch | Switch Root and Thumb | `Switch` |
 | Button | Button activation primitive | `Button` |
 | RadioGroup/Radio | Radio collection and selectable parts | `RadioGroup`, `RadioGroupItem` |

--- a/registry/collapsible/README.md
+++ b/registry/collapsible/README.md
@@ -1,0 +1,20 @@
+# Collapsible Recipe
+
+These files are the consumer-owned presentation layer for Collapsible. The
+root `registry.json` exposes separate `core/collapsible`, `react/collapsible`,
+and `solid/collapsible` items. Installation copies editable source into
+`components/ui` while open-state ownership and interaction remain in the
+versioned Collapsible Primitive.
+
+- `react.tsx` is the editable React Recipe.
+- `solid.tsx` is the equivalent Solid Recipe.
+- `core.ts` is the imperative Recipe.
+
+Each Recipe chooses a vertical layout, disclosure markers, spacing, colors,
+content indentation, and the labeled Trigger convenience interface. The
+packaged Primitive owns controlled and uncontrolled open state, focus,
+activation, disabled behavior, and Panel lifecycle.
+
+From the workspace root, `pnpm validate:registry --recipe=collapsible`
+installs all three Registry items in isolated consumers, compiles the installed
+source, and runs interaction, presentation, and theme-restyling smoke tests.

--- a/registry/collapsible/core.ts
+++ b/registry/collapsible/core.ts
@@ -1,0 +1,139 @@
+import { type RenderContext, TextRenderable } from "@opentui/core";
+import {
+  type CollapsiblePanelOptions,
+  CollapsiblePanelRenderable,
+  CollapsibleRootRenderable,
+  type CollapsibleTriggerOptions,
+  CollapsibleTriggerRenderable,
+  type CollapsibleTriggerState,
+  type CollapsibleRootOptions as PrimitiveCollapsibleRootOptions,
+} from "@tuiparts/core/collapsible";
+import { type Tokens, theme } from "./theme";
+
+/** Options for the consumer-owned imperative Collapsible Root. */
+export type CollapsibleOptions = Omit<PrimitiveCollapsibleRootOptions, "store">;
+
+/** Options for one labeled imperative Collapsible Trigger. */
+export interface CollapsibleTriggerRecipeOptions
+  extends Omit<CollapsibleTriggerOptions, "store"> {
+  /** Marker shown while closed. */
+  closedMark?: string;
+  /** Trigger label. */
+  label: string;
+  /** Marker shown while open. */
+  openMark?: string;
+}
+
+/** Options for one imperative Collapsible content region. */
+export type CollapsibleContentOptions = Omit<CollapsiblePanelOptions, "store">;
+
+class RecipeTriggerRenderable extends CollapsibleTriggerRenderable {
+  private readonly unsubscribeState: () => void;
+  private readonly unsubscribeTheme: () => void;
+
+  constructor(
+    ctx: RenderContext,
+    options: CollapsibleTriggerRecipeOptions & {
+      store: CollapsibleRootRenderable["store"];
+    },
+  ) {
+    const {
+      closedMark = "›",
+      label: content,
+      openMark = "⌄",
+      ...trigger
+    } = options;
+    super(ctx, {
+      flexDirection: "row",
+      gap: 1,
+      ...trigger,
+    });
+    const mark = new TextRenderable(ctx, { content: closedMark });
+    const label = new TextRenderable(ctx, { content });
+    this.add(mark);
+    this.add(label);
+
+    const apply = (
+      tokens: Readonly<Tokens>,
+      state: CollapsibleTriggerState,
+    ) => {
+      mark.content = state.open ? openMark : closedMark;
+      mark.fg = state.focused ? tokens.colors.focus : tokens.colors.primary;
+      label.fg = state.disabled
+        ? tokens.colors.disabledForeground
+        : tokens.colors.foreground;
+    };
+    apply(theme.get(), this.getState());
+    this.unsubscribeState = this.subscribe((state) =>
+      apply(theme.get(), state),
+    );
+    this.unsubscribeTheme = theme.subscribe(() =>
+      apply(theme.get(), this.getState()),
+    );
+  }
+
+  override endCoordinationLifetime(): void {
+    this.unsubscribeState();
+    this.unsubscribeTheme();
+    super.endCoordinationLifetime();
+  }
+}
+
+class RecipePanelRenderable extends CollapsiblePanelRenderable {
+  private readonly consumerPaddingLeft: CollapsibleContentOptions["paddingLeft"];
+  private readonly unsubscribeTheme: () => void;
+
+  constructor(
+    ctx: RenderContext,
+    options: CollapsibleContentOptions & {
+      store: CollapsibleRootRenderable["store"];
+    },
+  ) {
+    const tokens = theme.get();
+    super(ctx, {
+      paddingLeft: options.paddingLeft ?? tokens.density.comfortablePaddingX,
+      ...options,
+    });
+    this.consumerPaddingLeft = options.paddingLeft;
+    this.unsubscribeTheme = theme.subscribe(() => {
+      if (this.consumerPaddingLeft === undefined) {
+        this.paddingLeft = theme.get().density.comfortablePaddingX;
+      }
+    });
+  }
+
+  override endCoordinationLifetime(): void {
+    this.unsubscribeTheme();
+    super.endCoordinationLifetime();
+  }
+}
+
+/** Creates the imperative Collapsible ownership boundary. */
+export function createCollapsible(
+  ctx: RenderContext,
+  options: CollapsibleOptions = {},
+): CollapsibleRootRenderable {
+  return new CollapsibleRootRenderable(ctx, {
+    flexDirection: "column",
+    gap: 1,
+    ...options,
+  });
+}
+
+/** Creates one labeled imperative Collapsible Trigger. */
+export function createCollapsibleTrigger(
+  ctx: RenderContext,
+  root: CollapsibleRootRenderable,
+  options: CollapsibleTriggerRecipeOptions,
+): CollapsibleTriggerRenderable {
+  return new RecipeTriggerRenderable(ctx, { ...options, store: root.store });
+}
+
+/** Creates one imperative Collapsible content region. */
+export function createCollapsibleContent(
+  ctx: RenderContext,
+  root: CollapsibleRootRenderable,
+  options: CollapsibleContentOptions = {},
+): CollapsiblePanelRenderable {
+  return new RecipePanelRenderable(ctx, { ...options, store: root.store });
+}

--- a/registry/collapsible/react.tsx
+++ b/registry/collapsible/react.tsx
@@ -1,0 +1,69 @@
+/** @jsxImportSource @opentui/react */
+
+import { Collapsible as CollapsiblePrimitive } from "@tuiparts/react/collapsible";
+import { useTheme } from "./use-theme";
+
+/** Props for the consumer-owned React Collapsible Root. */
+export type CollapsibleProps = CollapsiblePrimitive.Root.Props;
+
+/** Props for the consumer-owned labeled React Collapsible Trigger. */
+export interface CollapsibleTriggerProps
+  extends Omit<CollapsiblePrimitive.Trigger.Props, "children"> {
+  /** Marker shown while closed. */
+  closedMark?: string;
+  /** Trigger label. */
+  label: string;
+  /** Marker shown while open. */
+  openMark?: string;
+}
+
+/** Props for the consumer-owned React Collapsible content region. */
+export type CollapsibleContentProps = CollapsiblePrimitive.Panel.Props;
+
+/** Consumer-owned React Collapsible Root layout. */
+export function Collapsible(props: CollapsibleProps) {
+  return (
+    <CollapsiblePrimitive.Root flexDirection="column" gap={1} {...props} />
+  );
+}
+
+/** Consumer-owned labeled React Collapsible Trigger presentation. */
+export function CollapsibleTrigger({
+  closedMark = "›",
+  label,
+  openMark = "⌄",
+  ...props
+}: CollapsibleTriggerProps) {
+  const tokens = useTheme();
+  return (
+    <CollapsiblePrimitive.Trigger flexDirection="row" gap={1} {...props}>
+      {(state) => (
+        <>
+          <text
+            content={state.open ? openMark : closedMark}
+            fg={state.focused ? tokens.colors.focus : tokens.colors.primary}
+          />
+          <text
+            content={label}
+            fg={
+              state.disabled
+                ? tokens.colors.disabledForeground
+                : tokens.colors.foreground
+            }
+          />
+        </>
+      )}
+    </CollapsiblePrimitive.Trigger>
+  );
+}
+
+/** Consumer-owned React Collapsible content composition seam. */
+export function CollapsibleContent(props: CollapsibleContentProps) {
+  const tokens = useTheme();
+  return (
+    <CollapsiblePrimitive.Panel
+      paddingLeft={tokens.density.comfortablePaddingX}
+      {...props}
+    />
+  );
+}

--- a/registry/collapsible/smoke/core.test.ts
+++ b/registry/collapsible/smoke/core.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { parseColor, TextRenderable } from "@opentui/core";
+import {
+  createTestRenderer,
+  type TestRendererSetup,
+} from "@opentui/core/testing";
+import {
+  createCollapsible,
+  createCollapsibleContent,
+  createCollapsibleTrigger,
+} from "./components/ui/collapsible";
+import { theme } from "./components/ui/theme";
+
+let setup: TestRendererSetup | undefined;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = undefined;
+  theme.setActive("terminal");
+});
+
+async function render() {
+  setup = await createTestRenderer({ width: 30, height: 5 });
+  const root = createCollapsible(setup.renderer);
+  const trigger = createCollapsibleTrigger(setup.renderer, root, {
+    label: "Details",
+  });
+  const content = createCollapsibleContent(setup.renderer, root);
+  content.add(new TextRenderable(setup.renderer, { content: "Content" }));
+  root.add(trigger);
+  root.add(content);
+  setup.renderer.root.add(root);
+  await setup.renderOnce();
+  return { content, root, trigger };
+}
+
+describe("installed Core Collapsible Recipe", () => {
+  it("opens through packaged behavior and renders Recipe-owned content", async () => {
+    const { content, root, trigger } = await render();
+    expect(setup?.captureCharFrame()).toContain("› Details");
+    expect(setup?.captureCharFrame()).not.toContain("Content");
+
+    trigger.press();
+    await setup?.renderOnce();
+
+    expect(root.open).toBe(true);
+    expect(content.visible).toBe(true);
+    expect(setup?.captureCharFrame()).toContain("⌄ Details");
+    expect(setup?.captureCharFrame()).toContain("Content");
+  });
+
+  it("restyles retained Recipe presentation from the Theme", async () => {
+    theme.register("smoke", {
+      tokens: { colors: { primary: "#123456" } },
+    });
+    const { content, trigger } = await render();
+    const mark = trigger.getChildren()[0];
+    if (!(mark instanceof TextRenderable)) {
+      throw new Error("Expected Collapsible mark");
+    }
+
+    theme.setActive("smoke");
+    await setup?.renderOnce();
+
+    expect(mark.fg.equals(parseColor("#123456"))).toBe(true);
+    expect(content.visible).toBe(false);
+  });
+});

--- a/registry/collapsible/smoke/react.test.tsx
+++ b/registry/collapsible/smoke/react.test.tsx
@@ -1,0 +1,89 @@
+/** @jsxImportSource @opentui/react */
+
+import { afterEach, expect, test } from "bun:test";
+import { type BaseRenderable, parseColor, TextRenderable } from "@opentui/core";
+import type { TestRendererSetup } from "@opentui/core/testing";
+import { testRender } from "@opentui/react/test-utils";
+import {
+  CollapsiblePanelRenderable,
+  CollapsibleTriggerRenderable,
+} from "@tuiparts/core/collapsible";
+import { act } from "react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./components/ui/collapsible";
+import { theme } from "./components/ui/theme";
+
+let setup: TestRendererSetup | undefined;
+
+function text(node: BaseRenderable): string[] {
+  if (!node.visible) return [];
+  return [
+    ...(node instanceof TextRenderable ? [node.plainText] : []),
+    ...node.getChildren().flatMap(text),
+  ];
+}
+
+afterEach(async () => {
+  await act(async () => setup?.renderer.destroy());
+  setup = undefined;
+  theme.setActive("terminal");
+});
+
+test("installed React Collapsible Recipe runtime smoke", async () => {
+  setup = await testRender(
+    <Collapsible id="root">
+      <CollapsibleTrigger id="trigger" label="Details" />
+      <CollapsibleContent id="content">
+        <text content="Content" />
+      </CollapsibleContent>
+    </Collapsible>,
+    { width: 30, height: 5 },
+  );
+  const trigger = setup.renderer.root.findDescendantById("trigger");
+  if (!(trigger instanceof CollapsibleTriggerRenderable)) {
+    throw new Error("Expected Collapsible Trigger");
+  }
+  expect(text(trigger)).toEqual(["›", "Details"]);
+  expect(setup.renderer.root.findDescendantById("content")).toBeUndefined();
+
+  await act(async () => trigger.press());
+  await setup.waitFor(() =>
+    Boolean(setup?.renderer.root.findDescendantById("content")),
+  );
+
+  expect(text(trigger)).toEqual(["⌄", "Details"]);
+  expect(setup.renderer.root.findDescendantById("content")).toBeInstanceOf(
+    CollapsiblePanelRenderable,
+  );
+});
+
+test("restyles a retained React Collapsible on Theme switch", async () => {
+  theme.register("smoke", {
+    tokens: { colors: { primary: "#123456" } },
+  });
+  setup = await testRender(
+    <Collapsible defaultOpen>
+      <CollapsibleTrigger id="trigger" label="Theme" />
+      <CollapsibleContent keepMounted />
+    </Collapsible>,
+    { width: 30, height: 5 },
+  );
+  const trigger = setup.renderer.root.findDescendantById("trigger");
+  if (!(trigger instanceof CollapsibleTriggerRenderable)) {
+    throw new Error("Expected Collapsible Trigger");
+  }
+  const retained = trigger;
+  const mark = trigger.getChildren()[0];
+  if (!(mark instanceof TextRenderable)) {
+    throw new Error("Expected Collapsible mark");
+  }
+
+  await act(async () => theme.setActive("smoke"));
+  await setup.waitFor(() => mark.fg.equals(parseColor("#123456")));
+
+  expect(setup.renderer.root.findDescendantById("trigger")).toBe(retained);
+  expect(text(trigger)).toEqual(["⌄", "Theme"]);
+});

--- a/registry/collapsible/smoke/solid.test.tsx
+++ b/registry/collapsible/smoke/solid.test.tsx
@@ -1,0 +1,93 @@
+/** @jsxImportSource @opentui/solid */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { type BaseRenderable, parseColor, TextRenderable } from "@opentui/core";
+import type { TestRendererSetup } from "@opentui/core/testing";
+import { testRender } from "@opentui/solid";
+import {
+  CollapsiblePanelRenderable,
+  CollapsibleTriggerRenderable,
+} from "@tuiparts/core/collapsible";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./components/ui/collapsible";
+import { theme } from "./components/ui/theme";
+
+let setup: TestRendererSetup | undefined;
+
+function text(node: BaseRenderable): string[] {
+  if (!node.visible) return [];
+  return [
+    ...(node instanceof TextRenderable ? [node.plainText] : []),
+    ...node.getChildren().flatMap(text),
+  ];
+}
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = undefined;
+  theme.setActive("terminal");
+});
+
+describe("installed Solid Collapsible Recipe", () => {
+  it("opens through packaged behavior and renders Recipe-owned content", async () => {
+    setup = await testRender(
+      () => (
+        <Collapsible id="root">
+          <CollapsibleTrigger id="trigger" label="Details" />
+          <CollapsibleContent id="content">
+            <text content="Content" />
+          </CollapsibleContent>
+        </Collapsible>
+      ),
+      { width: 30, height: 5 },
+    );
+    const trigger = setup.renderer.root.findDescendantById("trigger");
+    if (!(trigger instanceof CollapsibleTriggerRenderable)) {
+      throw new Error("Expected Collapsible Trigger");
+    }
+    expect(text(trigger)).toEqual(["›", "Details"]);
+    expect(setup.renderer.root.findDescendantById("content")).toBeUndefined();
+
+    trigger.press();
+    await setup.waitFor(() =>
+      Boolean(setup?.renderer.root.findDescendantById("content")),
+    );
+
+    expect(text(trigger)).toEqual(["⌄", "Details"]);
+    expect(setup.renderer.root.findDescendantById("content")).toBeInstanceOf(
+      CollapsiblePanelRenderable,
+    );
+  });
+
+  it("restyles a retained Solid Collapsible on Theme switch", async () => {
+    theme.register("smoke", {
+      tokens: { colors: { primary: "#123456" } },
+    });
+    setup = await testRender(
+      () => (
+        <Collapsible defaultOpen>
+          <CollapsibleTrigger id="trigger" label="Theme" />
+          <CollapsibleContent keepMounted />
+        </Collapsible>
+      ),
+      { width: 30, height: 5 },
+    );
+    const trigger = setup.renderer.root.findDescendantById("trigger");
+    if (!(trigger instanceof CollapsibleTriggerRenderable)) {
+      throw new Error("Expected Collapsible Trigger");
+    }
+    const mark = trigger.getChildren()[0];
+    if (!(mark instanceof TextRenderable)) {
+      throw new Error("Expected Collapsible mark");
+    }
+
+    theme.setActive("smoke");
+    await setup.waitFor(() => mark.fg.equals(parseColor("#123456")));
+
+    expect(setup.renderer.root.findDescendantById("trigger")).toBe(trigger);
+    expect(text(trigger)).toEqual(["⌄", "Theme"]);
+  });
+});

--- a/registry/collapsible/solid.tsx
+++ b/registry/collapsible/solid.tsx
@@ -1,0 +1,72 @@
+/** @jsxImportSource @opentui/solid */
+
+import { Collapsible as CollapsiblePrimitive } from "@tuiparts/solid/collapsible";
+import { splitProps } from "solid-js";
+import { useTheme } from "./use-theme";
+
+/** Props for the consumer-owned Solid Collapsible Root. */
+export type CollapsibleProps = CollapsiblePrimitive.Root.Props;
+
+/** Props for the consumer-owned labeled Solid Collapsible Trigger. */
+export interface CollapsibleTriggerProps
+  extends Omit<CollapsiblePrimitive.Trigger.Props, "children"> {
+  /** Marker shown while closed. */
+  closedMark?: string;
+  /** Trigger label. */
+  label: string;
+  /** Marker shown while open. */
+  openMark?: string;
+}
+
+/** Props for the consumer-owned Solid Collapsible content region. */
+export type CollapsibleContentProps = CollapsiblePrimitive.Panel.Props;
+
+/** Consumer-owned Solid Collapsible Root layout. */
+export function Collapsible(props: CollapsibleProps) {
+  return (
+    <CollapsiblePrimitive.Root flexDirection="column" gap={1} {...props} />
+  );
+}
+
+/** Consumer-owned labeled Solid Collapsible Trigger presentation. */
+export function CollapsibleTrigger(props: CollapsibleTriggerProps) {
+  const [recipe, trigger] = splitProps(props, [
+    "closedMark",
+    "label",
+    "openMark",
+  ]);
+  const tokens = useTheme();
+  return (
+    <CollapsiblePrimitive.Trigger flexDirection="row" gap={1} {...trigger}>
+      {(state: CollapsiblePrimitive.Trigger.State) => (
+        <>
+          <text
+            content={
+              state.open ? (recipe.openMark ?? "⌄") : (recipe.closedMark ?? "›")
+            }
+            fg={state.focused ? tokens().colors.focus : tokens().colors.primary}
+          />
+          <text
+            content={recipe.label}
+            fg={
+              state.disabled
+                ? tokens().colors.disabledForeground
+                : tokens().colors.foreground
+            }
+          />
+        </>
+      )}
+    </CollapsiblePrimitive.Trigger>
+  );
+}
+
+/** Consumer-owned Solid Collapsible content composition seam. */
+export function CollapsibleContent(props: CollapsibleContentProps) {
+  const tokens = useTheme();
+  return (
+    <CollapsiblePrimitive.Panel
+      paddingLeft={tokens().density.comfortablePaddingX}
+      {...props}
+    />
+  );
+}

--- a/registry/tsconfig.core.json
+++ b/registry/tsconfig.core.json
@@ -6,6 +6,7 @@
       "badge",
       "button",
       "checkbox",
+      "collapsible",
       "dialog",
       "input",
       "radio-group",

--- a/registry/tsconfig.react.json
+++ b/registry/tsconfig.react.json
@@ -8,6 +8,7 @@
       "badge",
       "button",
       "checkbox",
+      "collapsible",
       "dialog",
       "input",
       "radio-group",

--- a/registry/tsconfig.solid.json
+++ b/registry/tsconfig.solid.json
@@ -8,6 +8,7 @@
       "badge",
       "button",
       "checkbox",
+      "collapsible",
       "dialog",
       "input",
       "radio-group",

--- a/scripts/validate-packages.mjs
+++ b/scripts/validate-packages.mjs
@@ -96,6 +96,7 @@ try {
     "@tuiparts/core",
     "@tuiparts/core/button",
     "@tuiparts/core/checkbox",
+    "@tuiparts/core/collapsible",
     "@tuiparts/core/dialog",
     "@tuiparts/core/input",
     "@tuiparts/core/radio",
@@ -108,6 +109,7 @@ try {
     "@tuiparts/react",
     "@tuiparts/react/button",
     "@tuiparts/react/checkbox",
+    "@tuiparts/react/collapsible",
     "@tuiparts/react/dialog",
     "@tuiparts/react/input",
     "@tuiparts/react/radio",
@@ -120,6 +122,7 @@ try {
     "@tuiparts/solid",
     "@tuiparts/solid/button",
     "@tuiparts/solid/checkbox",
+    "@tuiparts/solid/collapsible",
     "@tuiparts/solid/dialog",
     "@tuiparts/solid/input",
     "@tuiparts/solid/radio",
@@ -158,6 +161,11 @@ try {
     `import { createTestRenderer } from "@opentui/core/testing";
 import { CheckboxRootRenderable } from "@tuiparts/core/checkbox";
 import {
+  CollapsiblePanelRenderable,
+  CollapsibleRootRenderable,
+  CollapsibleTriggerRenderable,
+} from "@tuiparts/core/collapsible";
+import {
   TabsListRenderable,
   TabsPanelRenderable,
   TabsRootRenderable,
@@ -170,6 +178,20 @@ try {
   setup.renderer.root.add(checkbox);
   checkbox.press();
   if (!checkbox.checked) throw new Error("Compiled Checkbox did not activate");
+
+  const collapsible = new CollapsibleRootRenderable(setup.renderer);
+  const trigger = new CollapsibleTriggerRenderable(setup.renderer, {
+    store: collapsible.store,
+  });
+  const panel = new CollapsiblePanelRenderable(setup.renderer, {
+    store: collapsible.store,
+  });
+  collapsible.add(trigger);
+  collapsible.add(panel);
+  setup.renderer.root.add(collapsible);
+  trigger.press();
+  if (!collapsible.open || !panel.visible)
+    throw new Error("Compiled Collapsible did not open its Panel");
 
   const root = new TabsRootRenderable(setup.renderer);
   const list = new TabsListRenderable(setup.renderer, { store: root.store });

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -75,6 +75,7 @@ const frameworks = {
 };
 const recipes = [
   "checkbox",
+  "collapsible",
   "switch",
   "button",
   "badge",
@@ -89,6 +90,7 @@ const recipes = [
 ];
 const catalogRecipes = [
   "checkbox",
+  "collapsible",
   "switch",
   "button",
   "badge",


### PR DESCRIPTION
## Summary

- add the framework-neutral Collapsible Store and Root, Trigger, and Panel Renderables
- add React and Solid compound adapters with controlled/uncontrolled ownership, real Renderable refs, conditional Panels, and `keepMounted`
- add consumer-owned Core, React, and Solid Registry Recipes with installed-consumer smoke coverage
- add package exports, packed-consumer checks, Primitive/Catalog documentation, contract evidence, and a linked Foundation changeset
- add runnable Core, React, and Solid terminal tracers

## Design

The public anatomy follows Base UI's `Collapsible.Root`, `Collapsible.Trigger`, and `Collapsible.Panel`, while keeping the contract terminal-native. Core owns open state, activation, focus, disablement, and lifecycle. Recipes own labels, disclosure glyphs, layout, and styling. Browser-only transition, DOM event, native-button, page-search, CSS, and propagation APIs are intentionally omitted.

## Validation

- `pnpm validate:foundation`
- `pnpm validate:registry --recipe=collapsible`
- `pnpm docs:build`
- manually exercised the Core, React, and Solid terminal tracers through closed/open keyboard interaction
