### PR TITLE
Keep CheckboxGroup coordination types internal

### DIFF
--- a/.changeset/bright-checkboxes-gather.md
+++ b/.changeset/bright-checkboxes-gather.md
@@ -4,6 +4,6 @@
 "@tuiparts/solid": patch
 ---
 
-Add CheckboxGroup with array-valued checked ownership, optional Checkbox.Root adoption, effective disablement, dynamic registration, and orientation-aware roving focus.
+Add CheckboxGroup with array-valued checked ownership, optional Checkbox.Root adoption, effective disablement, dynamic registration, and orientation-aware roving focus. Low-level collection registration and navigation types remain internal rather than becoming part of the public package interface.
 
 Checkbox state now exposes `tabbable`, and checked-change callbacks receive immutable terminal press details. Checkbox no longer shares its internal Store implementation with Switch so grouped collection policy remains isolated from Switch.

--- a/packages/core/src/checkbox-group/index.ts
+++ b/packages/core/src/checkbox-group/index.ts
@@ -1,11 +1,5 @@
 export type { PressDetails as CheckboxGroupChangeDetails } from "../internal/pressable";
 export {
-  type CheckboxGroupFocusDirection,
-  type CheckboxGroupItemKey,
-  type CheckboxGroupItemRegistration,
-  type CheckboxGroupItemRegistrationOptions,
-  type CheckboxGroupItemState,
-  type CheckboxGroupNavigationTarget,
   type CheckboxGroupOptions,
   type CheckboxGroupOrientation,
   CheckboxGroupRenderable,

--- a/packages/core/src/checkbox-group/primitive.ts
+++ b/packages/core/src/checkbox-group/primitive.ts
@@ -2,23 +2,11 @@ import type { BaseRenderable, BoxOptions, RenderContext } from "@opentui/core";
 import { CheckboxRootRenderable } from "../checkbox/primitive";
 import type { PressDetails } from "../internal/pressable";
 import {
-  type CollectionFocusDirection,
   type CollectionItemInput,
   type CollectionItemKey,
-  type CollectionItemRegistration,
-  type CollectionItemRegistrationOptions,
-  type CollectionNavigationTarget,
   RovingCollectionRenderable,
   RovingCollectionStore,
 } from "../internal/roving-collection";
-
-// These public aliases deliberately insulate API vocabulary from the internal
-// roving-collection vocabulary, so internal names never leak into declarations.
-/** Stable identity for a Checkbox registered with a CheckboxGroup. */
-export type CheckboxGroupItemKey = CollectionItemKey;
-
-/** Direction used by CheckboxGroup roving-focus navigation. */
-export type CheckboxGroupFocusDirection = CollectionFocusDirection;
 
 /** Terminal layout direction used by CheckboxGroup keyboard navigation. */
 export type CheckboxGroupOrientation = "horizontal" | "vertical";
@@ -68,16 +56,6 @@ export interface CheckboxGroupStoreOptions {
   /** Controlled checked values. */
   readonly value?: readonly string[];
 }
-
-/** Options used to register one Checkbox with a CheckboxGroup Store. */
-export type CheckboxGroupItemRegistrationOptions =
-  CollectionItemRegistrationOptions;
-
-/** Retained registration for one CheckboxGroup member. */
-export type CheckboxGroupItemRegistration = CollectionItemRegistration;
-
-/** Focus target returned by CheckboxGroup collection navigation. */
-export type CheckboxGroupNavigationTarget = CollectionNavigationTarget;
 
 function normalizeValue(
   value: readonly string[] | undefined,
@@ -139,7 +117,7 @@ export class CheckboxGroupStore extends RovingCollectionStore<
 
   /** Requests that a registered Checkbox change its checked state. */
   requestToggle(
-    key: CheckboxGroupItemKey,
+    key: CollectionItemKey,
     checked: boolean,
     details: PressDetails,
     onAccepted?: () => void,
@@ -204,7 +182,7 @@ export class CheckboxGroupStore extends RovingCollectionStore<
   }
 
   protected createItemState(
-    key: CheckboxGroupItemKey,
+    key: CollectionItemKey,
     item: CollectionItemInput,
   ): CheckboxGroupItemState {
     return Object.freeze({
@@ -387,7 +365,7 @@ export class CheckboxGroupRenderable extends RovingCollectionRenderable<
 
   protected itemKeyFor(
     child: BaseRenderable,
-  ): CheckboxGroupItemKey | null | undefined {
+  ): CollectionItemKey | null | undefined {
     return child instanceof CheckboxRootRenderable &&
       child.group === this._store
       ? (child.groupKey ?? null)

--- a/packages/core/src/checkbox/primitive.ts
+++ b/packages/core/src/checkbox/primitive.ts
@@ -6,14 +6,16 @@ import {
   type RenderContext,
 } from "@opentui/core";
 import {
-  type CheckboxGroupFocusDirection,
-  type CheckboxGroupItemKey,
-  type CheckboxGroupItemRegistration,
   type CheckboxGroupItemState,
   CheckboxGroupRenderable,
   type CheckboxGroupStore,
 } from "../checkbox-group/primitive";
 import { PressableRenderable, type PressDetails } from "../internal/pressable";
+import type {
+  CollectionFocusDirection,
+  CollectionItemKey,
+  CollectionItemRegistration,
+} from "../internal/roving-collection";
 
 /** Gesture details for one semantic Checkbox press. */
 export type CheckboxChangeDetails = PressDetails;
@@ -66,7 +68,7 @@ export class CheckboxStore {
   private _checked: boolean;
   private _value?: string;
   private onCheckedChangeCallback?: CheckboxCheckedChangeHandler;
-  private registration?: CheckboxGroupItemRegistration;
+  private registration?: CollectionItemRegistration;
   private collectionState?: CheckboxGroupItemState;
   private readonly listeners = new Set<CheckboxStateListener>();
   private unsubscribeGroup?: () => void;
@@ -104,7 +106,7 @@ export class CheckboxStore {
   }
 
   /** Current group registration key, when mounted in a CheckboxGroup. */
-  get groupKey(): CheckboxGroupItemKey | undefined {
+  get groupKey(): CollectionItemKey | undefined {
     return this.registration?.key;
   }
 
@@ -351,7 +353,7 @@ export class CheckboxRootRenderable extends PressableRenderable {
   }
 
   /** Group registration key when this Checkbox belongs to a group. */
-  get groupKey(): CheckboxGroupItemKey | undefined {
+  get groupKey(): CollectionItemKey | undefined {
     return this._store.groupKey;
   }
 
@@ -475,7 +477,7 @@ export class CheckboxRootRenderable extends PressableRenderable {
     this._store.setFocused(false);
   }
 
-  private moveFocus(direction: CheckboxGroupFocusDirection): boolean {
+  private moveFocus(direction: CollectionFocusDirection): boolean {
     const key = this.groupKey;
     if (!this.group || !key) return false;
     const target = this.group.getNavigationTarget(key, direction);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,12 +38,6 @@ export {
 } from "./checkbox";
 export {
   type CheckboxGroupChangeDetails,
-  type CheckboxGroupFocusDirection,
-  type CheckboxGroupItemKey,
-  type CheckboxGroupItemRegistration,
-  type CheckboxGroupItemRegistrationOptions,
-  type CheckboxGroupItemState,
-  type CheckboxGroupNavigationTarget,
   type CheckboxGroupOptions,
   type CheckboxGroupOrientation,
   CheckboxGroupRenderable,


### PR DESCRIPTION
## Summary

- remove low-level CheckboxGroup collection coordination types from the root Core entrypoint and `/checkbox-group` subpath before their first Foundation release
- keep required collection keys, registrations, item state, and focus direction inside the Core implementation
- update the pending CheckboxGroup changeset to describe the intentionally smaller public interface

This keeps consumers on the documented CheckboxGroup interface—Store, Renderable, state/options/orientation, and change types—rather than committing to an unsupported custom-member extension seam.

ToggleGroup is unchanged because its corresponding types have already shipped.

## Validation

- `pnpm format`
- `pnpm lint`
- `pnpm --filter @tuiparts/core typecheck`
- focused Checkbox and CheckboxGroup Core tests: 20 passed
- generated root and `/checkbox-group` declarations inspected to confirm the six names are not exported
- `pnpm validate:foundation`
- `pnpm changeset:status`
- `git diff --check`
