### PR TITLE
Add CheckboxGroup primitive and recipe

### DIFF
--- a/.changeset/bright-checkboxes-gather.md
+++ b/.changeset/bright-checkboxes-gather.md
@@ -1,0 +1,9 @@
+---
+"@tuiparts/core": patch
+"@tuiparts/react": patch
+"@tuiparts/solid": patch
+---
+
+Add CheckboxGroup with array-valued checked ownership, optional Checkbox.Root adoption, effective disablement, dynamic registration, and orientation-aware roving focus.
+
+Checkbox state now exposes `tabbable`, and checked-change callbacks receive immutable terminal press details. Checkbox no longer shares its internal Store implementation with Switch so grouped collection policy remains isolated from Switch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,8 +46,8 @@ tuiparts/
 | Symbol | Type | Location | Role |
 |--------|------|----------|------|
 | `PressableRenderable` | Class | `packages/core/src/internal/pressable.ts` | Shared activation behavior (guards, pointer model, focus sync) for all press-activated Roots (ADR-0007) |
-| `CheckboxRootRenderable` | Class | `packages/core/src/checkbox/primitive.ts` | Checkbox Root adapter over shared checked state and activation |
-| `CheckedStore` | Class | `packages/core/src/internal/checked-store.ts` | Shared checked-state behavior for Checkbox and Switch |
+| `CheckboxRootRenderable` | Class | `packages/core/src/checkbox/primitive.ts` | Standalone checked state or optional CheckboxGroup adoption over shared activation |
+| `CheckedStore` | Class | `packages/core/src/internal/checked-store.ts` | Internal checked-state behavior retained by Switch |
 | `toast` | Object | `packages/toast/src/state.ts` | Global toast API (toast.success, toast.error, etc.) |
 | `ToasterRenderable` | Class | `packages/toast/src/renderables/toaster.ts` | Container that manages toast notifications |
 | `DialogStore` | Class | `packages/core/src/dialog/primitive.ts` | Dialog state and layer coordination |

--- a/PRIMITIVES_AND_RECIPES.md
+++ b/PRIMITIVES_AND_RECIPES.md
@@ -96,14 +96,15 @@ Checkbox follows the primitive contract:
   `Checkbox.Indicator` parts.
 - The example recipes choose a mark, label, spacing, and colors in editable
   source.
-- Core callers pass the owning Root to Indicator; React and Solid hide that
+- Core callers pass the owning Store to Indicator; React and Solid hide that
   owner wiring through Root context.
 - An authored Indicator remains mounted and reflects checked state through
   Renderable visibility in Core, React, and Solid. Recipes may omit the part
   entirely when they do not need a visual indicator.
 - `press()`, Enter, Space, and an uncancelled primary-button release request the
-  same boolean change. Checkbox does not expose input-source details because no
-  Checkbox behavior currently depends on the activation source.
+  same boolean change and report frozen terminal press details.
+- A standalone Root owns checked state. Inside CheckboxGroup, the same Root
+  adopts array-valued group ownership through a required unique `value`.
 - Composition uses Root children, Indicator children, readonly state callbacks,
   and Renderable refs. It does not support arbitrary Root or Indicator
   replacement.
@@ -120,6 +121,32 @@ Reference implementations:
 `Checkbox` is the canonical React and Solid primitive export. Editable starter
 recipes reserve one terminal cell for `mark`; applications that need a wide
 mark own the corresponding recipe layout change.
+
+## CheckboxGroup primitive
+
+CheckboxGroup coordinates existing Checkbox Roots rather than introducing a
+second Item identity:
+
+- `CheckboxGroupStore` owns readonly checked values, registration, rendered
+  order, effective disablement, orientation, and roving focus.
+- `CheckboxGroupRenderable` is the non-focusable collection boundary.
+- Existing `CheckboxRootRenderable` registers with an optional group Store;
+  its Indicator continues to consume the same Checkbox Store.
+- React and Solid expose direct `CheckboxGroup` functions and supply ownership
+  to nested `Checkbox.Root` through context.
+- Arrow keys and Home/End move focus without changing checked values. Checkbox
+  activation updates the group value and invokes local then group callbacks.
+- Recipes may expose `CheckboxGroupItem` as labeled presentation, but it is not
+  a packaged Part.
+
+Reference implementations:
+
+- `packages/core/src/checkbox-group/primitive.ts`
+- `packages/react/src/checkbox-group/primitive.ts`
+- `packages/solid/src/checkbox-group/primitive.ts`
+- `registry/checkbox-group/core.ts`
+- `registry/checkbox-group/react.tsx`
+- `registry/checkbox-group/solid.tsx`
 
 ## Collapsible Primitive
 

--- a/PRIMITIVE_CONTRACT.md
+++ b/PRIMITIVE_CONTRACT.md
@@ -253,12 +253,17 @@ public base class.
 - Button, Checkbox, Switch, and Toggle expose attachable Core Stores. Their React
   adapters create Stores automatically and omit `store` from public framework
   Props. Passive Indicator and Thumb parts receive the owning Store in
-  Core and use private context wiring in framework adapters.
+  Core and use private context wiring in framework adapters. Checkbox and
+  Toggle Stores may adopt their matching group Store before construction.
 - Input and Textarea preserve OpenTUI-owned editing state and have no Store.
 - RadioGroup retains a public Store for dynamic item identity, selection,
   roving focus, ordering, and registration independent of any one Renderable.
 - Dialog retains a public Store for portal, layer, dismissal, nesting, and
   focus-restoration coordination across renderer-root ownership.
+- CheckboxGroup retains a public Store for array-valued checked ownership,
+  dynamic Checkbox identity, rendered order, and roving focus. A standalone
+  Checkbox owns checked state; a grouped Checkbox reads its group through the
+  same Checkbox Store before Renderable construction.
 - ToggleGroup retains a public Store for optional single or multiple
   selection, dynamic Toggle identity, rendered order, and roving focus. A
   standalone Toggle owns pressed state; a grouped Toggle reads selection from
@@ -406,10 +411,12 @@ architectural decision is recorded.
 
 The shipped primitives establish these precedents:
 
-- Checkbox proves primitive-owned toggle state, Root activation, a
-  retained state-reflecting Indicator, equivalent activation paths, and
-  editable glyph ownership. Its boolean change callback does not expose cause
-  details because no Checkbox behavior depends on cause.
+- Checkbox proves standalone checked ownership, optional CheckboxGroup
+  adoption, Root activation, a retained state-reflecting Indicator, equivalent
+  activation paths, immutable terminal change details, and editable glyph
+  ownership. CheckboxGroup proves array-valued checked ownership, dynamic
+  registration, rendered-order roving focus, and lifecycle repair without an
+  artificial Item Part.
 - RadioGroup proves dynamic collection registration, retained Radio identity,
   rendered-order navigation, disabled and unavailable skipping, roving focus,
   and Radio-local state. Actual focus remains owned by RadioRootRenderable.

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ version together.
 | [`@tuiparts/react`](./packages/react) | React compound-part Adapter |
 | [`@tuiparts/solid`](./packages/solid) | Solid compound-part Adapter |
 
-Accordion, Button, Checkbox, Collapsible, Dialog, Input, RadioGroup, Switch,
-Tabs, Textarea, Toggle, and ToggleGroup expose Primitive
+Accordion, Button, Checkbox, CheckboxGroup, Collapsible, Dialog, Input,
+RadioGroup, Switch, Tabs, Textarea, Toggle, and ToggleGroup expose Primitive
 behavior. Badge is distributed only as editable Recipe source because it has
 no reusable interaction behavior.
 
@@ -82,7 +82,8 @@ See the package READMEs for exact peer ranges and usage.
 ## Install a Recipe
 
 Recipes are installed with the official shadcn CLI and become
-application-owned source. The Catalog contains Accordion, Checkbox, Collapsible, Switch, Button,
+application-owned source. The Catalog contains Accordion, Checkbox,
+CheckboxGroup, Collapsible, Switch, Button,
 RadioGroup/Radio, Tabs, Toggle, ToggleGroup, Input, Textarea, Dialog, and Badge
 Recipes; every Recipe targets exactly one Adapter, so choose the `core/*`,
 `react/*`, or `solid/*` item for your runtime:

--- a/apps/www/docs/catalog/checkbox-group.mdx
+++ b/apps/www/docs/catalog/checkbox-group.mdx
@@ -1,0 +1,109 @@
+---
+title: Checkbox Group
+description: Present related checked choices with editable labels, marks, and layout.
+---
+
+Checkbox Group presents related choices that may be checked independently. The
+packaged Primitives own array-valued checked state, Checkbox registration,
+activation, disablement, and rendered-order focus. The Recipe adds labeled
+Checkbox presentation, marks, theme colors, and row or column layout.
+
+Use standalone [Checkbox](/catalog/checkbox) when another control does not need
+to share value ownership or keyboard navigation.
+
+## Install
+
+<CodeGroup>
+
+```bash React
+pnpm dlx shadcn@4.13.0 add @tuiparts/react/checkbox-group
+```
+
+```bash Solid
+pnpm dlx shadcn@4.13.0 add @tuiparts/solid/checkbox-group
+```
+
+```bash Core
+pnpm dlx shadcn@4.13.0 add @tuiparts/core/checkbox-group
+```
+
+</CodeGroup>
+
+## Use the Recipe
+
+### React and Solid
+
+```tsx
+import {
+  CheckboxGroup,
+  CheckboxGroupItem,
+} from "./components/ui/checkbox-group";
+
+<CheckboxGroup defaultValue={["email"]}>
+  <CheckboxGroupItem value="email" label="Email notifications" />
+  <CheckboxGroupItem value="sms" label="SMS notifications" />
+  <CheckboxGroupItem value="product" label="Product announcements" />
+</CheckboxGroup>;
+```
+
+Use `value` with `onValueChange` when the application owns the checked array.
+
+### Core
+
+```ts
+import {
+  createCheckboxGroup,
+  createCheckboxGroupItem,
+} from "./components/ui/checkbox-group";
+
+const notifications = createCheckboxGroup(ctx, {
+  defaultValue: ["email"],
+});
+
+notifications.add(
+  createCheckboxGroupItem(ctx, notifications.store, {
+    value: "email",
+    label: "Email notifications",
+  }),
+);
+notifications.add(
+  createCheckboxGroupItem(ctx, notifications.store, {
+    value: "sms",
+    label: "SMS notifications",
+  }),
+);
+
+parent.add(notifications);
+```
+
+Each Core item receives the group's Store explicitly.
+
+## Customize the Recipe
+
+The copied source owns group layout, spacing, the one-cell mark, labels, and
+tone mapping. It uses a column by default and switches to a row when
+`orientation="horizontal"`. Edit the source for wider marks, descriptions,
+section decoration, or another item convenience API. Shared glyph and color
+defaults come from the [Theme Recipe](/theming).
+
+## Behavior
+
+Every Item may be checked independently. Arrow keys move the group's single
+roving focus along its orientation; Home and End move to the first and last
+available Item. Enter, Return, Space, pointer activation, and `press()` toggle
+the focused Item without affecting the others. Disabled and unavailable Items
+are skipped.
+
+Detailed ownership, callbacks, focus repair, and lifecycle rules belong to the
+[Checkbox Group Primitive](/primitives/checkbox-group).
+
+## Recipe API
+
+`CheckboxGroup` forwards packaged group props and adds row or column starter
+layout from `orientation`.
+
+`CheckboxGroupItem` requires `value` and `label`. React and Solid accept `mark`
+and `tone="accent" | "success"` while forwarding the remaining Checkbox Root
+props. Core accepts `value`, `label`, `mark`, and `disabled`. The Item name is
+Recipe convenience; packaged behavior uses the existing `Checkbox.Root`
+rather than introducing a separate Item Part.

--- a/apps/www/docs/catalog/checkbox.mdx
+++ b/apps/www/docs/catalog/checkbox.mdx
@@ -8,8 +8,10 @@ submitted together. The packaged Primitive owns checked state, activation,
 focus, and Indicator visibility. The Recipe adds a one-cell mark, label, and
 tone.
 
-Use [Switch](/catalog/switch) for a setting that takes effect immediately and
-[Radio Group](/catalog/radio-group) for mutually exclusive options.
+Use [Checkbox Group](/catalog/checkbox-group) when related Checkboxes should
+share array ownership and keyboard navigation, [Switch](/catalog/switch) for a
+setting that takes effect immediately, and [Radio Group](/catalog/radio-group)
+for mutually exclusive options.
 
 ## Install
 

--- a/apps/www/docs/catalog/index.mdx
+++ b/apps/www/docs/catalog/index.mdx
@@ -21,7 +21,8 @@ install commands alongside usage and customization guidance.
 | [Button](/catalog/button) | An action without retained on/off state | Activation, pressed state, focus, disabled behavior |
 | [Input](/catalog/input) | Single-line text entry | OpenTUI-native editing and events |
 | [Textarea](/catalog/textarea) | Multiline text entry | OpenTUI-native EditBuffer and events |
-| [Checkbox](/catalog/checkbox) | An independent choice commonly submitted with others | Checked state and activation |
+| [Checkbox](/catalog/checkbox) | An independent checked choice | Checked state and activation |
+| [Checkbox Group](/catalog/checkbox-group) | Related choices checked independently with one keyboard stop | Array ownership and roving focus |
 | [Switch](/catalog/switch) | A setting that takes effect immediately | Checked state and activation |
 | [Toggle](/catalog/toggle) | An action whose pressed state remains visible | Pressed state and activation |
 | [Toggle Group](/catalog/toggle-group) | Related toggles sharing one keyboard stop | Selection and roving focus |

--- a/apps/www/docs/catalog/meta.ts
+++ b/apps/www/docs/catalog/meta.ts
@@ -9,6 +9,7 @@ export default defineMeta({
     "input",
     "textarea",
     "checkbox",
+    "checkbox-group",
     "switch",
     "toggle",
     "toggle-group",

--- a/apps/www/docs/primitives/checkbox-group.mdx
+++ b/apps/www/docs/primitives/checkbox-group.mdx
@@ -1,0 +1,166 @@
+---
+title: Checkbox Group
+description: Coordinate existing Checkbox Roots through shared checked values and roving focus.
+---
+
+Checkbox Group coordinates existing [Checkbox](/primitives/checkbox)
+Primitives. It owns array-valued checked state, registration, effective
+disablement, orientation-aware focus navigation, and lifecycle without choosing
+marks, labels, layout, or colors.
+
+## Install
+
+Install the [package for your runtime](/primitives#install), then import both
+the `checkbox-group` and `checkbox` subpaths:
+
+```ts
+import { CheckboxGroup } from "@tuiparts/react/checkbox-group";
+import { Checkbox } from "@tuiparts/react/checkbox";
+```
+
+Replace `react` with `solid`. Core exports the matching Store and Renderables
+from `@tuiparts/core/checkbox-group` and `@tuiparts/core/checkbox`.
+
+## Anatomy
+
+| Part | Responsibility |
+| --- | --- |
+| `CheckboxGroup` | Owns checked values, collection registration, orientation, and roving focus. |
+| `Checkbox.Root` | Registers through a unique `value`, reflects group ownership, and owns activation and focus. |
+| `Checkbox.Indicator` | Reflects its Checkbox Root's effective checked state. |
+
+There is no packaged `CheckboxGroup.Item`. A grouped Checkbox is the same
+Root/Indicator Primitive used independently; Catalog Recipes may add the
+`CheckboxGroupItem` convenience name for labeled presentation.
+
+## Compose the Primitive
+
+<CodeGroup>
+
+```tsx React
+import { Checkbox } from "@tuiparts/react/checkbox";
+import { CheckboxGroup } from "@tuiparts/react/checkbox-group";
+
+<CheckboxGroup defaultValue={["email"]} flexDirection="column" gap={1}>
+  {[
+    ["email", "Email notifications"],
+    ["sms", "SMS notifications"],
+  ].map(([value, label]) => (
+    <Checkbox.Root key={value} value={value} flexDirection="row" gap={1}>
+      <Checkbox.Indicator>
+        <text content="✓" />
+      </Checkbox.Indicator>
+      <text content={label} />
+    </Checkbox.Root>
+  ))}
+</CheckboxGroup>;
+```
+
+```tsx Solid
+import { Checkbox } from "@tuiparts/solid/checkbox";
+import { CheckboxGroup } from "@tuiparts/solid/checkbox-group";
+
+<CheckboxGroup defaultValue={["email"]} flexDirection="column" gap={1}>
+  <Checkbox.Root value="email" flexDirection="row" gap={1}>
+    <Checkbox.Indicator>
+      <text content="✓" />
+    </Checkbox.Indicator>
+    <text content="Email notifications" />
+  </Checkbox.Root>
+  <Checkbox.Root value="sms" flexDirection="row" gap={1}>
+    <Checkbox.Indicator>
+      <text content="✓" />
+    </Checkbox.Indicator>
+    <text content="SMS notifications" />
+  </Checkbox.Root>
+</CheckboxGroup>;
+```
+
+```ts Core
+import { TextRenderable } from "@opentui/core";
+import {
+  CheckboxIndicatorRenderable,
+  CheckboxRootRenderable,
+} from "@tuiparts/core/checkbox";
+import { CheckboxGroupRenderable } from "@tuiparts/core/checkbox-group";
+
+const group = new CheckboxGroupRenderable(ctx, {
+  defaultValue: ["email"],
+  flexDirection: "column",
+  gap: 1,
+});
+const email = new CheckboxRootRenderable(ctx, {
+  group: group.store,
+  value: "email",
+});
+const indicator = new CheckboxIndicatorRenderable(ctx, {
+  store: email.store,
+});
+indicator.add(new TextRenderable(ctx, { content: "✓" }));
+email.add(indicator);
+email.add(new TextRenderable(ctx, { content: "Email notifications" }));
+group.add(email);
+parent.add(group);
+```
+
+</CodeGroup>
+
+Framework adapters supply the group Store through context. Core callers pass
+`group.store` to every grouped Checkbox. Runnable tracers are available for
+[Core](https://github.com/tuiparts/tuiparts/blob/main/packages/core/examples/checkbox-group.ts),
+[React](https://github.com/tuiparts/tuiparts/blob/main/packages/react/examples/checkbox-group.tsx),
+and [Solid](https://github.com/tuiparts/tuiparts/blob/main/packages/solid/examples/checkbox-group.tsx).
+
+## State ownership
+
+Use group `value` with `onValueChange` for controlled ownership, or
+`defaultValue` for uncontrolled initial state. Values are deduplicated while
+preserving order. A grouped Checkbox requires a unique `value`; its standalone
+`checked` and `defaultChecked` props do not override group ownership.
+
+Group state contains `value`, `disabled`, and `orientation`; orientation
+is vertical by default. Checkbox state
+contains effective `checked` and `disabled`, actual `focused`, and whether it
+is the current roving `tabbable` item. A grouped activation commits
+uncontrolled state before calling the Checkbox's `onCheckedChange`, then the
+group's `onValueChange`; both receive the same frozen terminal press details.
+
+Renaming a checked uncontrolled Checkbox repairs its value without callbacks.
+Unmounting preserves the checked value so a conditional Checkbox with the same
+identity recovers state when it returns. Controlled values may name no live
+Checkbox.
+
+## Interaction
+
+| Input | Behavior |
+| --- | --- |
+| `Left` / `Right` | Moves focus in a horizontal group. |
+| `Up` / `Down` | Moves focus in a vertical group. |
+| `Home` / `End` | Moves focus to the first or last available Checkbox. |
+| `Enter`, `Return`, or `Space` | Toggles the focused Checkbox. |
+| Primary-pointer release or `press()` | Focuses when applicable and makes the same semantic request. |
+
+Focus movement does not change checked values. Navigation wraps by default;
+set `loopFocus={false}` to stop at collection edges. Root and Checkbox-local
+disablement combine. Disabled, hidden, detached, and destroyed Checkboxes are
+skipped, and losing the focused member repairs focus to the nearest available
+Checkbox.
+
+## API reference
+
+| Surface | API |
+| --- | --- |
+| React and Solid | `CheckboxGroup`, `Checkbox.Root`, `Checkbox.Indicator`, and scoped types |
+| Core | `CheckboxGroupRenderable`, `CheckboxGroupStore`, Checkbox Renderables and Store |
+| Group options | `value`, `defaultValue`, `onValueChange`, `orientation`, `loopFocus`, `disabled` |
+| Checkbox membership | Unique `value`; Core additionally receives `group` |
+| Group state | `value`, `disabled`, `orientation` |
+| Checkbox state | `checked`, `disabled`, `focused`, `tabbable` |
+| Change details | `source` is `"imperative"`, `"keyboard"`, or `"pointer"` |
+
+Framework refs target the actual matching Group, Root, or Indicator Renderable.
+
+## Start with the Recipe
+
+The editable [Checkbox Group Recipe](/catalog/checkbox-group) adds labeled
+Items, marks, theme colors, spacing, and orientation-aware starter layout.

--- a/apps/www/docs/primitives/checkbox.mdx
+++ b/apps/www/docs/primitives/checkbox.mdx
@@ -3,10 +3,11 @@ title: Checkbox
 description: Compose an independent checked choice from Root and Indicator Parts.
 ---
 
-Checkbox owns an independent boolean choice without prescribing its mark,
-label, layout, or colors. Use [Switch](/primitives/switch) for a setting that
-takes effect immediately and [Radio Group](/primitives/radio-group) for one
-selection from a set.
+Checkbox owns an independent boolean choice or adopts
+[Checkbox Group](/primitives/checkbox-group) array ownership without
+prescribing its mark, label, layout, or colors. Use
+[Switch](/primitives/switch) for a setting that takes effect immediately and
+[Radio Group](/primitives/radio-group) for one selection from a set.
 
 ## Install
 
@@ -87,13 +88,15 @@ the Root's Store explicitly.
 
 ## State ownership
 
-Use `checked` with `onCheckedChange` for controlled ownership, or
-`defaultChecked` for uncontrolled initial state. Readonly state contains
-`checked`, `disabled`, and `focused`.
+Use `checked` with `onCheckedChange` for controlled standalone ownership, or
+`defaultChecked` for uncontrolled initial state. Inside CheckboxGroup, Root
+requires `value` and derives checked state from the group instead. Readonly
+state contains `checked`, `disabled`, `focused`, and `tabbable`.
 
-Core callers can construct a `CheckboxStore` separately or use the Store
-created by `CheckboxRootRenderable`. An Indicator may be reattached to another
-Checkbox Store by assigning its `store` property.
+`onCheckedChange` receives the requested boolean and frozen terminal press
+details. Core callers can construct a `CheckboxStore` separately or use the
+Store created by `CheckboxRootRenderable`. An Indicator may be reattached to
+another Checkbox Store by assigning its `store` property.
 
 ## Interaction
 
@@ -111,8 +114,8 @@ Disabled Checkboxes reject focus and activation.
 | --- | --- |
 | React and Solid | `Checkbox.Root`, `Checkbox.Indicator` and their scoped `Props` types |
 | Core | `CheckboxRootRenderable`, `CheckboxIndicatorRenderable`, `CheckboxStore` |
-| State | `checked`, `disabled`, `focused` |
-| Root options | `checked`, `defaultChecked`, `disabled`, `onCheckedChange` |
+| State | `checked`, `disabled`, `focused`, `tabbable` |
+| Root options | `checked`, `defaultChecked`, `disabled`, `onCheckedChange`; grouped Root also requires `value` |
 | Indicator options | Native Box properties; Core additionally requires `store` |
 
 Framework refs target the matching Root or Indicator Renderable.

--- a/apps/www/docs/primitives/index.mdx
+++ b/apps/www/docs/primitives/index.mdx
@@ -44,7 +44,8 @@ Import each Primitive from its package subpath, such as
 | [Button](/primitives/button) | An action without retained on/off state | `Button` |
 | [Input](/primitives/input) | Single-line text entry | `Input` |
 | [Textarea](/primitives/textarea) | Multiline text entry | `Textarea` |
-| [Checkbox](/primitives/checkbox) | An independent checked choice | `Root`, `Indicator` |
+| [Checkbox](/primitives/checkbox) | A standalone or grouped checked choice | `Root`, `Indicator` |
+| [Checkbox Group](/primitives/checkbox-group) | Related Checkboxes with shared values and roving focus | `CheckboxGroup`, `Checkbox.Root`, `Checkbox.Indicator` |
 | [Switch](/primitives/switch) | A checked setting | `Root`, `Thumb` |
 | [Toggle](/primitives/toggle) | An action with retained pressed state | `Toggle` |
 | [Toggle Group](/primitives/toggle-group) | Related Toggles with shared selection and roving focus | `ToggleGroup`, `Toggle` |

--- a/apps/www/docs/primitives/meta.ts
+++ b/apps/www/docs/primitives/meta.ts
@@ -9,6 +9,7 @@ export default defineMeta({
     "input",
     "textarea",
     "checkbox",
+    "checkbox-group",
     "switch",
     "toggle",
     "toggle-group",

--- a/docs/adr/0008-checked-store-collapse.md
+++ b/docs/adr/0008-checked-store-collapse.md
@@ -4,6 +4,10 @@ status: accepted
 
 # Collapse Checkbox and Switch onto one internal CheckedStore
 
+> **Historical scope:** ADR-0012 supersedes Checkbox's participation in this
+> shared implementation after grouped ownership made its state behavior
+> materially different. `CheckedStore` continues to back Switch.
+
 Checkbox and Switch expose distinct public Stores, but their state behavior is
 identical. Their facades duplicated every operation while their Root
 Renderables duplicated the same Store plumbing.

--- a/docs/adr/0012-checkbox-optionally-adopts-checkbox-group.md
+++ b/docs/adr/0012-checkbox-optionally-adopts-checkbox-group.md
@@ -1,0 +1,55 @@
+---
+status: accepted
+---
+
+# Let Checkbox optionally adopt CheckboxGroup ownership
+
+## Context
+
+Checkbox is a complete two-state control on its own. CheckboxGroup adds shared
+array-valued ownership and rendered-order focus navigation to the same control.
+This matches Toggle's optional ToggleGroup adoption and differs from Radio,
+whose selection meaning is incomplete without RadioGroup.
+
+Checkbox and Switch previously shared the complete internal `CheckedStore`
+implementation under ADR-0008. Group adoption gives Checkbox additional value
+identity, registration, availability, roving-focus, and callback-detail
+semantics that Switch does not have. Keeping the former inheritance would
+force CheckboxGroup policy into Switch's state owner or introduce a shallow
+translation layer.
+
+## Decision
+
+Existing `Checkbox.Root` optionally adopts CheckboxGroup ownership. A
+standalone Checkbox owns controlled or uncontrolled checked state. A grouped
+Checkbox requires a unique string `value`; CheckboxGroup owns a readonly array
+of checked values. There is no `CheckboxGroup.Item` Part.
+
+Grouped Checkbox activation invokes its local checked-change callback before
+the group value-change callback. The same frozen Pressable details object is
+reported to both callbacks. Arrow keys and Home/End move roving focus without
+changing checked state. Group orientation determines the arrow axis and
+navigation wraps unless `loopFocus` is false.
+
+React creates the Checkbox Store before host construction with the optional
+group Store from context. Solid constructs the same Core ownership directly.
+Framework consumers never pass Stores.
+
+Checkbox now owns its Store implementation following Toggle's proven optional
+adoption shape. ADR-0008 remains authoritative for Switch and records the
+historical shared checked-state extraction, but its claim that Checkbox and
+Switch have identical state behavior is superseded by this decision. Shared
+Pressable behavior remains the common activation seam.
+
+## Consequences
+
+- Checkbox remains independently useful and keeps its Root/Indicator anatomy.
+- CheckboxGroup does not introduce an artificial Item Part or second checkbox
+  identity.
+- Grouped initial state is authoritative before framework children render.
+- `Checkbox.Root.State` gains truthful `tabbable` state and checked callbacks
+  gain Pressable change details.
+- Checkbox and Switch no longer share `CheckedStore`; this intentional
+  pre-release break avoids leaking collection policy into Switch.
+- CheckboxGroup reuses the established internal roving-collection engine, not a
+  new universal collection abstraction.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,10 +24,11 @@ specification. ADR-0009 defines how to deliver that contract completely.
 | [0005](0005-toggle-optionally-adopts-toggle-group.md) | Toggle may own standalone state or adopt ToggleGroup ownership. |
 | [0006](0006-theming-ships-as-registry-source.md) | Theming is consumer-owned Registry source, not a packaged Primitive. |
 | [0007](0007-pressable-base-class.md) | Press-activated Roots share one internal gesture implementation and contract. |
-| [0008](0008-checked-store-collapse.md) | Checkbox and Switch share one internal checked-state implementation while retaining distinct public Stores. |
+| [0008](0008-checked-store-collapse.md) | Historical Checkbox/Switch checked-state extraction; ADR-0012 supersedes Checkbox participation while Switch retains the internal Store. |
 | [0009](0009-deliver-primitives-and-recipes-as-complete-verticals.md) | Every Primitive or Recipe ships as a complete, validated vertical with tests owned by the correct seam. |
 | [0010](0010-public-root-state-hooks.md) | Framework adapters expose public Root state through `useRootState()` hooks; Recipes read Primitive state from them instead of Recipe-local contexts. |
 | [0011](0011-serve-recipes-as-universal-registry-items.md) | Recipes are universal shadcn Registry items that install without framework detection or `components.json`. |
+| [0012](0012-checkbox-optionally-adopts-checkbox-group.md) | Checkbox optionally adopts CheckboxGroup array ownership and roving focus without introducing an Item Part. |
 
 ADR numbering is intentionally append-only and may contain gaps. ADR-0003 was
 a temporary RC decision superseded by ADR-0004 before the first stable

--- a/docs/primitive-contracts/checkbox-group.md
+++ b/docs/primitive-contracts/checkbox-group.md
@@ -1,0 +1,78 @@
+# CheckboxGroup Primitive contract
+
+## Product boundary
+
+CheckboxGroup is a packaged Primitive because array-valued checked ownership,
+dynamic Checkbox registration, effective disablement, rendered-order focus
+navigation, and lifecycle coordination would otherwise be repeated by
+applications. Core owns that behavior. Recipes own labels, marks, layout,
+spacing, colors, and grouping decoration.
+
+## Public shape and ownership
+
+- `CheckboxGroup` is a single non-focusable Root that owns or adopts one
+  `CheckboxGroupStore` in Core. React and Solid create the Store and hide it
+  from framework consumers.
+- Existing `Checkbox.Root` remains a complete standalone control. Inside a
+  framework CheckboxGroup it optionally adopts that group's Store; Core callers
+  pass the group Store explicitly.
+- A grouped Checkbox requires a unique string `value`. Its existing Indicator
+  continues to consume the same Checkbox Store and needs no group-specific
+  Part.
+- There is no packaged `CheckboxGroup.Item`: it would duplicate Checkbox.Root's
+  behavior ownership rather than represent an independently composable node.
+
+A standalone Checkbox owns controlled or uncontrolled `checked` state. A
+grouped Checkbox derives `checked` from whether CheckboxGroup `value` contains
+its identity; its `checked` and `defaultChecked` inputs do not override group
+ownership. CheckboxGroup `value` and `defaultValue` are readonly string arrays,
+deduplicated while preserving order.
+
+CheckboxGroup state is a frozen, referentially stable snapshot containing
+`value`, `disabled`, and `orientation`. Grouped Checkbox state contains
+`checked`, effective `disabled`, actual `focused`, and `tabbable`. Root
+disablement combines with Checkbox-local disablement.
+
+A grouped activation commits an uncontrolled group request before invoking the
+Checkbox `onCheckedChange(checked, details)` callback and then
+`CheckboxGroup.onValueChange(value, details)`. A controlled request reports
+intent without committing. Details are frozen shared press details with
+`source: "imperative" | "keyboard" | "pointer"`. Passing `undefined` after a
+controlled group value releases control at the last observed value. Disabled,
+unavailable, or no-op requests do not notify.
+
+## Interaction and lifecycle
+
+Enter, Return, Space, primary-pointer release, and `press()` toggle the focused
+Checkbox through the same Pressable contract. Orientation selects Left/Right
+or Up/Down rendered-order navigation; Home and End move to the first and last
+available Checkbox. Navigation does not change checked state and wraps by
+default; `loopFocus={false}` stops at collection edges.
+
+Only the roving tab stop is focusable in a live group. Navigation skips local
+or Root-disabled, hidden, detached, and destroyed Checkboxes. Disabling,
+hiding, removing, or destroying the focused Checkbox repairs focus to the
+nearest available member. Removing the group permanently ends descendant group
+registrations.
+
+Live grouped values must be unique. Renaming a checked uncontrolled Checkbox
+repairs the group value without callbacks. Removing a Checkbox preserves the
+value, matching ToggleGroup: conditional controls recover their checked state
+when the same value remounts, while controlled values may always name no live
+Checkbox. Teardown is idempotent and released registrations cannot reactivate.
+
+## Conformance evidence plan
+
+| Surface | Applicability and evidence |
+| --- | --- |
+| Core | CheckboxGroup Store/Renderable and grouped Checkbox tests own normalization, controlled/uncontrolled ownership, callback order/details, registration, uniqueness, rename, activation, effective disablement, rendered-order navigation, availability, focus repair, and teardown. Existing standalone Checkbox coverage remains green. |
+| React | Real renderer tests own authoritative first render, controlled prop removal, callback replacement, context adoption, actual refs, retained Store/Renderable identities, conditional registration, Strict Mode, and subscription teardown. |
+| Solid | The adapter matrix is repeated through signals and Solid's real renderer, including reactive group and Checkbox props and cleanup. |
+| Registry | Core, React, and Solid Recipes install in isolated consumers, compile, toggle one Item, render Recipe-owned labels and marks, and react to Theme changes. |
+| Packed | All three `/checkbox-group` subpaths participate in declaration, runtime-import, and representative packed-consumer checks. |
+| Terminal | Runnable Core, React, and Solid tracers verify rendered focus movement and activation across multiple grouped Checkboxes. |
+
+Conditional Parts, overlay coordination, unavailable-selection fallback, and
+public Root state hooks are N/A. Checkbox Indicator retains its existing Core
+visibility and framework mounting contract; no Recipe requires supplementary
+Root state outside Checkbox render callbacks.

--- a/docs/primitives-and-recipes.md
+++ b/docs/primitives-and-recipes.md
@@ -83,7 +83,8 @@ root.add(indicator);
 | --- | --- | --- | --- | --- |
 | Button | `Button` | disabled, focused, pressed | `press()`; Enter/Return, Space, primary pointer | `ButtonRenderable` |
 | Accordion | `Accordion.Root`, `Accordion.Item`, `Accordion.Trigger`, `Accordion.Panel` | Root values and policy; Item open/disabled; Trigger focus | Up/Down/Home/End focus; Trigger `press()`; Enter/Return, Space, primary pointer | matching Part Renderable |
-| Checkbox | `Checkbox.Root`, `Checkbox.Indicator` | checked, disabled, focused | `press()`; Enter/Return, Space, primary pointer | matching Root or Indicator Renderable |
+| Checkbox | `Checkbox.Root`, `Checkbox.Indicator` | checked, disabled, focused, tabbable | `press()`; Enter/Return, Space, primary pointer | matching Root or Indicator Renderable |
+| CheckboxGroup | `CheckboxGroup` containing `Checkbox.Root` | value, disabled, orientation; Checkbox local state | arrows and Home/End move focus; Checkbox activation toggles membership | matching Group, Root, or Indicator Renderable |
 | Collapsible | `Collapsible.Root`, `Collapsible.Trigger`, `Collapsible.Panel` | open, disabled; Trigger focus | Trigger `press()`; Enter/Return, Space, primary pointer | matching Part Renderable |
 | Switch | `Switch.Root`, `Switch.Thumb` | checked, disabled, focused | `press()`; Enter/Return, Space, primary pointer | matching Root or Thumb Renderable |
 | Tabs | `Tabs.Root`, `Tabs.List`, `Tabs.Tab`, `Tabs.Panel` | value, activation mode, orientation; Tab/Panel local state | arrows and Home/End move focus; Tab activation selects | matching Part Renderable |
@@ -94,8 +95,8 @@ root.add(indicator);
 | Textarea | `Textarea` | OpenTUI-owned `EditBuffer` | native multiline editing; content, cursor, submit callbacks | `TextareaRenderable` |
 | Dialog | `Dialog.Root`, Trigger, Portal, Backdrop, Popup, Title, Description, Close | open | Trigger/Close `press()`; Enter/Return/Space, Escape, Tab containment | matching Dialog part Renderable |
 
-Accordion, Checkbox, Collapsible, Switch, Toggle, ToggleGroup, Tabs,
-RadioGroup, and Dialog support controlled and uncontrolled
+Accordion, Checkbox, CheckboxGroup, Collapsible, Switch, Toggle, ToggleGroup,
+Tabs, RadioGroup, and Dialog support controlled and uncontrolled
 ownership. RadioGroup owns one collection value and every Radio must belong to
 a group.
 Input and Textarea deliberately preserve OpenTUI's native mutable editing
@@ -123,6 +124,7 @@ The starter catalog provides `core/*`, `react/*`, and `solid/*` items for:
 
 - Accordion
 - Checkbox
+- CheckboxGroup
 - Collapsible
 - Switch
 - Button

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -25,6 +25,7 @@ colors, spacing, glyphs, labels, or fixed visual trees.
 | Accordion | `AccordionStore` | `AccordionRootRenderable`, `AccordionItemRenderable`, `AccordionTriggerRenderable`, `AccordionPanelRenderable` |
 | Button | `ButtonStore` | `ButtonRenderable` |
 | Checkbox | `CheckboxStore` | `CheckboxRootRenderable`, `CheckboxIndicatorRenderable` |
+| CheckboxGroup | `CheckboxGroupStore` | `CheckboxGroupRenderable` containing existing Checkbox Roots |
 | Collapsible | `CollapsibleStore` | `CollapsibleRootRenderable`, `CollapsibleTriggerRenderable`, `CollapsiblePanelRenderable` |
 | Dialog | `DialogStore` | Root, Trigger, Portal, Backdrop, Popup, Title, Description, Close Renderables |
 | Input | OpenTUI-native state | `InputRenderable` |
@@ -57,8 +58,9 @@ parent.add(root);
 Consumer-owned recipes assemble these parts with native OpenTUI Renderables and
 choose their presentation. Installable examples live under `registry/`.
 
-From a repository checkout, run the focused Accordion or Collapsible tracer
-with `pnpm --filter @tuiparts/core demo:accordion` or
+From a repository checkout, run a focused tracer with
+`pnpm --filter @tuiparts/core demo:checkbox-group`,
+`pnpm --filter @tuiparts/core demo:accordion`, or
 `pnpm --filter @tuiparts/core demo:collapsible`.
 
 ## Input

--- a/packages/core/examples/checkbox-group.ts
+++ b/packages/core/examples/checkbox-group.ts
@@ -1,0 +1,84 @@
+import {
+  BoxRenderable,
+  createCliRenderer,
+  TextRenderable,
+} from "@opentui/core";
+import {
+  CheckboxIndicatorRenderable,
+  CheckboxRootRenderable,
+  type CheckboxState,
+} from "../src/checkbox";
+import { CheckboxGroupRenderable } from "../src/checkbox-group";
+
+const renderer = await createCliRenderer({ exitOnCtrlC: true });
+renderer.setBackgroundColor("#0A0A0A");
+
+const screen = new BoxRenderable(renderer, {
+  flexDirection: "column",
+  gap: 1,
+  padding: 2,
+});
+screen.add(
+  new TextRenderable(renderer, {
+    content: "Core CheckboxGroup Primitive",
+    fg: "#FFFFFF",
+  }),
+);
+screen.add(
+  new TextRenderable(renderer, {
+    content: "Up/Down moves focus. Space/Enter toggles. Ctrl+C quits.",
+    fg: "#737373",
+  }),
+);
+
+const status = new TextRenderable(renderer, {
+  content: "Checked: email",
+  fg: "#60A5FA",
+});
+const group = new CheckboxGroupRenderable(renderer, {
+  defaultValue: ["email"],
+  flexDirection: "column",
+  onValueChange: (value, details) => {
+    status.content =
+      `Checked: ${value.join(", ") || "none"} (${details.source})`;
+  },
+});
+
+function createItem(value: string, labelText: string) {
+  const item = new CheckboxRootRenderable(renderer, {
+    flexDirection: "row",
+    gap: 1,
+    group: group.store,
+    height: 1,
+    paddingX: 1,
+    value,
+  });
+  const markCell = new BoxRenderable(renderer, { width: 1 });
+  const indicator = new CheckboxIndicatorRenderable(renderer, {
+    store: item.store,
+  });
+  indicator.add(
+    new TextRenderable(renderer, { content: "✓", fg: "#60A5FA" }),
+  );
+  markCell.add(indicator);
+  const label = new TextRenderable(renderer, { content: labelText });
+  item.add(markCell);
+  item.add(label);
+  const sync = (state: CheckboxState) => {
+    item.backgroundColor = state.focused ? "#262626" : "transparent";
+    label.fg = state.focused ? "#FFFFFF" : "#D4D4D4";
+  };
+  sync(item.getState());
+  item.subscribe(sync);
+  group.add(item);
+  return item;
+}
+
+const first = createItem("email", "Email notifications");
+createItem("sms", "SMS notifications");
+createItem("product", "Product announcements");
+
+screen.add(group);
+screen.add(status);
+renderer.root.add(screen);
+first.focus();

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "./accordion": "./src/accordion/index.ts",
     "./button": "./src/button/index.ts",
     "./checkbox": "./src/checkbox/index.ts",
+    "./checkbox-group": "./src/checkbox-group/index.ts",
     "./collapsible": "./src/collapsible/index.ts",
     "./dialog": "./src/dialog/index.ts",
     "./input": "./src/input/index.ts",
@@ -46,6 +47,10 @@
       "./checkbox": {
         "types": "./dist/checkbox/index.d.mts",
         "import": "./dist/checkbox/index.mjs"
+      },
+      "./checkbox-group": {
+        "types": "./dist/checkbox-group/index.d.mts",
+        "import": "./dist/checkbox-group/index.mjs"
       },
       "./collapsible": {
         "types": "./dist/collapsible/index.d.mts",
@@ -108,6 +113,7 @@
   "scripts": {
     "build": "tsdown",
     "demo:accordion": "bun run examples/accordion.ts",
+    "demo:checkbox-group": "bun run examples/checkbox-group.ts",
     "demo:collapsible": "bun run examples/collapsible.ts",
     "test": "bun test",
     "typecheck": "tsc --noEmit",

--- a/packages/core/src/checkbox-group/checkbox-group-primitive.test.ts
+++ b/packages/core/src/checkbox-group/checkbox-group-primitive.test.ts
@@ -1,0 +1,439 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { KeyEvent } from "@opentui/core";
+import {
+  createTestRenderer,
+  type TestRendererSetup,
+} from "@opentui/core/testing";
+import { CheckboxRootRenderable, CheckboxStore } from "../checkbox";
+import { CheckboxGroupRenderable, CheckboxGroupStore } from "./index";
+
+let setup: TestRendererSetup | undefined;
+
+function keyEvent(name: string): KeyEvent {
+  // SAFETY: These focused tests exercise only fields read by Checkbox's key
+  // handler; OpenTUI supplies the remaining KeyEvent fields at runtime.
+  return { name } as KeyEvent;
+}
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = undefined;
+});
+
+describe("CheckboxGroup primitive", () => {
+  it("supports array selection without duplicate values", async () => {
+    setup = await createTestRenderer({ width: 20, height: 4 });
+    const group = new CheckboxGroupRenderable(setup.renderer, {
+      defaultValue: ["bold"],
+    });
+    const bold = new CheckboxRootRenderable(setup.renderer, {
+      group: group.store,
+      value: "bold",
+    });
+    const italic = new CheckboxRootRenderable(setup.renderer, {
+      group: group.store,
+      value: "italic",
+    });
+    group.add(bold);
+    group.add(italic);
+    setup.renderer.root.add(group);
+    await setup.renderOnce();
+
+    italic.press();
+    expect(group.value).toEqual(["bold", "italic"]);
+    bold.press();
+    expect(group.value).toEqual(["italic"]);
+  });
+
+  it("repairs an uncontrolled checked value when a Checkbox is renamed", async () => {
+    setup = await createTestRenderer({ width: 20, height: 4 });
+    const group = new CheckboxGroupRenderable(setup.renderer, {
+      defaultValue: ["old"],
+    });
+    const item = new CheckboxRootRenderable(setup.renderer, {
+      group: group.store,
+      value: "old",
+    });
+    group.add(item);
+
+    item.value = "new";
+
+    expect(group.value).toEqual(["new"]);
+    expect(item.checked).toBe(true);
+  });
+
+  it("does not notify for unavailable grouped activation", async () => {
+    setup = await createTestRenderer({ width: 20, height: 4 });
+    const itemChanges: boolean[] = [];
+    const groupChanges: Array<readonly string[]> = [];
+    const group = new CheckboxGroupRenderable(setup.renderer, {
+      onValueChange: (value) => groupChanges.push(value),
+    });
+    const item = new CheckboxRootRenderable(setup.renderer, {
+      group: group.store,
+      onCheckedChange: (checked) => itemChanges.push(checked),
+      value: "alpha",
+    });
+    group.add(item);
+    setup.renderer.root.add(group);
+    await setup.renderOnce();
+    item.visible = false;
+
+    item.press();
+
+    expect(itemChanges).toEqual([]);
+    expect(groupChanges).toEqual([]);
+    expect(group.value).toEqual([]);
+  });
+
+  it("commits grouped state before item and group callbacks in order", async () => {
+    setup = await createTestRenderer({ width: 20, height: 4 });
+    const events: string[] = [];
+    const details: object[] = [];
+    const group = new CheckboxGroupRenderable(setup.renderer, {
+      onValueChange: (_value, changeDetails) => {
+        events.push(`group:${group.value.join(",")}`);
+        details.push(changeDetails);
+      },
+    });
+    const item = new CheckboxRootRenderable(setup.renderer, {
+      group: group.store,
+      onCheckedChange: (_checked, changeDetails) => {
+        events.push(`item:${group.value.join(",")}`);
+        details.push(changeDetails);
+      },
+      value: "alpha",
+    });
+    group.add(item);
+    setup.renderer.root.add(group);
+
+    item.press();
+
+    expect(events).toEqual(["item:alpha", "group:alpha"]);
+    expect(details[0]).toBe(details[1]);
+    expect(details.every(Object.isFrozen)).toBe(true);
+  });
+
+  it("reports imperative, keyboard, and pointer details once per activation", async () => {
+    setup = await createTestRenderer({ width: 20, height: 4 });
+    const sources: string[] = [];
+    const group = new CheckboxGroupRenderable(setup.renderer, {
+      onValueChange: (_value, details) => sources.push(details.source),
+    });
+    const item = new CheckboxRootRenderable(setup.renderer, {
+      group: group.store,
+      height: 1,
+      value: "alpha",
+      width: 5,
+    });
+    group.add(item);
+    setup.renderer.root.add(group);
+    await setup.renderOnce();
+
+    item.press();
+    expect(item.handleKeyPress(keyEvent("space"))).toBe(true);
+    await setup.mockMouse.click(0, 0);
+
+    expect(sources).toEqual(["imperative", "keyboard", "pointer"]);
+  });
+
+  it("moves roving focus without changing selection and honors orientation", async () => {
+    setup = await createTestRenderer({ width: 20, height: 4 });
+    const group = new CheckboxGroupRenderable(setup.renderer, {
+      defaultValue: ["alpha"],
+      flexDirection: "column",
+      orientation: "vertical",
+    });
+    const alpha = new CheckboxRootRenderable(setup.renderer, {
+      group: group.store,
+      value: "alpha",
+    });
+    const beta = new CheckboxRootRenderable(setup.renderer, {
+      group: group.store,
+      value: "beta",
+    });
+    group.add(alpha);
+    group.add(beta);
+    setup.renderer.root.add(group);
+    await setup.renderOnce();
+
+    alpha.focus();
+    expect(alpha.handleKeyPress(keyEvent("right"))).toBe(false);
+    expect(alpha.handleKeyPress(keyEvent("down"))).toBe(true);
+    expect(beta.focused).toBe(true);
+    expect(group.value).toEqual(["alpha"]);
+    expect(beta.checked).toBe(false);
+  });
+
+  it("skips disabled items, honors boundaries, and falls back when hidden", async () => {
+    setup = await createTestRenderer({ width: 30, height: 4 });
+    const group = new CheckboxGroupRenderable(setup.renderer, {
+      loopFocus: false,
+      orientation: "horizontal",
+    });
+    const alpha = new CheckboxRootRenderable(setup.renderer, {
+      group: group.store,
+      value: "alpha",
+    });
+    const beta = new CheckboxRootRenderable(setup.renderer, {
+      disabled: true,
+      group: group.store,
+      value: "beta",
+    });
+    const gamma = new CheckboxRootRenderable(setup.renderer, {
+      group: group.store,
+      value: "gamma",
+    });
+    group.add(alpha);
+    group.add(beta);
+    group.add(gamma);
+    setup.renderer.root.add(group);
+    await setup.renderOnce();
+
+    alpha.focus();
+    expect(alpha.handleKeyPress(keyEvent("right"))).toBe(true);
+    expect(gamma.focused).toBe(true);
+    expect(gamma.handleKeyPress(keyEvent("right"))).toBe(false);
+    expect(gamma.handleKeyPress(keyEvent("home"))).toBe(true);
+    expect(alpha.focused).toBe(true);
+    expect(alpha.handleKeyPress(keyEvent("end"))).toBe(true);
+    expect(gamma.focused).toBe(true);
+
+    gamma.visible = false;
+    expect(alpha.focused).toBe(true);
+    expect(beta.focused).toBe(false);
+  });
+
+  it("keeps the roving tab stop focusable without requiring focus first", async () => {
+    setup = await createTestRenderer({ width: 20, height: 4 });
+    const group = new CheckboxGroupRenderable(setup.renderer);
+    const alpha = new CheckboxRootRenderable(setup.renderer, {
+      group: group.store,
+      value: "alpha",
+    });
+    const beta = new CheckboxRootRenderable(setup.renderer, {
+      group: group.store,
+      value: "beta",
+    });
+    group.add(alpha);
+    group.add(beta);
+    setup.renderer.root.add(group);
+    await setup.renderOnce();
+
+    expect(alpha.focusable).toBe(true);
+    expect(beta.focusable).toBe(false);
+
+    alpha.disabled = true;
+    expect(alpha.focusable).toBe(false);
+    expect(beta.focusable).toBe(true);
+    expect(beta.getState().tabbable).toBe(true);
+  });
+
+  it("unregisters destroyed Checkboxes exactly once", async () => {
+    setup = await createTestRenderer({ width: 20, height: 4 });
+    const renderer = setup.renderer;
+    const group = new CheckboxGroupRenderable(renderer, {
+      defaultValue: ["alpha"],
+    });
+    const item = new CheckboxRootRenderable(renderer, {
+      group: group.store,
+      value: "alpha",
+    });
+    group.add(item);
+    setup.renderer.root.add(group);
+    await setup.renderOnce();
+
+    group.remove(item);
+    item.destroy();
+
+    const replacement = new CheckboxRootRenderable(renderer, {
+      group: group.store,
+      value: "alpha",
+    });
+    group.add(replacement);
+    expect(replacement.value).toBe("alpha");
+    expect(replacement.checked).toBe(true);
+  });
+
+  it("permanently ends descendant coordination when the group is removed", async () => {
+    setup = await createTestRenderer({ width: 20, height: 4 });
+    const renderer = setup.renderer;
+    const store = new CheckboxGroupStore({ defaultValue: ["alpha"] });
+    const group = new CheckboxGroupRenderable(renderer, { store });
+    const item = new CheckboxRootRenderable(setup.renderer, {
+      group: store,
+      value: "alpha",
+    });
+    group.add(item);
+    setup.renderer.root.add(group);
+    await setup.renderOnce();
+    expect(
+      () =>
+        new CheckboxGroupRenderable(renderer, {
+          disabled: true,
+          store,
+        }),
+    ).toThrow(
+      "CheckboxGroup Store may be adopted by only one live CheckboxGroup",
+    );
+    expect(store.state.disabled).toBe(false);
+
+    setup.renderer.root.remove(group);
+    item.press();
+    expect(store.state.value).toEqual(["alpha"]);
+
+    const replacement = new CheckboxGroupRenderable(renderer, { store });
+    const replacementItem = new CheckboxRootRenderable(renderer, {
+      group: store,
+      value: "alpha",
+    });
+    replacement.add(replacementItem);
+    setup.renderer.root.add(replacement);
+    await setup.renderOnce();
+    replacementItem.press();
+    expect(store.state.value).toEqual([]);
+  });
+
+  it("reports controlled intent without committing it and releases control", () => {
+    const values: Array<readonly string[]> = [];
+    const store = new CheckboxGroupStore({
+      value: ["alpha", "beta"],
+      onValueChange: (value) => values.push(value),
+    });
+    const alpha = store.registerItem("alpha", { focus: () => {} });
+    store.registerItem("beta", { focus: () => {} });
+
+    expect(store.state.value).toEqual(["alpha", "beta"]);
+    expect(Object.isFrozen(store.state)).toBe(true);
+    expect(Object.isFrozen(store.state.value)).toBe(true);
+
+    store.requestToggle(alpha.key, false, { source: "imperative" });
+    expect(values).toEqual([["beta"]]);
+    expect(store.state.value).toEqual(["alpha", "beta"]);
+
+    store.setValue(["beta"]);
+    store.setValue(undefined);
+    store.requestToggle(alpha.key, true, { source: "imperative" });
+    expect(store.state.value).toEqual(["beta", "alpha"]);
+    expect(values).toEqual([["beta"], ["beta", "alpha"]]);
+  });
+
+  it("does not publish snapshots for no-op collection refreshes", () => {
+    const store = new CheckboxGroupStore();
+    const item = store.registerItem("alpha", {
+      focus: () => {},
+      isAvailable: () => true,
+    });
+    const snapshots: object[] = [];
+    store.subscribe((state) => snapshots.push(state));
+
+    const initial = store.state;
+    item.refreshAvailability();
+    expect(store.state).toBe(initial);
+    expect(snapshots).toEqual([]);
+
+    item.setActive(true);
+    expect(snapshots).toHaveLength(1);
+    const active = store.state;
+    item.setActive(true);
+    item.refreshAvailability();
+    expect(store.state).toBe(active);
+    expect(snapshots).toHaveLength(1);
+  });
+
+  it("gates every activation seam while the group is disabled", async () => {
+    setup = await createTestRenderer({ width: 20, height: 4 });
+    const values: Array<readonly string[]> = [];
+    const group = new CheckboxGroupRenderable(setup.renderer, {
+      disabled: true,
+      flexDirection: "row",
+      height: 1,
+      onValueChange: (value) => values.push(value),
+    });
+    const alpha = new CheckboxRootRenderable(setup.renderer, {
+      group: group.store,
+      height: 1,
+      value: "alpha",
+      width: 5,
+    });
+    const beta = new CheckboxRootRenderable(setup.renderer, {
+      group: group.store,
+      height: 1,
+      value: "beta",
+      width: 5,
+    });
+    group.add(alpha);
+    group.add(beta);
+    setup.renderer.root.add(group);
+    await setup.renderOnce();
+
+    alpha.focus();
+    alpha.press();
+    expect(alpha.focusable).toBe(false);
+    expect(alpha.focused).toBe(false);
+    expect(alpha.handleKeyPress(keyEvent("space"))).toBe(false);
+    const alphaKey = alpha.groupKey;
+    if (!alphaKey) throw new Error("Expected alpha group registration");
+    expect(group.store.getNavigationTarget(alphaKey, "next")).toBeUndefined();
+    await setup.mockMouse.click(0, 0);
+    expect(group.value).toEqual([]);
+    expect(values).toEqual([]);
+
+    group.disabled = false;
+    await setup.mockMouse.click(5, 0);
+    expect(group.value).toEqual(["beta"]);
+  });
+
+  it("applies explicit behavior props to a supplied Store", async () => {
+    setup = await createTestRenderer({ width: 20, height: 4 });
+    const original = () => {};
+    const replacementValues: Array<readonly string[]> = [];
+    const store = new CheckboxGroupStore({
+      defaultValue: ["old"],
+      onValueChange: original,
+    });
+    const group = new CheckboxGroupRenderable(setup.renderer, {
+      disabled: true,
+      loopFocus: false,
+      onValueChange: (value) => replacementValues.push(value),
+      orientation: "vertical",
+      store,
+      value: ["alpha", "beta"],
+    });
+
+    expect(group.disabled).toBe(true);
+    expect(group.loopFocus).toBe(false);
+    expect(group.orientation).toBe("vertical");
+    expect(group.value).toEqual(["alpha", "beta"]);
+
+    group.disabled = false;
+    const item = new CheckboxRootRenderable(setup.renderer, {
+      group: store,
+      value: "gamma",
+    });
+    group.add(item);
+    setup.renderer.root.add(group);
+    item.press();
+    expect(replacementValues).toEqual([["alpha", "beta", "gamma"]]);
+  });
+
+  it("requires unique explicit values for grouped Checkboxes", async () => {
+    setup = await createTestRenderer({ width: 20, height: 4 });
+    const renderer = setup.renderer;
+    const group = new CheckboxGroupRenderable(renderer);
+    new CheckboxRootRenderable(renderer, {
+      group: group.store,
+      value: "alpha",
+    });
+    expect(
+      () =>
+        new CheckboxRootRenderable(renderer, {
+          group: group.store,
+          value: "alpha",
+        }),
+    ).toThrow('CheckboxGroup item value "alpha" is already registered');
+    expect(() => new CheckboxStore({ group: group.store })).toThrow(
+      "A Checkbox inside CheckboxGroup requires a value",
+    );
+  });
+});

--- a/packages/core/src/checkbox-group/index.ts
+++ b/packages/core/src/checkbox-group/index.ts
@@ -1,0 +1,16 @@
+export type { PressDetails as CheckboxGroupChangeDetails } from "../internal/pressable";
+export {
+  type CheckboxGroupFocusDirection,
+  type CheckboxGroupItemKey,
+  type CheckboxGroupItemRegistration,
+  type CheckboxGroupItemRegistrationOptions,
+  type CheckboxGroupItemState,
+  type CheckboxGroupNavigationTarget,
+  type CheckboxGroupOptions,
+  type CheckboxGroupOrientation,
+  CheckboxGroupRenderable,
+  type CheckboxGroupState,
+  CheckboxGroupStore,
+  type CheckboxGroupStoreOptions,
+  type CheckboxGroupValueChangeHandler,
+} from "./primitive";

--- a/packages/core/src/checkbox-group/primitive.ts
+++ b/packages/core/src/checkbox-group/primitive.ts
@@ -1,0 +1,396 @@
+import type { BaseRenderable, BoxOptions, RenderContext } from "@opentui/core";
+import { CheckboxRootRenderable } from "../checkbox/primitive";
+import type { PressDetails } from "../internal/pressable";
+import {
+  type CollectionFocusDirection,
+  type CollectionItemInput,
+  type CollectionItemKey,
+  type CollectionItemRegistration,
+  type CollectionItemRegistrationOptions,
+  type CollectionNavigationTarget,
+  RovingCollectionRenderable,
+  RovingCollectionStore,
+} from "../internal/roving-collection";
+
+// These public aliases deliberately insulate API vocabulary from the internal
+// roving-collection vocabulary, so internal names never leak into declarations.
+/** Stable identity for a Checkbox registered with a CheckboxGroup. */
+export type CheckboxGroupItemKey = CollectionItemKey;
+
+/** Direction used by CheckboxGroup roving-focus navigation. */
+export type CheckboxGroupFocusDirection = CollectionFocusDirection;
+
+/** Terminal layout direction used by CheckboxGroup keyboard navigation. */
+export type CheckboxGroupOrientation = "horizontal" | "vertical";
+
+/** Readonly observable CheckboxGroup state. */
+export interface CheckboxGroupState {
+  /** Whether group interaction is disabled. */
+  readonly disabled: boolean;
+  /** Arrow-key axis used for rendered-order navigation. */
+  readonly orientation: CheckboxGroupOrientation;
+  /** Values of the currently checked Checkboxes. */
+  readonly value: readonly string[];
+}
+
+/** Readonly state for one CheckboxGroup collection member. */
+export interface CheckboxGroupItemState {
+  /** Whether this Checkbox is a live rendered group member. */
+  readonly available: boolean;
+  /** Effective group or local disablement. */
+  readonly disabled: boolean;
+  /** Whether this Checkbox value belongs to group value. */
+  readonly checked: boolean;
+  /** Whether this Checkbox is the current roving tab stop. */
+  readonly tabbable: boolean;
+  /** Stable Checkbox identity. */
+  readonly value: string;
+}
+
+/** Callback invoked when a CheckboxGroup requests a new value. */
+export type CheckboxGroupValueChangeHandler = (
+  value: readonly string[],
+  details: PressDetails,
+) => void;
+
+/** Options used to construct a CheckboxGroup Store. */
+export interface CheckboxGroupStoreOptions {
+  /** Initial checked values when uncontrolled. */
+  readonly defaultValue?: readonly string[];
+  /** Whether group interaction is disabled. */
+  readonly disabled?: boolean;
+  /** Whether keyboard navigation wraps at collection edges. */
+  readonly loopFocus?: boolean;
+  /** Callback for one accepted checked-value request. */
+  readonly onValueChange?: CheckboxGroupValueChangeHandler;
+  /** Arrow-key navigation axis; defaults to vertical. */
+  readonly orientation?: CheckboxGroupOrientation;
+  /** Controlled checked values. */
+  readonly value?: readonly string[];
+}
+
+/** Options used to register one Checkbox with a CheckboxGroup Store. */
+export type CheckboxGroupItemRegistrationOptions =
+  CollectionItemRegistrationOptions;
+
+/** Retained registration for one CheckboxGroup member. */
+export type CheckboxGroupItemRegistration = CollectionItemRegistration;
+
+/** Focus target returned by CheckboxGroup collection navigation. */
+export type CheckboxGroupNavigationTarget = CollectionNavigationTarget;
+
+function normalizeValue(
+  value: readonly string[] | undefined,
+): readonly string[] {
+  return Object.freeze([...new Set(value ?? [])]);
+}
+
+function valuesEqual(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
+/** Framework-neutral selection and roving-focus owner for CheckboxGroup. */
+export class CheckboxGroupStore extends RovingCollectionStore<
+  CheckboxGroupState,
+  CheckboxGroupItemState
+> {
+  private controlled: boolean;
+  private _loopFocus: boolean;
+  private rootOwner?: object;
+  private onValueChangeCallback?: CheckboxGroupValueChangeHandler;
+
+  /** Creates a CheckboxGroup Store. */
+  constructor(options: CheckboxGroupStoreOptions = {}) {
+    super("CheckboxGroup", {
+      disabled: options.disabled ?? false,
+      orientation: options.orientation ?? "vertical",
+      value: normalizeValue(options.value ?? options.defaultValue),
+    });
+    this.controlled = options.value !== undefined;
+    this._loopFocus = options.loopFocus ?? true;
+    this.onValueChangeCallback = options.onValueChange;
+  }
+
+  /** Claims this Store for one live CheckboxGroup Root. */
+  attachRoot(owner: object): void {
+    if (this.rootOwner && this.rootOwner !== owner) {
+      throw new Error(
+        "CheckboxGroup Store may be adopted by only one live CheckboxGroup",
+      );
+    }
+    this.rootOwner = owner;
+  }
+
+  /** Releases one CheckboxGroup Root's claim. */
+  detachRoot(owner: object): void {
+    if (this.rootOwner === owner) this.rootOwner = undefined;
+  }
+
+  /** Whether keyboard navigation wraps at the collection edges. */
+  get loopFocus(): boolean {
+    return this._loopFocus;
+  }
+
+  /** Requests that a registered Checkbox change its checked state. */
+  requestToggle(
+    key: CheckboxGroupItemKey,
+    checked: boolean,
+    details: PressDetails,
+    onAccepted?: () => void,
+  ): void {
+    this.runMutation(() => {
+      const item = this.items.get(key);
+      if (
+        !item ||
+        !this.isItemAvailable(item) ||
+        item.state.checked === checked
+      )
+        return;
+      const value = normalizeValue(
+        checked
+          ? [...this.state.value, item.value]
+          : this.state.value.filter((value) => value !== item.value),
+      );
+      if (!this.controlled) this.update({ value });
+      const immutableDetails = Object.isFrozen(details)
+        ? details
+        : Object.freeze({ ...details });
+      onAccepted?.();
+      this.onValueChangeCallback?.(value, immutableDetails);
+    });
+  }
+
+  /** Applies a controlled value, or releases control when undefined. */
+  setValue(value: readonly string[] | undefined): void {
+    this.runMutation(() => {
+      if (value === undefined) {
+        this.controlled = false;
+        return;
+      }
+      this.controlled = true;
+      this.update({ value: normalizeValue(value) });
+    });
+  }
+
+  /** Updates group disablement. */
+  setDisabled(disabled: boolean): void {
+    this.runMutation(() => {
+      if (disabled) this.activeKey = null;
+      this.update({ disabled });
+    });
+  }
+
+  /** Updates the keyboard-navigation orientation. */
+  setOrientation(orientation: CheckboxGroupOrientation): void {
+    this.runMutation(() => this.update({ orientation }));
+  }
+
+  /** Updates whether keyboard navigation wraps. */
+  setLoopFocus(loopFocus: boolean): void {
+    this._loopFocus = loopFocus;
+  }
+
+  /** Replaces the value-change callback. */
+  setOnValueChange(
+    callback: CheckboxGroupValueChangeHandler | undefined,
+  ): void {
+    this.onValueChangeCallback = callback;
+  }
+
+  protected createItemState(
+    key: CheckboxGroupItemKey,
+    item: CollectionItemInput,
+  ): CheckboxGroupItemState {
+    return Object.freeze({
+      available: this.collectionAvailable && (item.isAvailable?.() ?? true),
+      disabled: this.state.disabled || item.disabled,
+      checked: this.state.value.includes(item.value),
+      tabbable: key === this.tabStopKey,
+      value: item.value,
+    });
+  }
+
+  protected override navigationWraps(): boolean {
+    return this._loopFocus;
+  }
+
+  protected override onItemValueRenamed(
+    previous: string,
+    next: string,
+  ): boolean {
+    if (this.controlled || !this.state.value.includes(previous)) return false;
+    const nextValue = this.state.value.map((entry) =>
+      entry === previous ? next : entry,
+    );
+    this.update({ value: normalizeValue(nextValue) });
+    return true;
+  }
+
+  protected override update(next: Partial<CheckboxGroupState>): void {
+    const nextValue = next.value;
+    const value =
+      nextValue && valuesEqual(nextValue, this.state.value)
+        ? this.state.value
+        : nextValue;
+    super.update(value ? { ...next, value } : next);
+  }
+}
+
+/** Native OpenTUI options plus CheckboxGroup behavior props. */
+export interface CheckboxGroupOptions
+  extends BoxOptions,
+    CheckboxGroupStoreOptions {
+  /** Existing Store for imperative composition. */
+  store?: CheckboxGroupStore;
+}
+
+/** Non-focusable Renderable that owns one CheckboxGroup collection. */
+export class CheckboxGroupRenderable extends RovingCollectionRenderable<
+  CheckboxGroupState,
+  CheckboxGroupItemState
+> {
+  private readonly _store: CheckboxGroupStore;
+  private readonly storeOwner: object;
+  private coordinationReleased = false;
+
+  /** Creates a CheckboxGroup Renderable. */
+  constructor(ctx: RenderContext, options: CheckboxGroupOptions = {}) {
+    const {
+      defaultValue,
+      disabled,
+      loopFocus,
+      onValueChange,
+      orientation,
+      store,
+      value,
+      ...boxOptions
+    } = options;
+    const groupStore =
+      store ??
+      new CheckboxGroupStore({
+        defaultValue,
+        disabled,
+        loopFocus,
+        onValueChange,
+        orientation,
+        value,
+      });
+    const storeOwner = {};
+    groupStore.attachRoot(storeOwner);
+    if (store) {
+      if (disabled !== undefined) store.setDisabled(disabled);
+      if (orientation !== undefined) store.setOrientation(orientation);
+      if (loopFocus !== undefined) store.setLoopFocus(loopFocus);
+      if (value !== undefined) store.setValue(value);
+      if (onValueChange !== undefined) store.setOnValueChange(onValueChange);
+    }
+    super(ctx, boxOptions, groupStore);
+    this._store = groupStore;
+    this.storeOwner = storeOwner;
+  }
+
+  /** Store owned by this group. */
+  get store(): CheckboxGroupStore {
+    return this._store;
+  }
+
+  /** Prevents replacement of a mounted group Store. */
+  set store(store: CheckboxGroupStore) {
+    if (store !== this._store)
+      throw new Error("CheckboxGroup store cannot be replaced");
+  }
+
+  /** Current immutable group state. */
+  getState(): CheckboxGroupState {
+    return this._store.state;
+  }
+
+  /** Current checked Checkbox values. */
+  get value(): readonly string[] {
+    return this._store.state.value;
+  }
+
+  set value(value: readonly string[] | undefined) {
+    this._store.setValue(value);
+  }
+
+  /** Whether the entire group is disabled. */
+  get disabled(): boolean {
+    return this._store.state.disabled;
+  }
+
+  set disabled(disabled: boolean | null | undefined) {
+    this._store.setDisabled(disabled ?? false);
+  }
+
+  /** Keyboard-navigation orientation. */
+  get orientation(): CheckboxGroupOrientation {
+    return this._store.state.orientation;
+  }
+
+  set orientation(orientation: CheckboxGroupOrientation | null | undefined) {
+    this._store.setOrientation(orientation ?? "vertical");
+  }
+
+  /** Whether keyboard navigation wraps at collection edges. */
+  get loopFocus(): boolean {
+    return this._store.loopFocus;
+  }
+
+  set loopFocus(loopFocus: boolean | null | undefined) {
+    this._store.setLoopFocus(loopFocus ?? true);
+  }
+
+  /** Replaces the value-change callback. */
+  set onValueChange(callback: CheckboxGroupValueChangeHandler | undefined) {
+    this._store.setOnValueChange(callback);
+  }
+
+  protected override onRemove(): void {
+    this.endCoordinationLifetime();
+    super.onRemove();
+  }
+
+  /** Permanently ends this group and descendant Checkbox coordination. */
+  override destroy(): void {
+    this.endCoordinationLifetime();
+    super.destroy();
+  }
+
+  /** Permanently releases every grouped descendant and collection owner. */
+  endCoordinationLifetime(): void {
+    if (this.coordinationReleased) return;
+    this.coordinationReleased = true;
+    const visit = (node: BaseRenderable): void => {
+      for (const child of node.getChildren()) {
+        if (
+          child instanceof CheckboxRootRenderable &&
+          child.group === this._store
+        ) {
+          child.endCoordinationLifetime();
+        } else {
+          visit(child);
+        }
+      }
+    };
+    visit(this);
+    this._store.setCollectionAvailable(false);
+    this.releaseCollectionOwnership();
+    this._store.detachRoot(this.storeOwner);
+  }
+
+  protected itemKeyFor(
+    child: BaseRenderable,
+  ): CheckboxGroupItemKey | null | undefined {
+    return child instanceof CheckboxRootRenderable &&
+      child.group === this._store
+      ? (child.groupKey ?? null)
+      : undefined;
+  }
+}

--- a/packages/core/src/checkbox/checkbox-primitive.test.ts
+++ b/packages/core/src/checkbox/checkbox-primitive.test.ts
@@ -23,6 +23,23 @@ describe("Checkbox primitive", () => {
     expect(root.checked).toBe(true);
   });
 
+  it("reports frozen semantic details after standalone state commits", async () => {
+    setup = await createTestRenderer({ width: 30, height: 5 });
+    const events: string[] = [];
+    const details: object[] = [];
+    const root = new CheckboxRootRenderable(setup.renderer, {
+      onCheckedChange: (checked, changeDetails) => {
+        events.push(`${checked}:${root.checked}`);
+        details.push(changeDetails);
+      },
+    });
+
+    root.press();
+
+    expect(events).toEqual(["true:true"]);
+    expect(details.every(Object.isFrozen)).toBe(true);
+  });
+
   it("adopts a Store and rejects replacement", async () => {
     setup = await createTestRenderer({ width: 30, height: 5 });
     const store = new CheckboxStore({ defaultChecked: true });
@@ -47,6 +64,7 @@ describe("Checkbox primitive", () => {
       checked: true,
       disabled: true,
       focused: false,
+      tabbable: false,
     });
     root.disabled = false;
     root.press();

--- a/packages/core/src/checkbox/index.ts
+++ b/packages/core/src/checkbox/index.ts
@@ -1,4 +1,6 @@
 export {
+  type CheckboxChangeDetails,
+  type CheckboxCheckedChangeHandler,
   type CheckboxIndicatorOptions,
   CheckboxIndicatorRenderable,
   type CheckboxRootOptions,

--- a/packages/core/src/checkbox/primitive.ts
+++ b/packages/core/src/checkbox/primitive.ts
@@ -1,63 +1,569 @@
 import {
+  type BaseRenderable,
   type BoxOptions,
   BoxRenderable,
+  type KeyEvent,
   type RenderContext,
 } from "@opentui/core";
-import { CheckedRootRenderable } from "../internal/checked-root";
 import {
-  type CheckedState,
-  CheckedStore,
-  type CheckedStoreOptions,
-} from "../internal/checked-store";
+  type CheckboxGroupFocusDirection,
+  type CheckboxGroupItemKey,
+  type CheckboxGroupItemRegistration,
+  type CheckboxGroupItemState,
+  CheckboxGroupRenderable,
+  type CheckboxGroupStore,
+} from "../checkbox-group/primitive";
+import { PressableRenderable, type PressDetails } from "../internal/pressable";
 
-export type CheckboxState = CheckedState;
-export type CheckboxStoreOptions = CheckedStoreOptions;
+/** Gesture details for one semantic Checkbox press. */
+export type CheckboxChangeDetails = PressDetails;
 
-export class CheckboxStore extends CheckedStore<"checkbox"> {}
-
-export interface CheckboxRootOptions extends BoxOptions, CheckboxStoreOptions {
-  store?: CheckboxStore;
+/** Readonly observable Checkbox state. */
+export interface CheckboxState {
+  /** Whether this Checkbox is checked. */
+  readonly checked: boolean;
+  /** Whether Root or group disablement blocks interaction. */
+  readonly disabled: boolean;
+  /** Whether this Root owns actual OpenTUI focus. */
+  readonly focused: boolean;
+  /** Whether this Root is the current group tab stop. */
+  readonly tabbable: boolean;
 }
 
-export class CheckboxRootRenderable extends CheckedRootRenderable<CheckboxStore> {
-  constructor(ctx: RenderContext, options: CheckboxRootOptions = {}) {
-    super(ctx, options, {
-      label: "Checkbox.Root",
-      createStore: (storeOptions) => new CheckboxStore(storeOptions),
+/** Callback invoked when a Checkbox requests a checked-state change. */
+export type CheckboxCheckedChangeHandler = (
+  checked: boolean,
+  details: CheckboxChangeDetails,
+) => void;
+
+/** Options used to construct a Checkbox Store. */
+export interface CheckboxStoreOptions {
+  /** Controlled standalone checked state. */
+  readonly checked?: boolean;
+  /** Initial standalone checked state when uncontrolled. */
+  readonly defaultChecked?: boolean;
+  /** Local Checkbox disablement. */
+  readonly disabled?: boolean;
+  /** Optional CheckboxGroup owner for Core composition. */
+  readonly group?: CheckboxGroupStore;
+  /** Callback for one accepted checked-state request. */
+  readonly onCheckedChange?: CheckboxCheckedChangeHandler;
+  /** Required unique identity when group is provided. */
+  readonly value?: string;
+}
+
+type CheckboxStateListener = (state: CheckboxState) => void;
+
+const IMPERATIVE_DETAILS: CheckboxChangeDetails = Object.freeze({
+  source: "imperative",
+});
+
+/** Framework-neutral owner for standalone or grouped Checkbox state. */
+export class CheckboxStore {
+  private controlled: boolean;
+  private snapshot: CheckboxState;
+  private _disabled: boolean;
+  private _checked: boolean;
+  private _value?: string;
+  private onCheckedChangeCallback?: CheckboxCheckedChangeHandler;
+  private registration?: CheckboxGroupItemRegistration;
+  private collectionState?: CheckboxGroupItemState;
+  private readonly listeners = new Set<CheckboxStateListener>();
+  private unsubscribeGroup?: () => void;
+
+  /** Creates a Checkbox Store. */
+  constructor(options: CheckboxStoreOptions = {}) {
+    if (options.group && options.value === undefined) {
+      throw new Error("A Checkbox inside CheckboxGroup requires a value");
+    }
+    this.controlled = !options.group && options.checked !== undefined;
+    this._disabled = options.disabled ?? false;
+    this._checked = options.checked ?? options.defaultChecked ?? false;
+    this._value = options.value;
+    this.group = options.group;
+    this.onCheckedChangeCallback = options.onCheckedChange;
+    const groupChecked =
+      this.group && this._value !== undefined
+        ? this.group.state.value.includes(this._value)
+        : undefined;
+    const disabled = this.group?.state.disabled || this._disabled;
+    this.snapshot = Object.freeze({
+      checked: groupChecked ?? this._checked,
+      disabled,
+      focused: false,
+      tabbable: !this.group && !disabled,
     });
+  }
+
+  /** Optional CheckboxGroup owner. */
+  readonly group?: CheckboxGroupStore;
+
+  /** Current immutable Checkbox state. */
+  get state(): CheckboxState {
+    return this.snapshot;
+  }
+
+  /** Current group registration key, when mounted in a CheckboxGroup. */
+  get groupKey(): CheckboxGroupItemKey | undefined {
+    return this.registration?.key;
+  }
+
+  /** Current group collection state, when mounted in a CheckboxGroup. */
+  get groupState(): CheckboxGroupItemState | undefined {
+    return this.collectionState;
+  }
+
+  /** Current optional identity value. */
+  get value(): string | undefined {
+    return this._value;
+  }
+
+  /** Subscribes to Checkbox state changes. */
+  subscribe(listener: CheckboxStateListener): () => void {
+    this.listeners.add(listener);
+    this.ensureGroupSubscription();
+    return () => {
+      this.listeners.delete(listener);
+      if (this.listeners.size === 0) {
+        this.unsubscribeGroup?.();
+        this.unsubscribeGroup = undefined;
+      }
+    };
+  }
+
+  /** Attaches the Store to its one live Checkbox Renderable. */
+  attach(options: {
+    focus: () => void;
+    isAvailable: () => boolean;
+  }): () => void {
+    if (!this.group) return () => {};
+    if (this.registration)
+      throw new Error("Checkbox Store is already attached");
+    const value = this._value;
+    if (value === undefined)
+      throw new Error("A Checkbox inside CheckboxGroup requires a value");
+    const registration = this.group.registerItem(value, {
+      disabled: this._disabled,
+      focus: options.focus,
+      isAvailable: options.isAvailable,
+    });
+    this.registration = registration;
+    this.refreshFromGroup();
+    return () => {
+      if (this.registration !== registration) return;
+      registration.unregister();
+      this.registration = undefined;
+      this.collectionState = undefined;
+      this.publish();
+    };
+  }
+
+  /** Requests the inverse checked state through the active ownership model. */
+  requestToggle(details: CheckboxChangeDetails = IMPERATIVE_DETAILS): void {
+    if (this.snapshot.disabled) return;
+    const checked = !this.snapshot.checked;
+    const immutableDetails = Object.freeze({ ...details });
+    if (this.group) {
+      const key = this.registration?.key;
+      if (!key) return;
+      this.group.requestToggle(key, checked, immutableDetails, () => {
+        this.onCheckedChangeCallback?.(checked, immutableDetails);
+      });
+      return;
+    }
+    if (!this.controlled) {
+      this._checked = checked;
+      this.publish();
+    }
+    this.onCheckedChangeCallback?.(checked, immutableDetails);
+  }
+
+  /** Applies a controlled checked value, or releases control when undefined. */
+  setChecked(checked: boolean | null | undefined): void {
+    if (this.group) return;
+    if (typeof checked !== "boolean") {
+      this.controlled = false;
+      return;
+    }
+    this.controlled = true;
+    this._checked = checked;
+    this.publish();
+  }
+
+  /** Updates local disablement. */
+  setDisabled(disabled: boolean): void {
+    this._disabled = disabled;
+    this.registration?.setDisabled(disabled);
+    this.publish();
+  }
+
+  /** Updates actual Renderable focus state. */
+  setFocused(focused: boolean): void {
+    if (this.snapshot.disabled && focused) return;
+    this.registration?.setActive(focused);
+    this.publish(focused);
+  }
+
+  /** Updates the value used when this Checkbox belongs to a group. */
+  setValue(value: string | undefined): void {
+    if (!this.group) {
+      this._value = value;
+      return;
+    }
+    if (value === undefined)
+      throw new Error("A Checkbox inside CheckboxGroup requires a value");
+    this._value = value;
+    this.registration?.setValue(value);
+    this.refreshFromGroup();
+  }
+
+  /** Replaces the checked-change callback. */
+  setOnCheckedChange(callback: CheckboxCheckedChangeHandler | undefined): void {
+    this.onCheckedChangeCallback = callback;
+  }
+
+  /** Re-evaluates whether this mounted group item is available. */
+  refreshAvailability(): void {
+    this.registration?.refreshAvailability();
+    this.refreshFromGroup();
+  }
+
+  private ensureGroupSubscription(): void {
+    if (!this.group || this.unsubscribeGroup) return;
+    this.unsubscribeGroup = this.group.subscribe(() => this.refreshFromGroup());
+  }
+
+  private refreshFromGroup(): void {
+    const key = this.registration?.key;
+    this.collectionState = key ? this.group?.getItemState(key) : undefined;
+    this.publish();
+  }
+
+  private createState(focused: boolean): CheckboxState {
+    const groupChecked =
+      this.group && this._value !== undefined
+        ? this.group.state.value.includes(this._value)
+        : undefined;
+    const disabled =
+      this.collectionState?.disabled ??
+      (this.group?.state.disabled || this._disabled);
+    return {
+      checked: this.collectionState?.checked ?? groupChecked ?? this._checked,
+      disabled,
+      focused: disabled ? false : focused,
+      tabbable: disabled
+        ? false
+        : this.group
+          ? (this.collectionState?.tabbable ?? false)
+          : true,
+    };
+  }
+
+  private publish(focused = this.snapshot.focused): void {
+    const state = this.createState(focused);
+    if (
+      state.disabled === this.snapshot.disabled &&
+      state.focused === this.snapshot.focused &&
+      state.checked === this.snapshot.checked &&
+      state.tabbable === this.snapshot.tabbable
+    )
+      return;
+    this.snapshot = Object.freeze(state);
+    for (const listener of [...this.listeners]) {
+      if (this.listeners.has(listener)) listener(this.snapshot);
+    }
   }
 }
 
+/** Native OpenTUI options plus Checkbox behavior props. */
+export interface CheckboxRootOptions extends BoxOptions, CheckboxStoreOptions {
+  /** Existing Store for imperative composition. */
+  store?: CheckboxStore;
+}
+
+/** Focusable two-state Checkbox Renderable. */
+export class CheckboxRootRenderable extends PressableRenderable {
+  private readonly _store: CheckboxStore;
+  private readonly detach: () => void;
+  private coordinationReleased = false;
+
+  /** Creates a Checkbox Renderable. */
+  constructor(ctx: RenderContext, options: CheckboxRootOptions = {}) {
+    const {
+      defaultChecked,
+      disabled,
+      group,
+      onCheckedChange,
+      checked,
+      store,
+      value,
+      ...boxOptions
+    } = options;
+    super(ctx, boxOptions);
+    this._store =
+      store ??
+      new CheckboxStore({
+        defaultChecked,
+        disabled,
+        group,
+        onCheckedChange,
+        checked,
+        value,
+      });
+    if (store) {
+      if (checked !== undefined) store.setChecked(checked);
+      if (disabled !== undefined) store.setDisabled(disabled);
+      if (value !== undefined) store.setValue(value);
+      if (onCheckedChange !== undefined)
+        store.setOnCheckedChange(onCheckedChange);
+    }
+    this.detach = this._store.attach({
+      focus: () => this.focus(),
+      isAvailable: () => this.isAvailable(),
+    });
+    this.attachPressable(this._store);
+  }
+
+  /** Grouped Checkboxes stay focusable only while they own the roving tab stop. */
+  protected override pressableFocusable(): boolean {
+    return this.canFocus();
+  }
+
+  /** Requests a Checkbox activation for one semantic press. */
+  protected handlePress(details: PressDetails): void {
+    this.activate(details);
+  }
+
+  /** Store owned by this Checkbox. */
+  get store(): CheckboxStore {
+    return this._store;
+  }
+
+  /** Prevents replacement of a mounted Checkbox Store. */
+  set store(store: CheckboxStore) {
+    if (store !== this._store)
+      throw new Error("Checkbox.Root store cannot be replaced");
+  }
+
+  /** Optional CheckboxGroup owner. */
+  get group(): CheckboxGroupStore | undefined {
+    return this._store.group;
+  }
+
+  /** Group registration key when this Checkbox belongs to a group. */
+  get groupKey(): CheckboxGroupItemKey | undefined {
+    return this._store.groupKey;
+  }
+
+  /** Current immutable Checkbox state. */
+  getState(): CheckboxState {
+    return this._store.state;
+  }
+
+  /** Subscribes to Checkbox state changes. */
+  subscribe(listener: CheckboxStateListener): () => void {
+    return this._store.subscribe(listener);
+  }
+
+  /** Handles grouped roving-focus keys outside the shared activation map. */
+  protected override handleUnclaimedKey(key: KeyEvent): boolean {
+    if (!this.group) return false;
+    const orientation = this.group.state.orientation;
+    if (
+      (orientation === "horizontal" && key.name === "left") ||
+      (orientation === "vertical" && key.name === "up")
+    )
+      return this.moveFocus("previous");
+    if (
+      (orientation === "horizontal" && key.name === "right") ||
+      (orientation === "vertical" && key.name === "down")
+    )
+      return this.moveFocus("next");
+    if (key.name === "home") return this.moveFocus("first");
+    if (key.name === "end") return this.moveFocus("last");
+    return false;
+  }
+
+  /** Focuses this Checkbox when it is eligible. */
+  override focus(): void {
+    if (this._store.state.disabled || !this.refreshCollection()) return;
+    this._focusable = true;
+    super.focus();
+  }
+
+  /** Current checked state. */
+  get checked(): boolean {
+    return this._store.state.checked;
+  }
+
+  set checked(checked: boolean | null | undefined) {
+    this._store.setChecked(checked);
+  }
+
+  /** Current disabled state. */
+  get disabled(): boolean {
+    return this._store.state.disabled;
+  }
+
+  set disabled(disabled: boolean | null | undefined) {
+    this._store.setDisabled(disabled ?? false);
+  }
+
+  /** Group identity value. */
+  get value(): string | undefined {
+    return this._store.value;
+  }
+
+  set value(value: string | undefined) {
+    this._store.setValue(value);
+  }
+
+  /** Replaces the checked-change callback. */
+  set onCheckedChange(callback: CheckboxCheckedChangeHandler | undefined) {
+    this._store.setOnCheckedChange(callback);
+  }
+
+  override get visible(): boolean {
+    return super.visible;
+  }
+
+  override set visible(visible: boolean) {
+    if (super.visible === visible) return;
+    const key = this.groupKey;
+    const fallback =
+      !visible && this._focused && key
+        ? this.group?.getFallbackTarget(key)
+        : undefined;
+    super.visible = visible;
+    this._store.refreshAvailability();
+    this._focusable = this.canFocus();
+    fallback?.focus();
+  }
+
+  protected override onRemove(): void {
+    this.endCoordinationLifetime();
+    super.onRemove();
+  }
+
+  /** Releases Store and group registration ownership. */
+  override destroy(): void {
+    this.endCoordinationLifetime();
+    super.destroy();
+  }
+
+  /** Permanently ends interaction and optional group coordination. */
+  endCoordinationLifetime(): void {
+    if (this.coordinationReleased) return;
+    this.coordinationReleased = true;
+    const visit = (node: BaseRenderable): void => {
+      for (const child of node.getChildren()) {
+        if (
+          child instanceof CheckboxIndicatorRenderable &&
+          child.store === this._store
+        ) {
+          child.endCoordinationLifetime();
+        } else {
+          visit(child);
+        }
+      }
+    };
+    visit(this);
+    this.detachPressable();
+    this.detach();
+    this._focusable = false;
+    if (this._focused) super.blur();
+    this._store.setFocused(false);
+  }
+
+  private moveFocus(direction: CheckboxGroupFocusDirection): boolean {
+    const key = this.groupKey;
+    if (!this.group || !key) return false;
+    const target = this.group.getNavigationTarget(key, direction);
+    if (!target) return false;
+    target.focus();
+    return true;
+  }
+
+  private activate(details: PressDetails): void {
+    if (this._isDestroyed) return;
+    if (this.group && !this.refreshCollection()) return;
+    this._store.requestToggle(details);
+  }
+
+  private canFocus(): boolean {
+    const state = this._store.state;
+    if (state.disabled) return false;
+    return state.tabbable || this._focused;
+  }
+
+  private isAvailable(): boolean {
+    if (this._isDestroyed || !this.visible) return false;
+    if (!this.group) return this.parent !== null;
+    let ancestor = this.parent;
+    while (ancestor) {
+      if (!ancestor.visible) return false;
+      if (
+        ancestor instanceof CheckboxGroupRenderable &&
+        ancestor.store === this.group
+      )
+        return ancestor.parent !== null;
+      ancestor = ancestor.parent;
+    }
+    return false;
+  }
+
+  private refreshCollection(): boolean {
+    if (!this.group) return this.isAvailable();
+    let ancestor = this.parent;
+    while (ancestor) {
+      if (
+        ancestor instanceof CheckboxGroupRenderable &&
+        ancestor.store === this.group
+      ) {
+        ancestor.refreshItems();
+        this._store.refreshAvailability();
+        return this.isAvailable();
+      }
+      ancestor = ancestor.parent;
+    }
+    return false;
+  }
+}
+
+/** Native OpenTUI options for a Checkbox Indicator. */
 export interface CheckboxIndicatorOptions extends BoxOptions {
+  /** Store owned by the matching Checkbox Root. */
   store: CheckboxStore;
 }
 
+/** Passive Part whose visibility reflects the owning Checkbox state. */
 export class CheckboxIndicatorRenderable extends BoxRenderable {
   private _store: CheckboxStore;
   private _unsubscribe: () => void;
+  private coordinationReleased = false;
 
+  /** Creates a Checkbox Indicator Renderable. */
   constructor(ctx: RenderContext, options: CheckboxIndicatorOptions) {
     const { store, ...boxOptions } = options;
-    super(ctx, {
-      ...boxOptions,
-      visible: store.state.checked,
-    });
+    super(ctx, { ...boxOptions, visible: store.state.checked });
     this._store = store;
     this._unsubscribe = store.subscribe((state) => {
       this.visible = state.checked;
     });
   }
 
+  /** Current immutable Checkbox state. */
   getState(): CheckboxState {
     return this._store.state;
   }
 
+  /** Store associated with this Indicator. */
   get store(): CheckboxStore {
     return this._store;
   }
 
   set store(store: CheckboxStore) {
-    if (this._store === store) return;
+    if (this.coordinationReleased || this._store === store) return;
     this._unsubscribe();
     this._store = store;
     this.visible = store.state.checked;
@@ -66,8 +572,21 @@ export class CheckboxIndicatorRenderable extends BoxRenderable {
     });
   }
 
+  protected override onRemove(): void {
+    this.endCoordinationLifetime();
+    super.onRemove();
+  }
+
+  /** Releases the Store subscription. */
   override destroy(): void {
-    this._unsubscribe();
+    this.endCoordinationLifetime();
     super.destroy();
+  }
+
+  /** Permanently releases Checkbox state coordination. */
+  endCoordinationLifetime(): void {
+    if (this.coordinationReleased) return;
+    this.coordinationReleased = true;
+    this._unsubscribe();
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,8 @@ export {
   type ButtonStoreOptions,
 } from "./button";
 export {
+  type CheckboxChangeDetails,
+  type CheckboxCheckedChangeHandler,
   type CheckboxIndicatorOptions,
   CheckboxIndicatorRenderable,
   type CheckboxRootOptions,
@@ -34,6 +36,22 @@ export {
   CheckboxStore,
   type CheckboxStoreOptions,
 } from "./checkbox";
+export {
+  type CheckboxGroupChangeDetails,
+  type CheckboxGroupFocusDirection,
+  type CheckboxGroupItemKey,
+  type CheckboxGroupItemRegistration,
+  type CheckboxGroupItemRegistrationOptions,
+  type CheckboxGroupItemState,
+  type CheckboxGroupNavigationTarget,
+  type CheckboxGroupOptions,
+  type CheckboxGroupOrientation,
+  CheckboxGroupRenderable,
+  type CheckboxGroupState,
+  CheckboxGroupStore,
+  type CheckboxGroupStoreOptions,
+  type CheckboxGroupValueChangeHandler,
+} from "./checkbox-group";
 export {
   type CollapsibleOpenChangeDetails,
   type CollapsibleOpenChangeHandler,

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     "src/accordion/index.ts",
     "src/button/index.ts",
     "src/checkbox/index.ts",
+    "src/checkbox-group/index.ts",
     "src/collapsible/index.ts",
     "src/dialog/index.ts",
     "src/input/index.ts",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -79,8 +79,9 @@ export function Settings() {
 }
 ```
 
-From a repository checkout, run the focused Accordion or Collapsible tracer
-with `pnpm --filter @tuiparts/react demo:accordion` or
+From a repository checkout, run a focused tracer with
+`pnpm --filter @tuiparts/react demo:checkbox-group`,
+`pnpm --filter @tuiparts/react demo:accordion`, or
 `pnpm --filter @tuiparts/react demo:collapsible`.
 
 ## Imports
@@ -92,6 +93,7 @@ supported:
 import { Accordion } from "@tuiparts/react/accordion";
 import { Button } from "@tuiparts/react/button";
 import { Checkbox } from "@tuiparts/react/checkbox";
+import { CheckboxGroup } from "@tuiparts/react/checkbox-group";
 import { Collapsible } from "@tuiparts/react/collapsible";
 import { Input } from "@tuiparts/react/input";
 import { Radio } from "@tuiparts/react/radio";

--- a/packages/react/examples/checkbox-group.tsx
+++ b/packages/react/examples/checkbox-group.tsx
@@ -1,0 +1,71 @@
+/** @jsxImportSource @opentui/react */
+
+import { createCliRenderer } from "@opentui/core";
+import { createRoot } from "@opentui/react";
+import type { CheckboxRootRenderable } from "@tuiparts/core/checkbox";
+import { useCallback, useState } from "react";
+import { Checkbox } from "../src/checkbox";
+import { CheckboxGroup } from "../src/checkbox-group";
+
+const items = [
+  ["email", "Email notifications"],
+  ["sms", "SMS notifications"],
+  ["product", "Product announcements"],
+] as const;
+
+function Demo() {
+  const [value, setValue] = useState<readonly string[]>(["email"]);
+  const focusFirst = useCallback(
+    (checkbox: CheckboxRootRenderable | null) => checkbox?.focus(),
+    [],
+  );
+  return (
+    <box flexDirection="column" gap={1} padding={2}>
+      <text content="React CheckboxGroup Primitive" fg="#FFFFFF" />
+      <text
+        content="Up/Down moves focus. Space/Enter toggles. Ctrl+C quits."
+        fg="#737373"
+      />
+      <CheckboxGroup value={value} onValueChange={setValue}>
+        {items.map(([itemValue, label], index) => (
+          <Checkbox.Root
+            key={itemValue}
+            ref={index === 0 ? focusFirst : undefined}
+            value={itemValue}
+            flexDirection="row"
+            gap={1}
+            height={1}
+          >
+            {(state) => (
+              <box
+                backgroundColor={state.focused ? "#262626" : "transparent"}
+                flexDirection="row"
+                gap={1}
+                paddingX={1}
+                width="100%"
+              >
+                <box width={1}>
+                  <Checkbox.Indicator>
+                    <text content="✓" fg="#60A5FA" />
+                  </Checkbox.Indicator>
+                </box>
+                <text
+                  content={label}
+                  fg={state.focused ? "#FFFFFF" : "#D4D4D4"}
+                />
+              </box>
+            )}
+          </Checkbox.Root>
+        ))}
+      </CheckboxGroup>
+      <text
+        content={`Checked: ${value.join(", ") || "none"}`}
+        fg="#60A5FA"
+      />
+    </box>
+  );
+}
+
+const renderer = await createCliRenderer({ exitOnCtrlC: true });
+renderer.setBackgroundColor("#0A0A0A");
+createRoot(renderer).render(<Demo />);

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -8,6 +8,7 @@
     "./dist/accordion/**",
     "./dist/button/**",
     "./dist/checkbox/**",
+    "./dist/checkbox-group/**",
     "./dist/collapsible/**",
     "./dist/dialog/**",
     "./dist/input/**",
@@ -30,6 +31,7 @@
     "./accordion": "./src/accordion/index.ts",
     "./button": "./src/button/index.tsx",
     "./checkbox": "./src/checkbox/index.tsx",
+    "./checkbox-group": "./src/checkbox-group/index.ts",
     "./collapsible": "./src/collapsible/index.ts",
     "./dialog": "./src/dialog/index.ts",
     "./input": "./src/input/index.tsx",
@@ -60,6 +62,10 @@
       "./checkbox": {
         "types": "./dist/checkbox/index.d.mts",
         "import": "./dist/checkbox/index.mjs"
+      },
+      "./checkbox-group": {
+        "types": "./dist/checkbox-group/index.d.mts",
+        "import": "./dist/checkbox-group/index.mjs"
       },
       "./collapsible": {
         "types": "./dist/collapsible/index.d.mts",
@@ -122,6 +128,7 @@
   "scripts": {
     "build": "tsdown",
     "demo:accordion": "bun run examples/accordion.tsx",
+    "demo:checkbox-group": "bun run examples/checkbox-group.tsx",
     "demo:collapsible": "bun run examples/collapsible.tsx",
     "test": "bun test",
     "typecheck": "tsc --noEmit",

--- a/packages/react/src/checkbox-group/checkbox-group-primitive.test.tsx
+++ b/packages/react/src/checkbox-group/checkbox-group-primitive.test.tsx
@@ -1,0 +1,275 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { TextRenderable } from "@opentui/core";
+import type { TestRendererSetup } from "@opentui/core/testing";
+import { testRender } from "@opentui/react/test-utils";
+import { CheckboxRootRenderable } from "@tuiparts/core/checkbox";
+import {
+  CheckboxGroupRenderable,
+  CheckboxGroupStore,
+} from "@tuiparts/core/checkbox-group";
+import { act, createElement, StrictMode, useState } from "react";
+import { Checkbox } from "../checkbox";
+import { CheckboxGroup } from "./index";
+
+let setup: TestRendererSetup | undefined;
+
+function textContent(id: string): string {
+  const text = setup?.renderer.root.findDescendantById(id);
+  if (!(text instanceof TextRenderable))
+    throw new Error(`Expected TextRenderable ${id}`);
+  return text.content.chunks.map((chunk) => chunk.text).join("");
+}
+
+afterEach(async () => {
+  await act(async () => setup?.renderer.destroy());
+  setup = undefined;
+});
+
+describe("React CheckboxGroup", () => {
+  it("provides authoritative grouped state during the first render", async () => {
+    setup = await testRender(
+      createElement(
+        CheckboxGroup,
+        { defaultValue: ["left"], id: "group" },
+        createElement(Checkbox.Root, {
+          // biome-ignore lint/correctness/noChildrenProp: ReactNode excludes render-function children.
+          children: (state) =>
+            createElement("text", {
+              content: state.checked ? "checked" : "idle",
+              id: "left-state",
+            }),
+          id: "left",
+          value: "left",
+        }),
+        createElement(Checkbox.Root, { id: "right", value: "right" }),
+      ),
+      { width: 30, height: 4 },
+    );
+    const group = setup.renderer.root.findDescendantById("group");
+    const left = setup.renderer.root.findDescendantById("left");
+    const right = setup.renderer.root.findDescendantById("right");
+    if (!(group instanceof CheckboxGroupRenderable))
+      throw new Error("Expected CheckboxGroupRenderable group");
+    if (!(left instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable left");
+    if (!(right instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable right");
+
+    expect(textContent("left-state")).toBe("checked");
+    expect(left.group).toBe(group.store);
+    await act(async () =>
+      setup?.waitFor(() => {
+        const key = right.groupKey;
+        return key ? group.store.getItemState(key)?.available === true : false;
+      }),
+    );
+
+    await act(async () => right.press());
+    await setup.waitFor(() => group.value.includes("right"));
+    expect(group.value).toEqual(["left", "right"]);
+  });
+
+  it("updates controlled group props without replacing Renderables", async () => {
+    const groupRefs: CheckboxGroupRenderable[] = [];
+    const itemRefs: CheckboxRootRenderable[] = [];
+    function App() {
+      const [value, setValue] = useState<readonly string[]>(["alpha"]);
+      return createElement(
+        CheckboxGroup,
+        {
+          id: "controlled-group",
+          onValueChange: setValue,
+          ref: (next) => {
+            if (next) groupRefs.push(next);
+          },
+          value,
+        },
+        createElement(Checkbox.Root, {
+          id: "alpha",
+          ref: (next) => {
+            if (next) itemRefs.push(next);
+          },
+          value: "alpha",
+        }),
+        createElement(Checkbox.Root, { id: "beta", value: "beta" }),
+      );
+    }
+
+    setup = await testRender(createElement(App), { width: 30, height: 4 });
+    const group = setup.renderer.root.findDescendantById("controlled-group");
+    const alpha = setup.renderer.root.findDescendantById("alpha");
+    const beta = setup.renderer.root.findDescendantById("beta");
+    if (!(group instanceof CheckboxGroupRenderable))
+      throw new Error("Expected CheckboxGroupRenderable controlled-group");
+    if (!(alpha instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable alpha");
+    if (!(beta instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable beta");
+    await act(async () =>
+      setup?.waitFor(() => {
+        const key = beta.groupKey;
+        return key ? group.store.getItemState(key)?.available === true : false;
+      }),
+    );
+    await act(async () => beta.press());
+    await setup.waitFor(() => group.value.includes("beta"));
+    expect(group.value).toEqual(["alpha", "beta"]);
+    expect(groupRefs.at(-1)).toBe(group);
+    expect(itemRefs.at(-1)).toBe(alpha);
+  });
+
+  it("releases controlled ownership when the value prop is removed", async () => {
+    const requests: Array<readonly string[]> = [];
+    let setValue: (value: readonly string[] | undefined) => void = () => {};
+    function App() {
+      const [value, updateValue] = useState<readonly string[] | undefined>([
+        "alpha",
+      ]);
+      setValue = updateValue;
+      return createElement(
+        CheckboxGroup,
+        {
+          id: "ownership-group",
+          onValueChange: (nextValue) => requests.push(nextValue),
+          value,
+        },
+        createElement(Checkbox.Root, { id: "ownership-alpha", value: "alpha" }),
+        createElement(Checkbox.Root, { id: "ownership-beta", value: "beta" }),
+      );
+    }
+
+    setup = await testRender(createElement(App), { width: 30, height: 4 });
+    const group = setup.renderer.root.findDescendantById("ownership-group");
+    const beta = setup.renderer.root.findDescendantById("ownership-beta");
+    if (!(group instanceof CheckboxGroupRenderable))
+      throw new Error("Expected CheckboxGroupRenderable ownership-group");
+    if (!(beta instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable ownership-beta");
+
+    expect(group.value).toEqual(["alpha"]);
+
+    await act(async () => setValue(undefined));
+    await act(async () => beta.press());
+    await setup.waitFor(() => group.value.includes("beta"));
+    expect(group.value).toEqual(["alpha", "beta"]);
+    expect(requests).toEqual([["alpha", "beta"]]);
+  });
+
+  it("replaces the group callback without replacing its Renderable", async () => {
+    const calls: string[] = [];
+    let replaceCallback: () => void = () => {};
+    const groupRefs: CheckboxGroupRenderable[] = [];
+    function App() {
+      const [replacement, setReplacement] = useState(false);
+      replaceCallback = () => setReplacement(true);
+      return createElement(
+        CheckboxGroup,
+        {
+          defaultValue: ["alpha"],
+          onValueChange: () => calls.push(replacement ? "new" : "old"),
+          ref: (value) => {
+            if (value) groupRefs.push(value);
+          },
+        },
+        createElement(Checkbox.Root, { id: "alpha-callback", value: "alpha" }),
+        createElement(Checkbox.Root, { id: "beta-callback", value: "beta" }),
+      );
+    }
+
+    setup = await testRender(createElement(App), { width: 30, height: 4 });
+    const group = groupRefs.at(-1);
+    const alpha = setup.renderer.root.findDescendantById("alpha-callback");
+    const beta = setup.renderer.root.findDescendantById("beta-callback");
+    if (!group)
+      throw new Error("Expected CheckboxGroupRenderable callback target");
+    if (!(alpha instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable alpha-callback");
+    if (!(beta instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable beta-callback");
+
+    await act(async () => replaceCallback());
+    await act(async () => alpha.press());
+
+    expect(calls).toEqual(["new"]);
+    expect(groupRefs.at(-1)).toBe(group);
+  });
+
+  it("releases subscriptions under StrictMode teardown", async () => {
+    const originalSubscribe = CheckboxGroupStore.prototype.subscribe;
+    let activeSubscriptions = 0;
+    CheckboxGroupStore.prototype.subscribe = function subscribe(listener) {
+      activeSubscriptions += 1;
+      const unsubscribe = originalSubscribe.call(this, listener);
+      let active = true;
+      return () => {
+        if (!active) return;
+        active = false;
+        activeSubscriptions -= 1;
+        unsubscribe();
+      };
+    };
+    try {
+      setup = await testRender(
+        createElement(
+          StrictMode,
+          undefined,
+          createElement(
+            CheckboxGroup,
+            undefined,
+            createElement(
+              Checkbox.Root,
+              { value: "alpha" },
+              createElement(Checkbox.Indicator),
+            ),
+          ),
+        ),
+        { width: 20, height: 3 },
+      );
+      expect(activeSubscriptions).toBeGreaterThan(0);
+      await act(async () => setup?.renderer.destroy());
+      setup = undefined;
+      expect(activeSubscriptions).toBe(0);
+    } finally {
+      CheckboxGroupStore.prototype.subscribe = originalSubscribe;
+    }
+  });
+
+  it("unregisters conditional Checkboxes before remounting the same value", async () => {
+    let setVisible: (visible: boolean) => void = () => {};
+    const itemRefs: CheckboxRootRenderable[] = [];
+    function App() {
+      const [visible, updateVisible] = useState(true);
+      setVisible = updateVisible;
+      return createElement(
+        CheckboxGroup,
+        { id: "lifecycle-group" },
+        visible
+          ? createElement(Checkbox.Root, {
+              id: "lifecycle-item",
+              ref: (value) => {
+                if (value) itemRefs.push(value);
+              },
+              value: "alpha",
+            })
+          : undefined,
+      );
+    }
+
+    setup = await testRender(createElement(App), { width: 30, height: 4 });
+    const first = itemRefs.at(-1);
+    if (!first) throw new Error("Expected initial lifecycle Checkbox");
+
+    await act(async () => setVisible(false));
+    await act(async () => setVisible(true));
+
+    const replacement = itemRefs.at(-1);
+    if (!replacement)
+      throw new Error("Expected replacement lifecycle Checkbox");
+    expect(replacement).not.toBe(first);
+    await act(async () => replacement.press());
+    const group = setup.renderer.root.findDescendantById("lifecycle-group");
+    if (!(group instanceof CheckboxGroupRenderable))
+      throw new Error("Expected CheckboxGroupRenderable lifecycle-group");
+    expect(group.value).toEqual(["alpha"]);
+  });
+});

--- a/packages/react/src/checkbox-group/index.ts
+++ b/packages/react/src/checkbox-group/index.ts
@@ -1,0 +1,1 @@
+export * from "./primitive";

--- a/packages/react/src/checkbox-group/primitive.ts
+++ b/packages/react/src/checkbox-group/primitive.ts
@@ -1,0 +1,54 @@
+import { extend } from "@opentui/react";
+import {
+  type CheckboxGroupChangeDetails,
+  type CheckboxGroupOptions,
+  type CheckboxGroupOrientation,
+  CheckboxGroupRenderable,
+  type CheckboxGroupState,
+  CheckboxGroupStore,
+  type CheckboxGroupValueChangeHandler,
+} from "@tuiparts/core/checkbox-group";
+import {
+  createElement,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+} from "react";
+import { CheckboxGroupContext } from "../internal/checkbox-group-context";
+import { useCoreStore } from "../internal/use-core-store";
+
+const CHECKBOX_GROUP_TAG = "otui-checkbox-group";
+
+extend({ [CHECKBOX_GROUP_TAG]: CheckboxGroupRenderable });
+
+type CheckboxGroupProps = Omit<CheckboxGroupOptions, "store"> & {
+  children?: ReactNode | ((state: CheckboxGroupState) => ReactNode);
+  ref?: Ref<CheckboxGroupRenderable>;
+};
+
+/** React adapter for CheckboxGroup selection and collection ownership. */
+export function CheckboxGroup({
+  children,
+  ...props
+}: CheckboxGroup.Props): ReactElement {
+  const [store, state] = useCoreStore<CheckboxGroupState, CheckboxGroupStore>(
+    () => new CheckboxGroupStore(props),
+  );
+  const content = typeof children === "function" ? children(state) : children;
+  return createElement(
+    CheckboxGroupContext.Provider,
+    { value: store },
+    createElement(CHECKBOX_GROUP_TAG, { ...props, store }, content),
+  );
+}
+
+CheckboxGroup.displayName = "CheckboxGroup";
+
+/** Types scoped to the React CheckboxGroup component. */
+export namespace CheckboxGroup {
+  export type Props = CheckboxGroupProps;
+  export type State = CheckboxGroupState;
+  export type ChangeDetails = CheckboxGroupChangeDetails;
+  export type Orientation = CheckboxGroupOrientation;
+  export type ValueChangeHandler = CheckboxGroupValueChangeHandler;
+}

--- a/packages/react/src/checkbox/primitive.ts
+++ b/packages/react/src/checkbox/primitive.ts
@@ -1,5 +1,7 @@
 import { extend } from "@opentui/react";
 import {
+  type CheckboxChangeDetails,
+  type CheckboxCheckedChangeHandler,
   type CheckboxIndicatorOptions,
   CheckboxIndicatorRenderable,
   type CheckboxRootOptions,
@@ -15,6 +17,7 @@ import {
   type Ref,
   useContext,
 } from "react";
+import { CheckboxGroupContext } from "../internal/checkbox-group-context";
 import { useCoreStore } from "../internal/use-core-store";
 
 const ROOT_TAG = "otui-checkbox-root";
@@ -27,7 +30,7 @@ extend({
 
 const CheckboxContext = createContext<CheckboxStore | null>(null);
 
-type RootProps = Omit<CheckboxRootOptions, "store"> & {
+type RootProps = Omit<CheckboxRootOptions, "group" | "store"> & {
   children?: ReactNode | ((state: CheckboxState) => ReactNode);
   ref?: Ref<CheckboxRootRenderable>;
 };
@@ -37,9 +40,11 @@ type IndicatorProps = Omit<CheckboxIndicatorOptions, "store"> & {
   ref?: Ref<CheckboxIndicatorRenderable>;
 };
 
+/** React adapter for a standalone or grouped Checkbox Root. */
 export function Root({ children, ...props }: Root.Props): ReactElement {
+  const group = useContext(CheckboxGroupContext);
   const [store, state] = useCoreStore<CheckboxState, CheckboxStore>(
-    () => new CheckboxStore(props),
+    () => new CheckboxStore({ ...props, group: group ?? undefined }),
   );
   const content = typeof children === "function" ? children(state) : children;
 
@@ -50,6 +55,7 @@ export function Root({ children, ...props }: Root.Props): ReactElement {
   );
 }
 
+/** React adapter for the passive Checkbox Indicator Part. */
 export function Indicator({
   children,
   ...props
@@ -64,11 +70,15 @@ export function Indicator({
 Root.displayName = "Checkbox.Root";
 Indicator.displayName = "Checkbox.Indicator";
 
+/** Types scoped to Checkbox.Root. */
 export namespace Root {
   export type Props = RootProps;
   export type State = CheckboxState;
+  export type ChangeDetails = CheckboxChangeDetails;
+  export type CheckedChangeHandler = CheckboxCheckedChangeHandler;
 }
 
+/** Types scoped to Checkbox.Indicator. */
 export namespace Indicator {
   export type Props = IndicatorProps;
 }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,6 +2,7 @@
 export * from "./accordion";
 export * from "./button";
 export * from "./checkbox";
+export * from "./checkbox-group";
 export * from "./collapsible";
 export * from "./dialog";
 export * from "./input";

--- a/packages/react/src/internal/checkbox-group-context.ts
+++ b/packages/react/src/internal/checkbox-group-context.ts
@@ -1,0 +1,7 @@
+import type { CheckboxGroupStore } from "@tuiparts/core/checkbox-group";
+import { createContext } from "react";
+
+/** Private CheckboxGroup ownership consumed by Checkbox.Root. */
+export const CheckboxGroupContext = createContext<CheckboxGroupStore | null>(
+  null,
+);

--- a/packages/react/tsdown.config.ts
+++ b/packages/react/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     "src/accordion/index.ts",
     "src/button/index.tsx",
     "src/checkbox/index.tsx",
+    "src/checkbox-group/index.ts",
     "src/collapsible/index.ts",
     "src/dialog/index.ts",
     "src/input/index.tsx",

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -82,8 +82,9 @@ export function Settings() {
 Solid props are spread reactively onto the existing Renderable. Signal changes
 update controlled primitive state without remounting.
 
-From a repository checkout, run the focused Accordion or Collapsible tracer
-with `pnpm --filter @tuiparts/solid demo:accordion` or
+From a repository checkout, run a focused tracer with
+`pnpm --filter @tuiparts/solid demo:checkbox-group`,
+`pnpm --filter @tuiparts/solid demo:accordion`, or
 `pnpm --filter @tuiparts/solid demo:collapsible`.
 
 ## Imports
@@ -92,6 +93,7 @@ with `pnpm --filter @tuiparts/solid demo:accordion` or
 import { Accordion } from "@tuiparts/solid/accordion";
 import { Button } from "@tuiparts/solid/button";
 import { Checkbox } from "@tuiparts/solid/checkbox";
+import { CheckboxGroup } from "@tuiparts/solid/checkbox-group";
 import { Collapsible } from "@tuiparts/solid/collapsible";
 import { Input } from "@tuiparts/solid/input";
 import { Radio } from "@tuiparts/solid/radio";

--- a/packages/solid/examples/checkbox-group.tsx
+++ b/packages/solid/examples/checkbox-group.tsx
@@ -1,0 +1,72 @@
+/** @jsxImportSource @opentui/solid */
+
+import { createCliRenderer } from "@opentui/core";
+import { render } from "@opentui/solid";
+import type { CheckboxRootRenderable } from "@tuiparts/core/checkbox";
+import { createSignal, For, onMount } from "solid-js";
+import { Checkbox } from "../src/checkbox";
+import { CheckboxGroup } from "../src/checkbox-group";
+
+const items = [
+  ["email", "Email notifications"],
+  ["sms", "SMS notifications"],
+  ["product", "Product announcements"],
+] as const;
+
+function Demo() {
+  const [value, setValue] = createSignal<readonly string[]>(["email"]);
+  let first: CheckboxRootRenderable | undefined;
+  onMount(() => queueMicrotask(() => first?.focus()));
+  return (
+    <box flexDirection="column" gap={1} padding={2}>
+      <text content="Solid CheckboxGroup Primitive" fg="#FFFFFF" />
+      <text
+        content="Up/Down moves focus. Space/Enter toggles. Ctrl+C quits."
+        fg="#737373"
+      />
+      <CheckboxGroup value={value()} onValueChange={setValue}>
+        <For each={items}>
+          {([itemValue, label], index) => (
+            <Checkbox.Root
+              ref={(checkbox) => {
+                if (index() === 0) first = checkbox;
+              }}
+              value={itemValue}
+              flexDirection="row"
+              gap={1}
+              height={1}
+            >
+              {(state: Checkbox.Root.State) => (
+                <box
+                  backgroundColor={state.focused ? "#262626" : "transparent"}
+                  flexDirection="row"
+                  gap={1}
+                  paddingX={1}
+                  width="100%"
+                >
+                  <box width={1}>
+                    <Checkbox.Indicator>
+                      <text content="✓" fg="#60A5FA" />
+                    </Checkbox.Indicator>
+                  </box>
+                  <text
+                    content={label}
+                    fg={state.focused ? "#FFFFFF" : "#D4D4D4"}
+                  />
+                </box>
+              )}
+            </Checkbox.Root>
+          )}
+        </For>
+      </CheckboxGroup>
+      <text
+        content={`Checked: ${value().join(", ") || "none"}`}
+        fg="#60A5FA"
+      />
+    </box>
+  );
+}
+
+const renderer = await createCliRenderer({ exitOnCtrlC: true });
+renderer.setBackgroundColor("#0A0A0A");
+await render(() => <Demo />, renderer);

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -8,6 +8,7 @@
     "./dist/accordion/**",
     "./dist/button/**",
     "./dist/checkbox/**",
+    "./dist/checkbox-group/**",
     "./dist/collapsible/**",
     "./dist/dialog/**",
     "./dist/input/**",
@@ -30,6 +31,7 @@
     "./accordion": "./src/accordion/index.ts",
     "./button": "./src/button/index.tsx",
     "./checkbox": "./src/checkbox/index.tsx",
+    "./checkbox-group": "./src/checkbox-group/index.ts",
     "./collapsible": "./src/collapsible/index.ts",
     "./dialog": "./src/dialog/index.ts",
     "./input": "./src/input/index.tsx",
@@ -60,6 +62,10 @@
       "./checkbox": {
         "types": "./dist/checkbox/index.d.mts",
         "import": "./dist/checkbox/index.mjs"
+      },
+      "./checkbox-group": {
+        "types": "./dist/checkbox-group/index.d.mts",
+        "import": "./dist/checkbox-group/index.mjs"
       },
       "./collapsible": {
         "types": "./dist/collapsible/index.d.mts",
@@ -122,6 +128,7 @@
   "scripts": {
     "build": "tsdown",
     "demo:accordion": "bun run --preload @opentui/solid/preload examples/accordion.tsx",
+    "demo:checkbox-group": "bun run --preload @opentui/solid/preload examples/checkbox-group.tsx",
     "demo:collapsible": "bun run --preload @opentui/solid/preload examples/collapsible.tsx",
     "test": "bun test --preload @opentui/solid/preload",
     "typecheck": "tsc --noEmit",

--- a/packages/solid/src/checkbox-group/checkbox-group-primitive.test.tsx
+++ b/packages/solid/src/checkbox-group/checkbox-group-primitive.test.tsx
@@ -1,0 +1,333 @@
+/** @jsxImportSource @opentui/solid */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { TextRenderable } from "@opentui/core";
+import type { TestRendererSetup } from "@opentui/core/testing";
+import { testRender } from "@opentui/solid";
+import {
+  CheckboxRootRenderable,
+  type CheckboxState,
+} from "@tuiparts/core/checkbox";
+import {
+  CheckboxGroupRenderable,
+  CheckboxGroupStore,
+} from "@tuiparts/core/checkbox-group";
+import { createSignal } from "solid-js";
+import { Checkbox } from "../checkbox";
+import { CheckboxGroup } from "./index";
+
+let setup: TestRendererSetup | undefined;
+
+function textContent(id: string): string {
+  const text = setup?.renderer.root.findDescendantById(id);
+  if (!(text instanceof TextRenderable))
+    throw new Error(`Expected TextRenderable ${id}`);
+  return text.content.chunks.map((chunk) => chunk.text).join("");
+}
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = undefined;
+});
+
+describe("Solid CheckboxGroup", () => {
+  it("provides grouped state with a single checkbox round-trip", async () => {
+    setup = await testRender(
+      () => (
+        <CheckboxGroup defaultValue={["left"]} id="group">
+          <Checkbox.Root id="left" value="left">
+            {(state: CheckboxState) => (
+              <text
+                content={state.checked ? "checked" : "idle"}
+                id="left-state"
+              />
+            )}
+          </Checkbox.Root>
+          <Checkbox.Root id="right" value="right" />
+        </CheckboxGroup>
+      ),
+      { width: 30, height: 4 },
+    );
+    const group = setup.renderer.root.findDescendantById("group");
+    const right = setup.renderer.root.findDescendantById("right");
+    if (!(group instanceof CheckboxGroupRenderable))
+      throw new Error("Expected CheckboxGroupRenderable group");
+    if (!(right instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable right");
+
+    expect(textContent("left-state")).toBe("checked");
+    expect(group.value).toEqual(["left"]);
+
+    right.press();
+    await setup.waitFor(() => group.value.includes("right"));
+    expect(group.value).toEqual(["left", "right"]);
+  });
+
+  it("reactively updates controlled values without replacing Renderables", async () => {
+    let groupRef: CheckboxGroupRenderable | undefined;
+    let itemRef: CheckboxRootRenderable | undefined;
+    setup = await testRender(
+      () => {
+        const [value, setValue] = createSignal<readonly string[]>(["alpha"]);
+        return (
+          <CheckboxGroup
+            onValueChange={setValue}
+            ref={(next) => {
+              groupRef = next;
+            }}
+            value={value()}
+          >
+            <Checkbox.Root
+              ref={(next) => {
+                itemRef = next;
+              }}
+              value="alpha"
+            />
+            <Checkbox.Root id="beta" value="beta" />
+          </CheckboxGroup>
+        );
+      },
+      { width: 30, height: 4 },
+    );
+    const group = groupRef;
+    const item = itemRef;
+    const beta = setup.renderer.root.findDescendantById("beta");
+    if (!(beta instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable beta");
+    await setup.waitFor(() => {
+      const key = beta.groupKey;
+      return key && group
+        ? group.store.getItemState(key)?.available === true
+        : false;
+    });
+    beta.press();
+    await setup.waitFor(() => group?.value.includes("beta") ?? false);
+    expect(group?.value).toEqual(["alpha", "beta"]);
+    expect(groupRef).toBe(group);
+    expect(itemRef).toBe(item);
+  });
+
+  it("releases controlled group ownership at the observed value", async () => {
+    const requests: Array<readonly string[]> = [];
+    let setValue: (value: readonly string[] | undefined) => void = () => {};
+    let groupRef: CheckboxGroupRenderable | undefined;
+    setup = await testRender(
+      () => {
+        const [value, updateValue] = createSignal<
+          readonly string[] | undefined
+        >(["alpha"]);
+        setValue = updateValue;
+        return (
+          <CheckboxGroup
+            onValueChange={(nextValue) => requests.push(nextValue)}
+            ref={(group) => {
+              groupRef = group;
+            }}
+            value={value()}
+          >
+            <Checkbox.Root id="ownership-alpha" value="alpha" />
+            <Checkbox.Root id="ownership-beta" value="beta" />
+          </CheckboxGroup>
+        );
+      },
+      { width: 30, height: 4 },
+    );
+    const group = groupRef;
+    const alpha = setup.renderer.root.findDescendantById("ownership-alpha");
+    const beta = setup.renderer.root.findDescendantById("ownership-beta");
+    if (!group) throw new Error("Expected ownership CheckboxGroup");
+    if (!(alpha instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable ownership-alpha");
+    if (!(beta instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable ownership-beta");
+
+    // The change callback fires while controlled.
+    beta.press();
+    expect(requests).toEqual([["alpha", "beta"]]);
+
+    // Controlled prop commits through the Store.
+    setValue(["beta"]);
+    await setup.waitFor(() => group.value[0] === "beta");
+
+    // Prop removal: clearing the controlled value releases ownership.
+    setValue(undefined);
+    await Promise.resolve();
+    alpha.press();
+    expect(group.value).toEqual(["beta", "alpha"]);
+    expect(requests).toEqual([
+      ["alpha", "beta"],
+      ["beta", "alpha"],
+    ]);
+  });
+
+  it("reactively propagates disabled and visible props on a retained group", async () => {
+    const requests: Array<readonly string[]> = [];
+    let enableGroup: () => void = () => {};
+    let hideBeta: () => void = () => {};
+    let groupRef: CheckboxGroupRenderable | undefined;
+    setup = await testRender(
+      () => {
+        const [disabled, setDisabled] = createSignal(true);
+        const [betaVisible, setBetaVisible] = createSignal(true);
+        enableGroup = () => setDisabled(false);
+        hideBeta = () => setBetaVisible(false);
+        return (
+          <CheckboxGroup
+            disabled={disabled()}
+            onValueChange={(value) => requests.push(value)}
+            ref={(group) => {
+              groupRef = group;
+            }}
+          >
+            <Checkbox.Root id="disabled-alpha" value="alpha" />
+            <Checkbox.Root
+              id="disabled-beta"
+              value="beta"
+              visible={betaVisible()}
+            />
+          </CheckboxGroup>
+        );
+      },
+      { width: 30, height: 4 },
+    );
+    const group = groupRef;
+    const alpha = setup.renderer.root.findDescendantById("disabled-alpha");
+    const beta = setup.renderer.root.findDescendantById("disabled-beta");
+    if (!group) throw new Error("Expected disabled CheckboxGroup");
+    if (!(alpha instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable disabled-alpha");
+    if (!(beta instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable disabled-beta");
+    expect(group.disabled).toBe(true);
+
+    // Reactive disabled and visible prop propagation.
+    enableGroup();
+    await setup.waitFor(() => !group.disabled);
+    hideBeta();
+    await setup.waitFor(() => !beta.visible);
+
+    // One selection round-trip on the re-enabled group.
+    alpha.press();
+    expect(group.value).toEqual(["alpha"]);
+    expect(requests).toEqual([["alpha"]]);
+  });
+
+  it("replaces the group callback without replacing its Renderable", async () => {
+    const calls: string[] = [];
+    let replaceCallback: () => void = () => {};
+    let groupRef: CheckboxGroupRenderable | undefined;
+    setup = await testRender(
+      () => {
+        const [replacement, setReplacement] = createSignal(false);
+        replaceCallback = () => setReplacement(true);
+        return (
+          <CheckboxGroup
+            defaultValue={["alpha"]}
+            onValueChange={
+              replacement() ? () => calls.push("new") : () => calls.push("old")
+            }
+            ref={(value) => {
+              groupRef = value;
+            }}
+          >
+            <Checkbox.Root id="alpha-callback" value="alpha" />
+            <Checkbox.Root id="beta-callback" value="beta" />
+          </CheckboxGroup>
+        );
+      },
+      { width: 30, height: 4 },
+    );
+    const group = groupRef;
+    const alpha = setup.renderer.root.findDescendantById("alpha-callback");
+    const beta = setup.renderer.root.findDescendantById("beta-callback");
+    if (!group)
+      throw new Error("Expected CheckboxGroupRenderable callback target");
+    if (!(alpha instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable alpha-callback");
+    if (!(beta instanceof CheckboxRootRenderable))
+      throw new Error("Expected CheckboxRootRenderable beta-callback");
+
+    beta.press();
+    replaceCallback();
+    await Promise.resolve();
+    alpha.press();
+
+    expect(calls).toEqual(["old", "new"]);
+    expect(groupRef).toBe(group);
+  });
+
+  it("releases group subscriptions on teardown", async () => {
+    const originalSubscribe = CheckboxGroupStore.prototype.subscribe;
+    let activeSubscriptions = 0;
+    CheckboxGroupStore.prototype.subscribe = function subscribe(listener) {
+      activeSubscriptions += 1;
+      const unsubscribe = originalSubscribe.call(this, listener);
+      let active = true;
+      return () => {
+        if (!active) return;
+        active = false;
+        activeSubscriptions -= 1;
+        unsubscribe();
+      };
+    };
+    try {
+      setup = await testRender(
+        () => (
+          <CheckboxGroup>
+            <Checkbox.Root value="alpha">
+              <Checkbox.Indicator />
+            </Checkbox.Root>
+          </CheckboxGroup>
+        ),
+        { width: 20, height: 3 },
+      );
+      expect(activeSubscriptions).toBeGreaterThan(0);
+      setup.renderer.destroy();
+      setup = undefined;
+      expect(activeSubscriptions).toBe(0);
+    } finally {
+      CheckboxGroupStore.prototype.subscribe = originalSubscribe;
+    }
+  });
+
+  it("unregisters conditional Checkboxes before remounting the same value", async () => {
+    let setVisible: (visible: boolean) => void = () => {};
+    const groupRefs: CheckboxGroupRenderable[] = [];
+    const itemRefs: CheckboxRootRenderable[] = [];
+    setup = await testRender(
+      () => {
+        const [visible, updateVisible] = createSignal(true);
+        setVisible = updateVisible;
+        return (
+          <CheckboxGroup ref={(value) => groupRefs.push(value)}>
+            {visible() ? (
+              <Checkbox.Root
+                ref={(value) => itemRefs.push(value)}
+                value="alpha"
+              />
+            ) : null}
+          </CheckboxGroup>
+        );
+      },
+      { width: 30, height: 4 },
+    );
+    const first = itemRefs.at(-1);
+    if (!first) throw new Error("Expected initial lifecycle Checkbox");
+    const group = groupRefs.at(-1);
+    if (!group) throw new Error("Expected lifecycle CheckboxGroup");
+    const firstKey = first.groupKey;
+    if (!firstKey) throw new Error("Expected lifecycle Checkbox registration");
+
+    setVisible(false);
+    await setup.waitFor(() => group.store.getItemState(firstKey) === undefined);
+    setVisible(true);
+    await setup.waitFor(() => itemRefs.at(-1) !== first);
+
+    const replacement = itemRefs.at(-1);
+    if (!replacement)
+      throw new Error("Expected replacement lifecycle Checkbox");
+    expect(replacement).not.toBe(first);
+    replacement.press();
+    expect(group.value).toEqual(["alpha"]);
+  });
+});

--- a/packages/solid/src/checkbox-group/index.ts
+++ b/packages/solid/src/checkbox-group/index.ts
@@ -1,0 +1,1 @@
+export * from "./primitive";

--- a/packages/solid/src/checkbox-group/primitive.ts
+++ b/packages/solid/src/checkbox-group/primitive.ts
@@ -1,0 +1,95 @@
+import type { JSX } from "@opentui/solid";
+import { useRenderer } from "@opentui/solid";
+import {
+  type CheckboxGroupChangeDetails,
+  type CheckboxGroupOptions,
+  type CheckboxGroupOrientation,
+  CheckboxGroupRenderable,
+  type CheckboxGroupState,
+  CheckboxGroupStore,
+  type CheckboxGroupValueChangeHandler,
+} from "@tuiparts/core/checkbox-group";
+import {
+  createComponent,
+  createEffect,
+  type Ref,
+  splitProps,
+  untrack,
+} from "solid-js";
+import { CheckboxGroupContext } from "../internal/checkbox-group-context";
+import {
+  setRenderableRef,
+  spreadRenderableProps,
+} from "../internal/renderable-props";
+import { createRenderableState } from "../internal/renderable-state";
+
+type CheckboxGroupProps = Omit<CheckboxGroupOptions, "store"> & {
+  children?: JSX.Element | ((state: CheckboxGroupState) => JSX.Element);
+  ref?: Ref<CheckboxGroupRenderable>;
+};
+
+/** Solid adapter for CheckboxGroup selection and collection ownership. */
+export function CheckboxGroup(props: CheckboxGroup.Props): JSX.Element {
+  const renderer = useRenderer();
+  const store = new CheckboxGroupStore({
+    defaultValue: props.defaultValue,
+    disabled: props.disabled,
+    loopFocus: props.loopFocus,
+    onValueChange: props.onValueChange,
+    orientation: props.orientation,
+    value: props.value,
+  });
+  const state = createRenderableState(store, store.state);
+  const publicState: CheckboxGroupState = {
+    get disabled() {
+      return state().disabled;
+    },
+    get orientation() {
+      return state().orientation;
+    },
+    get value() {
+      return state().value;
+    },
+  };
+  const [local, renderableProps] = splitProps(props, [
+    "children",
+    "defaultValue",
+    "disabled",
+    "loopFocus",
+    "onValueChange",
+    "orientation",
+    "ref",
+    "value",
+  ]);
+  const element = new CheckboxGroupRenderable(
+    renderer,
+    untrack(() => ({ ...renderableProps, store })),
+  );
+  createEffect(() => {
+    element.disabled = local.disabled;
+    element.loopFocus = local.loopFocus;
+    element.onValueChange = local.onValueChange;
+    element.orientation = local.orientation;
+    element.value = local.value;
+  });
+  setRenderableRef(local.ref, element);
+
+  return createComponent(CheckboxGroupContext.Provider, {
+    value: store,
+    get children() {
+      const child = local.children;
+      const children = typeof child === "function" ? child(publicState) : child;
+      spreadRenderableProps(element, () => ({ ...renderableProps, children }));
+      return element;
+    },
+  });
+}
+
+/** Types scoped to the Solid CheckboxGroup component. */
+export namespace CheckboxGroup {
+  export type Props = CheckboxGroupProps;
+  export type State = CheckboxGroupState;
+  export type ChangeDetails = CheckboxGroupChangeDetails;
+  export type Orientation = CheckboxGroupOrientation;
+  export type ValueChangeHandler = CheckboxGroupValueChangeHandler;
+}

--- a/packages/solid/src/checkbox/primitive.ts
+++ b/packages/solid/src/checkbox/primitive.ts
@@ -1,6 +1,8 @@
 import type { JSX } from "@opentui/solid";
 import { useRenderer } from "@opentui/solid";
 import {
+  type CheckboxChangeDetails,
+  type CheckboxCheckedChangeHandler,
   type CheckboxIndicatorOptions,
   CheckboxIndicatorRenderable,
   type CheckboxRootOptions,
@@ -16,18 +18,16 @@ import {
   untrack,
   useContext,
 } from "solid-js";
+import { CheckboxGroupContext } from "../internal/checkbox-group-context";
 import {
   setRenderableRef,
   spreadRenderableProps,
 } from "../internal/renderable-props";
-import {
-  createRenderableState,
-  createToggleStateView,
-} from "../internal/renderable-state";
+import { createRenderableState } from "../internal/renderable-state";
 
 const CheckboxContext = createContext<CheckboxRootRenderable>();
 
-type RootProps = Omit<CheckboxRootOptions, "store"> & {
+type RootProps = Omit<CheckboxRootOptions, "group" | "store"> & {
   children?: JSX.Element | ((state: CheckboxState) => JSX.Element);
   ref?: Ref<CheckboxRootRenderable>;
 };
@@ -37,8 +37,10 @@ type IndicatorProps = Omit<CheckboxIndicatorOptions, "store"> & {
   ref?: Ref<CheckboxIndicatorRenderable>;
 };
 
+/** Solid adapter for a standalone or grouped Checkbox Root. */
 export function Root(props: Root.Props): JSX.Element {
   const renderer = useRenderer();
+  const group = useContext(CheckboxGroupContext);
   const [local, renderableProps] = splitProps(props, [
     "checked",
     "children",
@@ -46,6 +48,7 @@ export function Root(props: Root.Props): JSX.Element {
     "disabled",
     "onCheckedChange",
     "ref",
+    "value",
   ]);
   const element = new CheckboxRootRenderable(
     renderer,
@@ -54,15 +57,31 @@ export function Root(props: Root.Props): JSX.Element {
       checked: local.checked,
       defaultChecked: local.defaultChecked,
       disabled: local.disabled,
+      group,
       onCheckedChange: local.onCheckedChange,
+      value: local.value,
     })),
   );
   const state = createRenderableState(element, element.getState());
-  const publicState: CheckboxState = createToggleStateView(state);
+  const publicState: CheckboxState = {
+    get checked() {
+      return state().checked;
+    },
+    get disabled() {
+      return state().disabled;
+    },
+    get focused() {
+      return state().focused;
+    },
+    get tabbable() {
+      return state().tabbable;
+    },
+  };
   createEffect(() => {
     element.checked = local.checked;
     element.disabled = local.disabled;
     element.onCheckedChange = local.onCheckedChange;
+    element.value = local.value;
   });
   setRenderableRef(local.ref, element);
 
@@ -77,6 +96,7 @@ export function Root(props: Root.Props): JSX.Element {
   });
 }
 
+/** Solid adapter for the passive Checkbox Indicator Part. */
 export function Indicator(props: Indicator.Props): JSX.Element {
   const renderer = useRenderer();
   const root = useContext(CheckboxContext);
@@ -96,11 +116,15 @@ export function Indicator(props: Indicator.Props): JSX.Element {
   return element;
 }
 
+/** Types scoped to Checkbox.Root. */
 export namespace Root {
   export type Props = RootProps;
   export type State = CheckboxState;
+  export type ChangeDetails = CheckboxChangeDetails;
+  export type CheckedChangeHandler = CheckboxCheckedChangeHandler;
 }
 
+/** Types scoped to Checkbox.Indicator. */
 export namespace Indicator {
   export type Props = IndicatorProps;
 }

--- a/packages/solid/src/index.ts
+++ b/packages/solid/src/index.ts
@@ -2,6 +2,7 @@
 export * from "./accordion";
 export * from "./button";
 export * from "./checkbox";
+export * from "./checkbox-group";
 export * from "./collapsible";
 export * from "./dialog";
 export * from "./input";

--- a/packages/solid/src/internal/checkbox-group-context.ts
+++ b/packages/solid/src/internal/checkbox-group-context.ts
@@ -1,0 +1,5 @@
+import type { CheckboxGroupStore } from "@tuiparts/core/checkbox-group";
+import { createContext } from "solid-js";
+
+/** Private CheckboxGroup ownership consumed by Checkbox.Root. */
+export const CheckboxGroupContext = createContext<CheckboxGroupStore>();

--- a/packages/solid/tsdown.config.ts
+++ b/packages/solid/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     "src/accordion/index.ts",
     "src/button/index.tsx",
     "src/checkbox/index.tsx",
+    "src/checkbox-group/index.ts",
     "src/collapsible/index.ts",
     "src/dialog/index.ts",
     "src/input/index.tsx",

--- a/registry.json
+++ b/registry.json
@@ -67,6 +67,69 @@
       "registryDependencies": ["https://tuiparts.sh/r/solid/theme.json"]
     },
     {
+      "name": "core/checkbox-group",
+      "type": "registry:item",
+      "title": "Checkbox Group (Core)",
+      "description": "Editable imperative CheckboxGroup Recipe built on the tuiparts.sh packaged Primitives.",
+      "dependencies": ["@tuiparts/core@>=0.0.1 <0.1.0"],
+      "files": [
+        {
+          "path": "registry/checkbox-group/core.ts",
+          "type": "registry:file",
+          "target": "components/ui/checkbox-group.ts"
+        }
+      ],
+      "meta": {
+        "framework": "core",
+        "primitiveStatus": "primitive",
+        "sourceOwnership": "consumer",
+        "updateStrategy": "shadcn-add"
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/core/theme.json"]
+    },
+    {
+      "name": "react/checkbox-group",
+      "type": "registry:item",
+      "title": "Checkbox Group (React)",
+      "description": "Editable React CheckboxGroup Recipe built on the tuiparts.sh packaged Primitives.",
+      "dependencies": ["@tuiparts/react@>=0.0.1 <0.1.0"],
+      "files": [
+        {
+          "path": "registry/checkbox-group/react.tsx",
+          "type": "registry:file",
+          "target": "components/ui/checkbox-group.tsx"
+        }
+      ],
+      "meta": {
+        "framework": "react",
+        "primitiveStatus": "primitive",
+        "sourceOwnership": "consumer",
+        "updateStrategy": "shadcn-add"
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/react/theme.json"]
+    },
+    {
+      "name": "solid/checkbox-group",
+      "type": "registry:item",
+      "title": "Checkbox Group (Solid)",
+      "description": "Editable Solid CheckboxGroup Recipe built on the tuiparts.sh packaged Primitives.",
+      "dependencies": ["@tuiparts/solid@>=0.0.1 <0.1.0"],
+      "files": [
+        {
+          "path": "registry/checkbox-group/solid.tsx",
+          "type": "registry:file",
+          "target": "components/ui/checkbox-group.tsx"
+        }
+      ],
+      "meta": {
+        "framework": "solid",
+        "primitiveStatus": "primitive",
+        "sourceOwnership": "consumer",
+        "updateStrategy": "shadcn-add"
+      },
+      "registryDependencies": ["https://tuiparts.sh/r/solid/theme.json"]
+    },
+    {
       "name": "core/checkbox",
       "type": "registry:item",
       "title": "Checkbox (Core)",

--- a/registry/README.md
+++ b/registry/README.md
@@ -16,6 +16,7 @@ Each catalog recipe is available as `core/<name>`, `react/<name>`, and
 | --- | --- | --- |
 | Accordion | Single or multiple expansion, activation, focus, and Panel lifecycle | `Accordion`, `AccordionItem`, `AccordionTrigger`, `AccordionContent` |
 | Checkbox | Checkbox Root and Indicator | `Checkbox` |
+| CheckboxGroup/Checkbox | Array-valued checked ownership and roving focus | `CheckboxGroup`, `CheckboxGroupItem` |
 | Collapsible | Open state, activation, focus, and Panel lifecycle | `Collapsible`, `CollapsibleTrigger`, `CollapsibleContent` |
 | Switch | Switch Root and Thumb | `Switch` |
 | Button | Button activation primitive | `Button` |
@@ -171,7 +172,7 @@ dependencies on a hidden theme runtime.
 `pnpm validate:registry` verifies the catalog's dependencies, lifecycle
 metadata, and matching React/Solid vocabulary. It builds every registry item
 with the pinned official shadcn CLI, creates an isolated strict OpenTUI host
-for each runtime, and installs every item with bounded concurrency (30
+for each runtime, and installs every item with bounded concurrency (45
 consumers; the framework-neutral preset items install and byte-compare inside
 the three theme consumers, whose smokes exercise them). It resolves each
 Recipe's Theme `registryDependencies` from the locally built Registry,

--- a/registry/checkbox-group/README.md
+++ b/registry/checkbox-group/README.md
@@ -1,0 +1,18 @@
+# CheckboxGroup Recipe
+
+Editable CheckboxGroup presentation for Core, React, and Solid. The Recipe
+uses the packaged CheckboxGroup and existing Checkbox Primitives for
+array-valued ownership, activation, disablement, focus navigation, and dynamic
+registration. Installed source owns labels, marks, layout, spacing, and theme
+colors.
+
+Install the item for your runtime:
+
+```bash
+pnpm dlx shadcn@4.13.0 add @tuiparts/react/checkbox-group
+pnpm dlx shadcn@4.13.0 add @tuiparts/solid/checkbox-group
+pnpm dlx shadcn@4.13.0 add @tuiparts/core/checkbox-group
+```
+
+The CheckboxGroup item depends on the matching Checkbox and Theme Recipes, so
+the CLI installs those editable sources with it.

--- a/registry/checkbox-group/core.ts
+++ b/registry/checkbox-group/core.ts
@@ -1,0 +1,105 @@
+import {
+  BoxRenderable,
+  type RenderContext,
+  TextRenderable,
+} from "@opentui/core";
+import {
+  CheckboxIndicatorRenderable,
+  CheckboxRootRenderable,
+  type CheckboxState,
+} from "@tuiparts/core/checkbox";
+import {
+  CheckboxGroupRenderable,
+  type CheckboxGroupStore,
+  type CheckboxGroupOptions as PrimitiveCheckboxGroupOptions,
+} from "@tuiparts/core/checkbox-group";
+import { type Tokens, theme } from "./theme";
+
+/** Options for the consumer-owned imperative CheckboxGroup Root. */
+export type CheckboxGroupOptions = Omit<PrimitiveCheckboxGroupOptions, "store">;
+
+/** Options for one consumer-owned grouped Checkbox. */
+export interface CheckboxGroupItemOptions {
+  /** Whether this Checkbox is locally disabled. */
+  disabled?: boolean;
+  /** Grouped Checkbox label. */
+  label: string;
+  /** One terminal-cell mark; widen the editable mark cell for wider content. */
+  mark?: string;
+  /** Unique value owned by CheckboxGroup. */
+  value: string;
+}
+
+class CheckboxGroupItemRecipeRenderable extends CheckboxRootRenderable {
+  private readonly unsubscribeState: () => void;
+  private readonly unsubscribeTheme: () => void;
+
+  constructor(
+    ctx: RenderContext,
+    store: CheckboxGroupStore,
+    options: CheckboxGroupItemOptions,
+  ) {
+    super(ctx, {
+      backgroundColor: "transparent",
+      disabled: options.disabled,
+      flexDirection: "row",
+      gap: 1,
+      group: store,
+      value: options.value,
+    });
+    const markCell = new BoxRenderable(ctx, { width: 1 });
+    const indicator = new CheckboxIndicatorRenderable(ctx, {
+      store: this.store,
+    });
+    const mark = new TextRenderable(ctx, { content: "" });
+    const label = new TextRenderable(ctx, { content: options.label });
+    indicator.add(mark);
+    markCell.add(indicator);
+    this.add(markCell);
+    this.add(label);
+
+    const apply = (tokens: Readonly<Tokens>, state: CheckboxState) => {
+      mark.content = options.mark ?? tokens.glyphs.check;
+      mark.fg = tokens.colors.primary;
+      label.fg = state.disabled
+        ? tokens.colors.disabledForeground
+        : state.focused
+          ? tokens.colors.focus
+          : tokens.colors.foreground;
+    };
+    apply(theme.get(), this.getState());
+    this.unsubscribeState = this.subscribe((state) =>
+      apply(theme.get(), state),
+    );
+    this.unsubscribeTheme = theme.subscribe(() =>
+      apply(theme.get(), this.getState()),
+    );
+  }
+
+  override endCoordinationLifetime(): void {
+    this.unsubscribeState();
+    this.unsubscribeTheme();
+    super.endCoordinationLifetime();
+  }
+}
+
+/** Creates the imperative CheckboxGroup ownership boundary. */
+export function createCheckboxGroup(
+  ctx: RenderContext,
+  options: CheckboxGroupOptions = {},
+): CheckboxGroupRenderable {
+  return new CheckboxGroupRenderable(ctx, {
+    ...options,
+    flexDirection: options.orientation === "horizontal" ? "row" : "column",
+    gap: options.gap ?? 1,
+  });
+}
+
+/** Creates one grouped Checkbox using packaged Checkbox behavior. */
+export function createCheckboxGroupItem(
+  ctx: RenderContext,
+  store: CheckboxGroupStore,
+  options: CheckboxGroupItemOptions,
+): CheckboxRootRenderable {
+  return new CheckboxGroupItemRecipeRenderable(ctx, store, options);
+}

--- a/registry/checkbox-group/react.tsx
+++ b/registry/checkbox-group/react.tsx
@@ -1,0 +1,75 @@
+/** @jsxImportSource @opentui/react */
+
+import { Checkbox as CheckboxPrimitive } from "@tuiparts/react/checkbox";
+import { CheckboxGroup as CheckboxGroupPrimitive } from "@tuiparts/react/checkbox-group";
+import { useTheme } from "./use-theme";
+
+/** Props for the consumer-owned React CheckboxGroup layout. */
+export type CheckboxGroupProps = CheckboxGroupPrimitive.Props;
+
+/** Props for one consumer-owned grouped Checkbox. */
+export interface CheckboxGroupItemProps
+  extends Omit<CheckboxPrimitive.Root.Props, "children" | "value"> {
+  /** Grouped Checkbox label. */
+  label: string;
+  /** One terminal-cell mark; widen the editable mark cell for wider content. */
+  mark?: string;
+  /** Semantic color treatment. */
+  tone?: "accent" | "success";
+  /** Unique value owned by CheckboxGroup. */
+  value: string;
+}
+
+/** Consumer-owned React CheckboxGroup layout. */
+export function CheckboxGroup({ orientation, ...props }: CheckboxGroupProps) {
+  return (
+    <CheckboxGroupPrimitive
+      flexDirection={orientation === "horizontal" ? "row" : "column"}
+      gap={1}
+      orientation={orientation}
+      {...props}
+    />
+  );
+}
+
+/** Consumer-owned grouped Checkbox presentation. */
+export function CheckboxGroupItem({
+  label,
+  mark,
+  tone = "accent",
+  disabled,
+  ...props
+}: CheckboxGroupItemProps) {
+  const tokens = useTheme();
+  const markColor =
+    tone === "success" ? tokens.colors.success : tokens.colors.primary;
+  return (
+    <CheckboxPrimitive.Root
+      backgroundColor="transparent"
+      disabled={disabled}
+      flexDirection="row"
+      gap={1}
+      {...props}
+    >
+      {(state) => (
+        <>
+          <box width={1}>
+            <CheckboxPrimitive.Indicator>
+              <text content={mark ?? tokens.glyphs.check} fg={markColor} />
+            </CheckboxPrimitive.Indicator>
+          </box>
+          <text
+            content={label}
+            fg={
+              state.disabled
+                ? tokens.colors.disabledForeground
+                : state.focused
+                  ? tokens.colors.focus
+                  : tokens.colors.foreground
+            }
+          />
+        </>
+      )}
+    </CheckboxPrimitive.Root>
+  );
+}

--- a/registry/checkbox-group/smoke/core.test.ts
+++ b/registry/checkbox-group/smoke/core.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, expect, test } from "bun:test";
+import { parseColor, TextRenderable } from "@opentui/core";
+import {
+  createTestRenderer,
+  type TestRendererSetup,
+} from "@opentui/core/testing";
+import {
+  createCheckboxGroup,
+  createCheckboxGroupItem,
+} from "./components/ui/checkbox-group";
+import { theme } from "./components/ui/theme";
+
+let setup: TestRendererSetup | undefined;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = undefined;
+});
+
+test("installed Core CheckboxGroup recipe runtime smoke", async () => {
+  setup = await createTestRenderer({ width: 30, height: 3 });
+  const group = createCheckboxGroup(setup.renderer);
+  const left = createCheckboxGroupItem(setup.renderer, group.store, {
+    label: "Left",
+    value: "left",
+  });
+  group.add(left);
+  setup.renderer.root.add(group);
+  await setup.renderOnce();
+  left.press();
+  expect(group.value).toEqual(["left"]);
+});
+
+test("restyles from the theme store on theme switch", async () => {
+  theme.register("smoke", { tokens: { colors: { primary: "#123456" } } });
+  setup = await createTestRenderer({ width: 30, height: 3 });
+  const group = createCheckboxGroup(setup.renderer);
+  const left = createCheckboxGroupItem(setup.renderer, group.store, {
+    label: "Left",
+    value: "left",
+  });
+  group.add(left);
+  setup.renderer.root.add(group);
+  await setup.renderOnce();
+  left.press();
+  expect(group.value).toEqual(["left"]);
+
+  theme.setActive("smoke");
+  const indicator = left.getChildren()[0]?.getChildren()[0];
+  const mark = indicator?.getChildren()[0];
+  if (!(mark instanceof TextRenderable))
+    throw new Error("Expected Checkbox mark TextRenderable");
+  expect(mark.fg.equals(parseColor("#123456"))).toBe(true);
+
+  theme.setActive("terminal");
+  expect(mark.fg.equals(parseColor("#123456"))).toBe(false);
+});

--- a/registry/checkbox-group/smoke/react.test.tsx
+++ b/registry/checkbox-group/smoke/react.test.tsx
@@ -1,0 +1,69 @@
+/** @jsxImportSource @opentui/react */
+
+import { afterEach, expect, test } from "bun:test";
+import { parseColor, TextRenderable } from "@opentui/core";
+import type { TestRendererSetup } from "@opentui/core/testing";
+import { testRender } from "@opentui/react/test-utils";
+import { CheckboxRootRenderable } from "@tuiparts/core/checkbox";
+import { CheckboxGroupRenderable } from "@tuiparts/core/checkbox-group";
+import { act } from "react";
+import {
+  CheckboxGroup,
+  CheckboxGroupItem,
+} from "./components/ui/checkbox-group";
+import { theme } from "./components/ui/theme";
+
+let setup: TestRendererSetup | undefined;
+
+afterEach(async () => {
+  await act(async () => setup?.renderer.destroy());
+  setup = undefined;
+});
+
+test("installed React CheckboxGroup recipe runtime smoke", async () => {
+  setup = await testRender(
+    <CheckboxGroup id="group">
+      <CheckboxGroupItem id="left" label="Left" value="left" />
+    </CheckboxGroup>,
+    { width: 30, height: 3 },
+  );
+  const group = setup.renderer.root.findDescendantById("group");
+  const left = setup.renderer.root.findDescendantById("left");
+  if (!(group instanceof CheckboxGroupRenderable))
+    throw new Error("Expected CheckboxGroupRenderable group");
+  if (!(left instanceof CheckboxRootRenderable))
+    throw new Error("Expected CheckboxRootRenderable left");
+  await setup.waitFor(() => {
+    const key = left.groupKey;
+    return key ? group.store.getItemState(key)?.available === true : false;
+  });
+  await act(async () => left.press());
+  expect(group.value).toEqual(["left"]);
+});
+
+test("restyles rendered items on theme switch", async () => {
+  theme.register("smoke", { tokens: { colors: { primary: "#123456" } } });
+  setup = await testRender(
+    <CheckboxGroup id="themed" defaultValue={["left"]}>
+      <CheckboxGroupItem id="themed-left" label="Left" value="left" />
+    </CheckboxGroup>,
+    { width: 30, height: 3 },
+  );
+  const left = setup.renderer.root.findDescendantById("themed-left");
+  if (!(left instanceof CheckboxRootRenderable))
+    throw new Error("Expected themed CheckboxRootRenderable");
+  const indicator = left.getChildren()[0]?.getChildren()[0];
+  const mark = indicator?.getChildren()[0];
+  if (!(mark instanceof TextRenderable))
+    throw new Error("Expected Checkbox mark TextRenderable");
+
+  await act(async () => {
+    theme.setActive("smoke");
+  });
+  await setup.waitFor(() => mark.fg.equals(parseColor("#123456")));
+
+  expect(setup.renderer.root.findDescendantById("themed-left")).toBe(left);
+  await act(async () => {
+    theme.setActive("terminal");
+  });
+});

--- a/registry/checkbox-group/smoke/solid.test.tsx
+++ b/registry/checkbox-group/smoke/solid.test.tsx
@@ -1,0 +1,62 @@
+/** @jsxImportSource @opentui/solid */
+
+import { afterEach, expect, test } from "bun:test";
+import { parseColor, TextRenderable } from "@opentui/core";
+import type { TestRendererSetup } from "@opentui/core/testing";
+import { testRender } from "@opentui/solid";
+import { CheckboxRootRenderable } from "@tuiparts/core/checkbox";
+import type { CheckboxGroupRenderable } from "@tuiparts/core/checkbox-group";
+import {
+  CheckboxGroup,
+  CheckboxGroupItem,
+} from "./components/ui/checkbox-group";
+import { theme } from "./components/ui/theme";
+
+let setup: TestRendererSetup | undefined;
+let group: CheckboxGroupRenderable | undefined;
+
+afterEach(() => {
+  setup?.renderer.destroy();
+  setup = undefined;
+});
+
+test("installed Solid CheckboxGroup recipe runtime smoke", async () => {
+  setup = await testRender(
+    () => (
+      <CheckboxGroup ref={(value) => (group = value)}>
+        <CheckboxGroupItem id="left" label="Left" value="left" />
+      </CheckboxGroup>
+    ),
+    { width: 30, height: 3 },
+  );
+  const left = setup.renderer.root.findDescendantById("left");
+  if (!(left instanceof CheckboxRootRenderable))
+    throw new Error("Expected CheckboxRootRenderable left");
+  left.press();
+  expect(group?.value).toEqual(["left"]);
+});
+
+test("restyles rendered items on theme switch", async () => {
+  theme.register("smoke", { tokens: { colors: { primary: "#123456" } } });
+  setup = await testRender(
+    () => (
+      <CheckboxGroup id="themed" defaultValue={["left"]}>
+        <CheckboxGroupItem id="themed-left" label="Left" value="left" />
+      </CheckboxGroup>
+    ),
+    { width: 30, height: 3 },
+  );
+  const left = setup.renderer.root.findDescendantById("themed-left");
+  if (!(left instanceof CheckboxRootRenderable))
+    throw new Error("Expected themed CheckboxRootRenderable");
+  const indicator = left.getChildren()[0]?.getChildren()[0];
+  const mark = indicator?.getChildren()[0];
+  if (!(mark instanceof TextRenderable))
+    throw new Error("Expected Checkbox mark TextRenderable");
+
+  theme.setActive("smoke");
+  await setup.waitFor(() => mark.fg.equals(parseColor("#123456")));
+
+  expect(setup.renderer.root.findDescendantById("themed-left")).toBe(left);
+  theme.setActive("terminal");
+});

--- a/registry/checkbox-group/solid.tsx
+++ b/registry/checkbox-group/solid.tsx
@@ -1,0 +1,82 @@
+/** @jsxImportSource @opentui/solid */
+
+import { Checkbox as CheckboxPrimitive } from "@tuiparts/solid/checkbox";
+import { CheckboxGroup as CheckboxGroupPrimitive } from "@tuiparts/solid/checkbox-group";
+import { splitProps } from "solid-js";
+import { useTheme } from "./use-theme";
+
+/** Props for the consumer-owned Solid CheckboxGroup layout. */
+export type CheckboxGroupProps = CheckboxGroupPrimitive.Props;
+
+/** Props for one consumer-owned grouped Checkbox. */
+export interface CheckboxGroupItemProps
+  extends Omit<CheckboxPrimitive.Root.Props, "children" | "value"> {
+  /** Grouped Checkbox label. */
+  label: string;
+  /** One terminal-cell mark; widen the editable mark cell for wider content. */
+  mark?: string;
+  /** Semantic color treatment. */
+  tone?: "accent" | "success";
+  /** Unique value owned by CheckboxGroup. */
+  value: string;
+}
+
+/** Consumer-owned Solid CheckboxGroup layout. */
+export function CheckboxGroup(props: CheckboxGroupProps) {
+  const [local, group] = splitProps(props, ["orientation"]);
+  return (
+    <CheckboxGroupPrimitive
+      flexDirection={local.orientation === "horizontal" ? "row" : "column"}
+      gap={1}
+      orientation={local.orientation}
+      {...group}
+    />
+  );
+}
+
+/** Consumer-owned grouped Checkbox presentation. */
+export function CheckboxGroupItem(props: CheckboxGroupItemProps) {
+  const [recipe, checkbox] = splitProps(props, [
+    "disabled",
+    "label",
+    "mark",
+    "tone",
+  ]);
+  const tokens = useTheme();
+  return (
+    <CheckboxPrimitive.Root
+      backgroundColor="transparent"
+      disabled={recipe.disabled}
+      flexDirection="row"
+      gap={1}
+      {...checkbox}
+    >
+      {(state: CheckboxPrimitive.Root.State) => (
+        <>
+          <box width={1}>
+            <CheckboxPrimitive.Indicator>
+              <text
+                content={recipe.mark ?? tokens().glyphs.check}
+                fg={
+                  recipe.tone === "success"
+                    ? tokens().colors.success
+                    : tokens().colors.primary
+                }
+              />
+            </CheckboxPrimitive.Indicator>
+          </box>
+          <text
+            content={recipe.label}
+            fg={
+              state.disabled
+                ? tokens().colors.disabledForeground
+                : state.focused
+                  ? tokens().colors.focus
+                  : tokens().colors.foreground
+            }
+          />
+        </>
+      )}
+    </CheckboxPrimitive.Root>
+  );
+}

--- a/registry/checkbox/core.ts
+++ b/registry/checkbox/core.ts
@@ -4,6 +4,7 @@ import {
   TextRenderable,
 } from "@opentui/core";
 import {
+  type CheckboxChangeDetails,
   CheckboxIndicatorRenderable,
   CheckboxRootRenderable,
 } from "@tuiparts/core/checkbox";
@@ -16,7 +17,7 @@ export interface CheckboxOptions {
   label: string;
   /** One terminal-cell mark; widen the editable mark cell for wider content. */
   mark?: string;
-  onCheckedChange?: (checked: boolean) => void;
+  onCheckedChange?: (checked: boolean, details: CheckboxChangeDetails) => void;
 }
 
 class CheckboxRecipeRenderable extends CheckboxRootRenderable {

--- a/registry/tsconfig.core.json
+++ b/registry/tsconfig.core.json
@@ -7,6 +7,7 @@
       "badge",
       "button",
       "checkbox",
+      "checkbox-group",
       "collapsible",
       "dialog",
       "input",

--- a/registry/tsconfig.react.json
+++ b/registry/tsconfig.react.json
@@ -9,6 +9,7 @@
       "badge",
       "button",
       "checkbox",
+      "checkbox-group",
       "collapsible",
       "dialog",
       "input",

--- a/registry/tsconfig.solid.json
+++ b/registry/tsconfig.solid.json
@@ -9,6 +9,7 @@
       "badge",
       "button",
       "checkbox",
+      "checkbox-group",
       "collapsible",
       "dialog",
       "input",

--- a/scripts/validate-packages.mjs
+++ b/scripts/validate-packages.mjs
@@ -97,6 +97,7 @@ try {
     "@tuiparts/core/accordion",
     "@tuiparts/core/button",
     "@tuiparts/core/checkbox",
+    "@tuiparts/core/checkbox-group",
     "@tuiparts/core/collapsible",
     "@tuiparts/core/dialog",
     "@tuiparts/core/input",
@@ -111,6 +112,7 @@ try {
     "@tuiparts/react/accordion",
     "@tuiparts/react/button",
     "@tuiparts/react/checkbox",
+    "@tuiparts/react/checkbox-group",
     "@tuiparts/react/collapsible",
     "@tuiparts/react/dialog",
     "@tuiparts/react/input",
@@ -125,6 +127,7 @@ try {
     "@tuiparts/solid/accordion",
     "@tuiparts/solid/button",
     "@tuiparts/solid/checkbox",
+    "@tuiparts/solid/checkbox-group",
     "@tuiparts/solid/collapsible",
     "@tuiparts/solid/dialog",
     "@tuiparts/solid/input",
@@ -169,6 +172,7 @@ import {
   AccordionTriggerRenderable,
 } from "@tuiparts/core/accordion";
 import { CheckboxRootRenderable } from "@tuiparts/core/checkbox";
+import { CheckboxGroupRenderable } from "@tuiparts/core/checkbox-group";
 import {
   CollapsiblePanelRenderable,
   CollapsibleRootRenderable,
@@ -206,6 +210,17 @@ try {
   setup.renderer.root.add(checkbox);
   checkbox.press();
   if (!checkbox.checked) throw new Error("Compiled Checkbox did not activate");
+
+  const checkboxGroup = new CheckboxGroupRenderable(setup.renderer);
+  const groupedCheckbox = new CheckboxRootRenderable(setup.renderer, {
+    group: checkboxGroup.store,
+    value: "updates",
+  });
+  checkboxGroup.add(groupedCheckbox);
+  setup.renderer.root.add(checkboxGroup);
+  groupedCheckbox.press();
+  if (checkboxGroup.value[0] !== "updates")
+    throw new Error("Compiled CheckboxGroup did not check its item");
 
   const collapsible = new CollapsibleRootRenderable(setup.renderer);
   const trigger = new CollapsibleTriggerRenderable(setup.renderer, {

--- a/scripts/validate-registry.mjs
+++ b/scripts/validate-registry.mjs
@@ -75,6 +75,7 @@ const frameworks = {
 };
 const recipes = [
   "accordion",
+  "checkbox-group",
   "checkbox",
   "collapsible",
   "switch",
@@ -91,6 +92,7 @@ const recipes = [
 ];
 const catalogRecipes = [
   "accordion",
+  "checkbox-group",
   "checkbox",
   "collapsible",
   "switch",


### PR DESCRIPTION
## Summary

- add framework-neutral CheckboxGroup behavior with array-valued controlled/uncontrolled ownership, effective disablement, dynamic Checkbox registration, and orientation-aware roving focus
- let existing `Checkbox.Root` optionally adopt CheckboxGroup ownership in React and Solid, preserving standalone Checkbox and avoiding an artificial `CheckboxGroup.Item` Part
- add Core, React, and Solid package exports, tests, Registry Recipes, smoke coverage, packed-consumer validation, documentation, runnable tracers, and a linked Foundation changeset

## Behavior

- grouped Checkboxes require unique string values and remain independently checkable
- vertical groups use Up/Down; horizontal groups use Left/Right; Home/End are supported; navigation wraps unless `loopFocus` is false
- removed items preserve selected values for conditional remounts, while uncontrolled value renames repair selection without callbacks
- local Checkbox callbacks run before the group callback and receive the same frozen Pressable details
- one live CheckboxGroup Root may adopt a Store at a time, with coordination teardown and focus repair covered by tests

## Intentional pre-release Checkbox changes

- `CheckboxState` now exposes truthful `tabbable` state
- checked-change callbacks now receive immutable terminal activation details
- Checkbox now owns its Store implementation rather than inheriting the Switch-oriented shared `CheckedStore`; this keeps group identity, collection, and focus policy out of Switch

These decisions are recorded in ADR-0012 and the CheckboxGroup behavior contract.

## Validation

- `pnpm format`
- `pnpm typecheck`
- `pnpm lint`
- focused Core, React, Solid, and Registry CheckboxGroup tests
- `pnpm validate:foundation`
- `pnpm validate:registry --recipe=checkbox-group`
- `pnpm docs:build`
- `pnpm changeset:status`
- `git diff --check`
- manually exercised Core, React, and Solid tracers through focus movement and keyboard activation
